### PR TITLE
Add job naming and labels support for ingest operations

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -533,6 +533,9 @@ func (c *Client) CreateRelation(ctx context.Context, input CreateRelationInput) 
 
 // IngestOptions configures ingestion.
 type IngestOptions struct {
+	// Name is a user-provided identifier for the job (for rerunning)
+	Name *string
+	// Labels to apply to all ingested entities (curated)
 	Labels       []string
 	ExtractGraph *bool
 	DryRun       *bool
@@ -544,6 +547,8 @@ type Job struct {
 	ID          string        `json:"id"`
 	Type        string        `json:"type"`
 	Status      string        `json:"status"`
+	Name        *string       `json:"name,omitempty"`
+	Labels      []string      `json:"labels"`
 	Progress    int           `json:"progress"`
 	Total       int           `json:"total"`
 	Result      *IngestResult `json:"result,omitempty"`
@@ -566,6 +571,9 @@ func (c *Client) IngestFile(ctx context.Context, filePath string, opts *IngestOp
 	vars := map[string]any{"filePath": filePath}
 	if opts != nil {
 		input := map[string]any{}
+		if opts.Name != nil {
+			input["name"] = *opts.Name
+		}
 		if len(opts.Labels) > 0 {
 			input["labels"] = opts.Labels
 		}
@@ -603,6 +611,9 @@ func (c *Client) IngestDirectory(ctx context.Context, dirPath string, opts *Inge
 	vars := map[string]any{"dirPath": dirPath}
 	if opts != nil {
 		input := map[string]any{}
+		if opts.Name != nil {
+			input["name"] = *opts.Name
+		}
 		if len(opts.Labels) > 0 {
 			input["labels"] = opts.Labels
 		}
@@ -641,6 +652,9 @@ func (c *Client) IngestDirectoryAsync(ctx context.Context, dirPath string, opts 
 	vars := map[string]any{"dirPath": dirPath}
 	if opts != nil {
 		input := map[string]any{}
+		if opts.Name != nil {
+			input["name"] = *opts.Name
+		}
 		if len(opts.Labels) > 0 {
 			input["labels"] = opts.Labels
 		}
@@ -708,6 +722,9 @@ func (c *Client) IngestFiles(ctx context.Context, files []FileContentInput, base
 
 	if opts != nil {
 		options := map[string]any{}
+		if opts.Name != nil {
+			options["name"] = *opts.Name
+		}
 		if len(opts.Labels) > 0 {
 			options["labels"] = opts.Labels
 		}
@@ -750,6 +767,9 @@ func (c *Client) IngestFilesAsync(ctx context.Context, files []FileContentInput,
 
 	if opts != nil {
 		options := map[string]any{}
+		if opts.Name != nil {
+			options["name"] = *opts.Name
+		}
 		if len(opts.Labels) > 0 {
 			options["labels"] = opts.Labels
 		}

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -155,10 +155,13 @@ func SchemaSQL(dimension int) string {
     -- INGEST_JOB TABLE (Async Job Persistence)
     -- ==========================================================================
     -- Persists async ingestion jobs for restart resilience.
+    -- Jobs can be named for easy re-running and have curated labels.
     DEFINE TABLE IF NOT EXISTS ingest_job SCHEMAFULL;
 
     DEFINE FIELD IF NOT EXISTS job_type ON ingest_job TYPE string;
     DEFINE FIELD IF NOT EXISTS status ON ingest_job TYPE string;
+    DEFINE FIELD IF NOT EXISTS name ON ingest_job TYPE option<string>;          -- User-provided name for rerunning
+    DEFINE FIELD IF NOT EXISTS labels ON ingest_job TYPE array<string> DEFAULT [];  -- Curated labels applied to entities
     DEFINE FIELD IF NOT EXISTS dir_path ON ingest_job TYPE string;
     DEFINE FIELD IF NOT EXISTS files ON ingest_job TYPE array<string>;
     DEFINE FIELD IF NOT EXISTS options ON ingest_job TYPE option<object> FLEXIBLE;
@@ -170,5 +173,6 @@ func SchemaSQL(dimension int) string {
     DEFINE FIELD IF NOT EXISTS completed_at ON ingest_job TYPE option<datetime>;
 
     DEFINE INDEX IF NOT EXISTS idx_job_status ON ingest_job FIELDS status;
+    DEFINE INDEX IF NOT EXISTS idx_job_name ON ingest_job FIELDS name UNIQUE;
 `, dimension, dimension)
 }

--- a/internal/graph/helpers.go
+++ b/internal/graph/helpers.go
@@ -115,10 +115,24 @@ func serviceJobToGraphQL(j *service.Job) *Job {
 		pendingFiles = &snapshot.PendingFiles
 	}
 
+	// Handle name (optional)
+	var name *string
+	if snapshot.Name != "" {
+		name = &snapshot.Name
+	}
+
+	// Ensure labels is never nil
+	labels := snapshot.Labels
+	if labels == nil {
+		labels = []string{}
+	}
+
 	return &Job{
 		ID:           snapshot.ID,
 		Type:         snapshot.Type,
 		Status:       string(snapshot.Status),
+		Name:         name,
+		Labels:       labels,
 		Progress:     snapshot.Progress,
 		Total:        snapshot.Total,
 		Result:       result,
@@ -128,6 +142,94 @@ func serviceJobToGraphQL(j *service.Job) *Job {
 		DirPath:      dirPath,
 		PendingFiles: pendingFiles,
 	}
+}
+
+// dbJobToGraphQL converts a models.IngestJob (from database) to a GraphQL Job.
+func dbJobToGraphQL(j *models.IngestJob) *Job {
+	if j == nil {
+		return nil
+	}
+
+	jobID, err := models.RecordIDString(j.ID)
+	if err != nil {
+		jobID = fmt.Sprintf("%v", j.ID.ID)
+	}
+
+	var errPtr *string
+	if j.Error != nil {
+		errPtr = j.Error
+	}
+
+	var result *IngestResult
+	if j.Result != nil {
+		result = &IngestResult{
+			FilesProcessed:   intFromMap(j.Result, "files_processed"),
+			EntitiesCreated:  intFromMap(j.Result, "entities_created"),
+			ChunksCreated:    intFromMap(j.Result, "chunks_created"),
+			RelationsCreated: intFromMap(j.Result, "relations_created"),
+			Errors:           stringsFromMap(j.Result, "errors"),
+		}
+	}
+
+	var dirPath *string
+	if j.DirPath != "" {
+		dirPath = &j.DirPath
+	}
+
+	// Ensure labels is never nil
+	labels := j.Labels
+	if labels == nil {
+		labels = []string{}
+	}
+
+	return &Job{
+		ID:          jobID,
+		Type:        j.JobType,
+		Status:      j.Status,
+		Name:        j.Name,
+		Labels:      labels,
+		Progress:    j.Progress,
+		Total:       j.Total,
+		Result:      result,
+		Error:       errPtr,
+		StartedAt:   j.StartedAt,
+		CompletedAt: j.CompletedAt,
+		DirPath:     dirPath,
+	}
+}
+
+// intFromMap extracts an int from a map[string]any.
+func intFromMap(m map[string]any, key string) int {
+	if v, ok := m[key]; ok {
+		switch n := v.(type) {
+		case int:
+			return n
+		case int64:
+			return int(n)
+		case float64:
+			return int(n)
+		}
+	}
+	return 0
+}
+
+// stringsFromMap extracts a []string from a map[string]any.
+func stringsFromMap(m map[string]any, key string) []string {
+	if v, ok := m[key]; ok {
+		if arr, ok := v.([]any); ok {
+			result := make([]string, 0, len(arr))
+			for _, item := range arr {
+				if s, ok := item.(string); ok {
+					result = append(result, s)
+				}
+			}
+			return result
+		}
+		if arr, ok := v.([]string); ok {
+			return arr
+		}
+	}
+	return []string{}
 }
 
 // intPtr returns a pointer to an int value.

--- a/internal/graph/model_gen.go
+++ b/internal/graph/model_gen.go
@@ -51,6 +51,8 @@ type Job struct {
 	ID           string        `json:"id"`
 	Type         string        `json:"type"`
 	Status       string        `json:"status"`
+	Name         *string       `json:"name,omitempty"`
+	Labels       []string      `json:"labels"`
 	Progress     int           `json:"progress"`
 	Total        int           `json:"total"`
 	Result       *IngestResult `json:"result,omitempty"`

--- a/internal/graph/models.go
+++ b/internal/graph/models.go
@@ -135,6 +135,9 @@ type SearchInput struct {
 
 // IngestInput is the input for ingest operations.
 type IngestInput struct {
+	// User-provided name for identifying and rerunning this job
+	Name *string `json:"name,omitempty"`
+	// Curated labels to apply to all ingested entities
 	Labels       []string `json:"labels,omitempty"`
 	ExtractGraph *bool    `json:"extractGraph,omitempty"`
 	DryRun       *bool    `json:"dryRun,omitempty"`

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -76,6 +76,8 @@ type Job {
   id: ID!
   type: String!
   status: String!
+  name: String
+  labels: [String!]!
   progress: Int!
   total: Int!
   result: IngestResult
@@ -171,6 +173,9 @@ input SearchInput {
 }
 
 input IngestInput {
+  """User-provided name for identifying and rerunning this job"""
+  name: String
+  """Curated labels to apply to all ingested entities"""
   labels: [String!]
   extractGraph: Boolean
   dryRun: Boolean
@@ -232,6 +237,8 @@ type Query {
   # Job tracking
   jobs: [Job!]!
   job(id: ID!): Job
+  """Get the most recent job with the given name"""
+  jobByName(name: String!): Job
 
   # Server statistics (in-memory, resets on restart)
   serverStats: ServerStats!

--- a/internal/models/job.go
+++ b/internal/models/job.go
@@ -12,6 +12,8 @@ type IngestJob struct {
 	ID          surrealmodels.RecordID `json:"id"`
 	JobType     string                 `json:"job_type"`
 	Status      string                 `json:"status"`
+	Name        *string                `json:"name,omitempty"`   // User-provided name for rerunning
+	Labels      []string               `json:"labels,omitempty"` // Curated labels applied to entities
 	DirPath     string                 `json:"dir_path"`
 	Files       []string               `json:"files"`
 	Options     map[string]any         `json:"options,omitempty"`


### PR DESCRIPTION
## Summary
This PR adds support for naming ingest jobs and applying curated labels to ingested entities. Jobs can now be identified by user-provided names for easy re-running, and labels are persisted alongside job metadata for better organization and tracking.

## Key Changes

- **CLI Enhancement**: Added `--name` flag to the `scrape` command to allow users to name ingest jobs for identification and rerunning
- **Job Naming**: Implemented job naming throughout the stack with a unique index on the `name` field in the database
- **Labels Persistence**: Moved labels from job options to top-level job fields for better organization and querying
- **Database Schema**: Updated `ingest_job` table to include `name` (optional string) and `labels` (array of strings) fields with appropriate indexes
- **GraphQL API**: 
  - Added `name` and `labels` fields to the `Job` type
  - Added `name` and `labels` fields to `IngestInput` for mutations
  - Added new `jobByName(name: String!)` query to retrieve jobs by name
- **Job Lookup**: Implemented `GetJobByName()` database method to retrieve the most recent job with a given name
- **Service Layer**: Updated `IngestOptions` and `JobManager` to handle name and labels as first-class properties
- **GraphQL Helpers**: Added `dbJobToGraphQL()` converter to transform database job records to GraphQL Job objects with proper field mapping

## Implementation Details

- Job names are optional and stored as nullable strings in the database
- Labels are always returned as non-nil arrays (empty array if not set) to maintain GraphQL consistency
- The `jobByName` query checks in-memory jobs first, then falls back to the database for historical jobs
- Labels are now excluded from the generic `options` map during persistence, reducing duplication
- All ingest methods (file, directory, async variants) support the new name and labels parameters

https://claude.ai/code/session_01EARKzFF3poYGfmcMKPkqFd