### PR TITLE
feat: make LLM provider optional

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 type LLMProvider string
 
 const (
+	ProviderNone      LLMProvider = "none"
 	ProviderOllama    LLMProvider = "ollama"
 	ProviderOpenAI    LLMProvider = "openai"
 	ProviderAnthropic LLMProvider = "anthropic"

--- a/internal/graph/resolver.go
+++ b/internal/graph/resolver.go
@@ -72,7 +72,11 @@ func NewResolver(ctx context.Context, cfg config.Config) (*Resolver, error) {
 
 	// Log configuration
 	slog.Info("embedding settings", "provider", cfg.EmbedProvider, "model", cfg.EmbedModel, "dimension", cfg.EmbedDimension)
-	slog.Info("llm settings", "provider", cfg.LLMProvider, "model", cfg.LLMModel)
+	if model != nil {
+		slog.Info("llm settings", "provider", cfg.LLMProvider, "model", cfg.LLMModel)
+	} else {
+		slog.Info("llm disabled")
+	}
 	slog.Info("ingest settings", "workers", cfg.IngestConcurrency)
 
 	ingestService := service.NewIngestService(dbClient, embedder, model)

--- a/internal/llm/model.go
+++ b/internal/llm/model.go
@@ -130,6 +130,9 @@ func NewModel(cfg config.Config, mc *metrics.Collector) (*Model, error) {
 	var err error
 
 	switch cfg.LLMProvider {
+	case config.ProviderNone:
+		return nil, nil
+
 	case config.ProviderOllama:
 		model, err = ollama.New(
 			ollama.WithModel(cfg.LLMModel),

--- a/internal/service/ingest.go
+++ b/internal/service/ingest.go
@@ -242,7 +242,9 @@ func (s *IngestService) ingestFileInternal(ctx context.Context, filePath string,
 	}
 
 	// Extract graph relations using LLM if requested
-	if opts.ExtractGraph && s.model != nil {
+	if opts.ExtractGraph && s.model == nil {
+		slog.Warn("graph extraction requested but LLM is disabled, skipping", "file", filePath)
+	} else if opts.ExtractGraph {
 		if err := s.extractGraphRelations(ctx, createResult.Entity); err != nil {
 			// Fatal API errors (billing, auth) should stop everything
 			if errors.Is(err, llm.ErrFatalAPI) {


### PR DESCRIPTION
## Summary
- Add `KNOWHOW_LLM_PROVIDER=none` to start the server without an LLM
- `Ask` and `AskStream` return raw search context (via `buildSearchContext()`) when no LLM is configured
- `AskStreamMultiTurn` and `AskWithTemplate` return actionable error messages pointing to the env var
- Embedder stays required — hybrid search always works

## Test plan
- [x] `just build-all` compiles
- [x] `just test` passes
- [ ] Manual: `KNOWHOW_LLM_PROVIDER=none just dev` — server starts, ask returns concatenated context

🤖 Generated with [Claude Code](https://claude.com/claude-code)