### PR TITLE
fix: chunk documents exceeding MaxSize even when below Threshold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,17 @@ KNOWHOW_EMBED_DIMENSION=768
 # HTTPS_PROXY=...                                 # Set by Teleport proxy
 
 # =============================================================================
+# Chunking Configuration
+# =============================================================================
+# Tune chunk sizes to match your embedding model's context window.
+# Defaults target models with ~1500+ token context (MaxSize 4000 chars ≈ 1000 tokens).
+# For mxbai-embed-large (512 token max sequence length), use: THRESHOLD=1200 TARGET=1000 MIN=200 MAX=1500
+# KNOWHOW_CHUNK_THRESHOLD=6000
+# KNOWHOW_CHUNK_TARGET_SIZE=3000
+# KNOWHOW_CHUNK_MIN_SIZE=800
+# KNOWHOW_CHUNK_MAX_SIZE=4000
+
+# =============================================================================
 # Server Settings
 # =============================================================================
 KNOWHOW_INGEST_CONCURRENCY=4

--- a/cmd/knowhow-mcp/tools.go
+++ b/cmd/knowhow-mcp/tools.go
@@ -32,12 +32,12 @@ type vaultsResponse struct {
 
 type searchResponse struct {
 	Search []struct {
-		DocumentID string  `json:"documentId"`
-		Path       string  `json:"path"`
-		Title      string  `json:"title"`
-		Labels     []string `json:"labels"`
-		DocType    *string `json:"docType"`
-		Score      float64 `json:"score"`
+		DocumentID    string   `json:"documentId"`
+		Path          string   `json:"path"`
+		Title         string   `json:"title"`
+		Labels        []string `json:"labels"`
+		DocType       *string  `json:"docType"`
+		Score         float64  `json:"score"`
 		MatchedChunks []struct {
 			Snippet     string  `json:"snippet"`
 			HeadingPath *string `json:"headingPath"`
@@ -66,12 +66,12 @@ type createDocumentResponse struct {
 // ---------- Tool input types ----------
 
 type SearchInput struct {
-	Query    string  `json:"query" jsonschema:"description=Search query text"`
+	Query    string   `json:"query" jsonschema:"description=Search query text"`
 	Labels   []string `json:"labels,omitempty" jsonschema:"description=Filter by labels"`
-	DocType  *string `json:"doc_type,omitempty" jsonschema:"description=Filter by document type"`
-	Folder   *string `json:"folder,omitempty" jsonschema:"description=Filter by folder path prefix"`
-	Limit    *int    `json:"limit,omitempty" jsonschema:"description=Max results (default 20)"`
-	Instance *string `json:"instance,omitempty" jsonschema:"description=Instance name (searches all if omitted)"`
+	DocType  *string  `json:"doc_type,omitempty" jsonschema:"description=Filter by document type"`
+	Folder   *string  `json:"folder,omitempty" jsonschema:"description=Filter by folder path prefix"`
+	Limit    *int     `json:"limit,omitempty" jsonschema:"description=Max results (default 20)"`
+	Instance *string  `json:"instance,omitempty" jsonschema:"description=Instance name (searches all if omitted)"`
 }
 
 type GetDocumentInput struct {

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -91,6 +91,25 @@ Research consensus (Pinecone, LlamaIndex, OpenAI cookbook):
 - Match chunk size to embedding model's training data (most trained on ~512 token passages)
 
 Our defaults are in `DefaultChunkConfig()` in `internal/parser/chunker.go`.
+Chunk sizes are configurable via environment variables:
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `KNOWHOW_CHUNK_THRESHOLD` | 6000 | Only chunk if content exceeds this length |
+| `KNOWHOW_CHUNK_TARGET_SIZE` | 3000 | Ideal chunk size in chars |
+| `KNOWHOW_CHUNK_MIN_SIZE` | 800 | Minimum chunk size (smaller merges with neighbors) |
+| `KNOWHOW_CHUNK_MAX_SIZE` | 4000 | Maximum chunk size (larger chunks get split) |
+
+### Model-Specific Chunk Sizes
+
+For `mxbai-embed-large` via Ollama (512 token max sequence length ≈ 2048 chars, with headroom):
+
+```bash
+KNOWHOW_CHUNK_THRESHOLD=1200
+KNOWHOW_CHUNK_TARGET_SIZE=1000
+KNOWHOW_CHUNK_MIN_SIZE=200
+KNOWHOW_CHUNK_MAX_SIZE=1500
+```
 
 ### AST-Based Markdown Chunking
 

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -17,9 +17,9 @@ const maxToolIterations = 5
 
 // StreamEvent is sent to the client via SSE.
 type StreamEvent struct {
-	Type    string `json:"type"`              // "token" | "tool_call" | "tool_result" | "done" | "error" | "message_id" | "conversation_id"
-	Content string `json:"content"`           // token text, tool result, error message, or message ID
-	Tool    string `json:"tool,omitempty"`     // tool name for tool_call/tool_result events
+	Type    string `json:"type"`           // "token" | "tool_call" | "tool_result" | "done" | "error" | "message_id" | "conversation_id"
+	Content string `json:"content"`        // token text, tool result, error message, or message ID
+	Tool    string `json:"tool,omitempty"` // tool name for tool_call/tool_result events
 }
 
 // Service orchestrates the agent loop: intent detection → tool execution → streaming answer.
@@ -290,7 +290,7 @@ func (s *Service) buildHistory(messages []models.Message, toolContext string) []
 			history = append(history, llm.ChatMessage{Role: "user", Content: msg.Content})
 		case models.RoleAssistant:
 			history = append(history, llm.ChatMessage{Role: "assistant", Content: msg.Content})
-		// Skip tool_call and tool_result — current turn's results are in toolContext; historical tool messages are omitted
+			// Skip tool_call and tool_result — current turn's results are in toolContext; historical tool messages are omitted
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/raphi011/knowhow/internal/parser"
 )
 
 // LLMProvider identifies the LLM provider.
@@ -57,6 +59,22 @@ type Config struct {
 	// Embedding worker settings
 	EmbedWorkerInterval int // seconds between worker ticks (default: 5)
 	EmbedWorkerBatch    int // max chunks per tick (default: 10)
+
+	// Chunking settings
+	ChunkThreshold  int // only chunk if content exceeds this length (default: 6000)
+	ChunkTargetSize int // ideal chunk size in chars (default: 3000)
+	ChunkMinSize    int // minimum chunk size in chars (default: 800)
+	ChunkMaxSize    int // maximum chunk size in chars (default: 4000)
+}
+
+// ChunkConfig returns the chunking configuration as a parser.ChunkConfig.
+func (c Config) ChunkConfig() parser.ChunkConfig {
+	return parser.ChunkConfig{
+		Threshold:  c.ChunkThreshold,
+		TargetSize: c.ChunkTargetSize,
+		MinSize:    c.ChunkMinSize,
+		MaxSize:    c.ChunkMaxSize,
+	}
 }
 
 // Load reads configuration from environment variables.
@@ -97,6 +115,12 @@ func Load() Config {
 		// Embedding worker
 		EmbedWorkerInterval: getEnvInt("KNOWHOW_EMBED_WORKER_INTERVAL", 5),
 		EmbedWorkerBatch:    getEnvInt("KNOWHOW_EMBED_WORKER_BATCH", 10),
+
+		// Chunking
+		ChunkThreshold:  getEnvInt("KNOWHOW_CHUNK_THRESHOLD", 6000),
+		ChunkTargetSize: getEnvInt("KNOWHOW_CHUNK_TARGET_SIZE", 3000),
+		ChunkMinSize:    getEnvInt("KNOWHOW_CHUNK_MIN_SIZE", 800),
+		ChunkMaxSize:    getEnvInt("KNOWHOW_CHUNK_MAX_SIZE", 4000),
 	}
 }
 

--- a/internal/db/helpers.go
+++ b/internal/db/helpers.go
@@ -24,4 +24,3 @@ func optionalObject(m map[string]any) any {
 	}
 	return m
 }
-

--- a/internal/document/service.go
+++ b/internal/document/service.go
@@ -20,17 +20,19 @@ import (
 
 // Service manages document lifecycle: parse → extract → store → link → embed.
 type Service struct {
-	db       *db.Client
-	embedder *llm.Embedder // optional — nil disables embedding
-	resolver *LinkResolver
+	db          *db.Client
+	embedder    *llm.Embedder // optional — nil disables embedding
+	resolver    *LinkResolver
+	chunkConfig parser.ChunkConfig
 }
 
 // NewService creates a new document service.
-func NewService(db *db.Client, embedder *llm.Embedder) *Service {
+func NewService(db *db.Client, embedder *llm.Embedder, chunkConfig parser.ChunkConfig) *Service {
 	return &Service{
-		db:       db,
-		embedder: embedder,
-		resolver: NewLinkResolver(db),
+		db:          db,
+		embedder:    embedder,
+		resolver:    NewLinkResolver(db),
+		chunkConfig: chunkConfig,
 	}
 }
 
@@ -321,7 +323,7 @@ func (s *Service) resolveDanglingForDoc(ctx context.Context, vaultID string, doc
 // by content, preserving embeddings for unchanged chunks and scheduling embedding
 // only for new/changed chunks.
 func (s *Service) syncChunks(ctx context.Context, docID string, parsed *parser.MarkdownDoc, labels []string) error {
-	newChunkResults := parser.ChunkMarkdown(parsed, parser.DefaultChunkConfig())
+	newChunkResults := parser.ChunkMarkdown(parsed, s.chunkConfig)
 
 	oldChunks, err := s.db.GetChunks(ctx, docID)
 	if err != nil {

--- a/internal/graph/resolver.go
+++ b/internal/graph/resolver.go
@@ -4,6 +4,7 @@ package graph
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -77,14 +78,26 @@ func NewResolver(ctx context.Context, cfg config.Config) (*Resolver, error) {
 		}
 	}
 
+	chunkConfig := cfg.ChunkConfig()
+	if err := chunkConfig.Validate(); err != nil {
+		if closeErr := dbClient.Close(ctx); closeErr != nil {
+			slog.Warn("failed to close DB during cleanup", "error", closeErr)
+		}
+		return nil, fmt.Errorf("invalid chunk configuration: %w", err)
+	}
+
 	slog.Info("resolver initialized",
 		"embed_provider", cfg.EmbedProvider,
 		"embed_dimension", cfg.EmbedDimension,
 		"semantic_search", embedder != nil,
 		"agent_chat", model != nil,
+		"chunk_threshold", chunkConfig.Threshold,
+		"chunk_target", chunkConfig.TargetSize,
+		"chunk_min", chunkConfig.MinSize,
+		"chunk_max", chunkConfig.MaxSize,
 	)
 
-	docService := document.NewService(dbClient, embedder)
+	docService := document.NewService(dbClient, embedder, chunkConfig)
 
 	workerDone := make(chan struct{})
 	close(workerDone) // safe default: <-workerDone returns immediately if no worker

--- a/internal/integration/lifecycle_test.go
+++ b/internal/integration/lifecycle_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/raphi011/knowhow/internal/db"
 	"github.com/raphi011/knowhow/internal/document"
 	"github.com/raphi011/knowhow/internal/models"
+	"github.com/raphi011/knowhow/internal/parser"
 	"github.com/raphi011/knowhow/internal/search"
 	"github.com/raphi011/knowhow/internal/vault"
 	"github.com/testcontainers/testcontainers-go"
@@ -132,7 +133,7 @@ func TestFullLifecycle(t *testing.T) {
 
 	// --- Documents with wiki-links ---
 
-	docSvc := document.NewService(testDB, nil) // no embedder
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig()) // no embedder
 
 	doc1, err := docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID,
@@ -377,7 +378,7 @@ func TestDeleteByPrefix(t *testing.T) {
 	}
 	vaultID := models.MustRecordIDString(v.ID)
 
-	docSvc := document.NewService(testDB, nil)
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
 
 	// Create 3 documents: 2 under /test-prefix/, 1 under /other/
 	for _, path := range []string{"/test-prefix/a.md", "/test-prefix/b.md", "/other/c.md"} {
@@ -445,7 +446,7 @@ func TestMoveByPrefix(t *testing.T) {
 	}
 	vaultID := models.MustRecordIDString(v.ID)
 
-	docSvc := document.NewService(testDB, nil)
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
 
 	// Create 2 documents under /old-folder/
 	for _, path := range []string{"/old-folder/a.md", "/old-folder/b.md"} {
@@ -515,7 +516,7 @@ func TestDeleteByPrefix_BoundaryCollision(t *testing.T) {
 	}
 	vaultID := models.MustRecordIDString(v.ID)
 
-	docSvc := document.NewService(testDB, nil)
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
 
 	// Create docs under similar-looking prefixes
 	paths := []string{
@@ -590,7 +591,7 @@ func TestMoveByPrefix_NestedSubfolders(t *testing.T) {
 	}
 	vaultID := models.MustRecordIDString(v.ID)
 
-	docSvc := document.NewService(testDB, nil)
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
 
 	// Create deeply nested documents
 	paths := []string{
@@ -657,7 +658,7 @@ func TestMoveByPrefix_BoundaryCollision(t *testing.T) {
 	}
 	vaultID := models.MustRecordIDString(v.ID)
 
-	docSvc := document.NewService(testDB, nil)
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
 
 	paths := []string{
 		"/guides/a.md",
@@ -723,7 +724,7 @@ func TestMoveByPrefix_SamePrefix(t *testing.T) {
 	}
 	vaultID := models.MustRecordIDString(v.ID)
 
-	docSvc := document.NewService(testDB, nil)
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
 
 	_, err = docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID,
@@ -777,7 +778,7 @@ func TestSyncChunks_PreservesUnchangedChunks(t *testing.T) {
 	vaultID := models.MustRecordIDString(v.ID)
 
 	// nil embedder — embed_at should NOT be set on any chunks
-	docSvc := document.NewService(testDB, nil)
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
 
 	// --- Step 1: Create a document with initial content ---
 	doc, err := docSvc.Create(ctx, models.DocumentInput{
@@ -889,10 +890,9 @@ func TestSyncChunks_PartialUpdate(t *testing.T) {
 	}
 	vaultID := models.MustRecordIDString(v.ID)
 
-	docSvc := document.NewService(testDB, nil)
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
 
-	// Create document with content long enough to produce multiple chunks.
-	// Default chunk config has a max of ~1500 chars, so we use heading-based splitting.
+	// Create document with content that uses heading-based splitting.
 	longContent := "# Section A\n\nContent of section A that is preserved across updates.\n\n# Section B\n\nContent of section B that will change."
 
 	doc, err := docSvc.Create(ctx, models.DocumentInput{

--- a/internal/integration/proposal_test.go
+++ b/internal/integration/proposal_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/raphi011/knowhow/internal/document"
 	"github.com/raphi011/knowhow/internal/models"
+	"github.com/raphi011/knowhow/internal/parser"
 	"github.com/raphi011/knowhow/internal/review"
 	"github.com/raphi011/knowhow/internal/vault"
 )
@@ -37,7 +38,7 @@ func TestProposalLifecycle(t *testing.T) {
 		t.Fatalf("vault ID: %v", err)
 	}
 
-	docSvc := document.NewService(testDB, nil)
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
 	reviewSvc := review.NewService(testDB, docSvc)
 
 	// --- Create a document ---

--- a/internal/parser/chunker.go
+++ b/internal/parser/chunker.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"strings"
 	"unicode"
 )
@@ -26,6 +27,7 @@ type ChunkConfig struct {
 
 // DefaultChunkConfig returns sensible defaults for embedding-quality chunk sizes.
 // TargetSize ~750 tokens, MaxSize ~1000 tokens (at ~4 chars/token for English prose).
+// These are typically overridden by KNOWHOW_CHUNK_* environment variables (see justfile).
 func DefaultChunkConfig() ChunkConfig {
 	return ChunkConfig{
 		Threshold:  6000,
@@ -35,8 +37,26 @@ func DefaultChunkConfig() ChunkConfig {
 	}
 }
 
-// ShouldChunk returns true if content should be chunked.
-func ShouldChunk(content string, config ChunkConfig) bool {
+// Validate checks that chunk config values form a coherent configuration.
+func (c ChunkConfig) Validate() error {
+	if c.MinSize <= 0 || c.TargetSize <= 0 || c.MaxSize <= 0 || c.Threshold <= 0 {
+		return fmt.Errorf("all chunk config values must be positive: min=%d target=%d max=%d threshold=%d",
+			c.MinSize, c.TargetSize, c.MaxSize, c.Threshold)
+	}
+	if c.MinSize >= c.TargetSize {
+		return fmt.Errorf("chunk MinSize (%d) must be less than TargetSize (%d)", c.MinSize, c.TargetSize)
+	}
+	if c.TargetSize >= c.MaxSize {
+		return fmt.Errorf("chunk TargetSize (%d) must be less than MaxSize (%d)", c.TargetSize, c.MaxSize)
+	}
+	if c.MaxSize > c.Threshold {
+		return fmt.Errorf("chunk MaxSize (%d) must not exceed Threshold (%d)", c.MaxSize, c.Threshold)
+	}
+	return nil
+}
+
+// ExceedsThreshold returns true if content length exceeds the chunking threshold.
+func ExceedsThreshold(content string, config ChunkConfig) bool {
 	return len(content) > config.Threshold
 }
 
@@ -44,17 +64,21 @@ func ShouldChunk(content string, config ChunkConfig) bool {
 // Prioritizes section boundaries, then paragraph boundaries.
 // Returns empty slice if content has no semantic value for embedding.
 func ChunkMarkdown(doc *MarkdownDoc, config ChunkConfig) []ChunkResult {
-	// If content is short enough, return as single chunk (only if non-empty)
-	if !ShouldChunk(doc.Content, config) {
+	// If content is below threshold, check whether it also fits within MaxSize
+	if !ExceedsThreshold(doc.Content, config) {
 		trimmed := strings.TrimSpace(doc.Content)
 		if trimmed == "" {
-			return []ChunkResult{} // No content to chunk
+			return []ChunkResult{}
 		}
-		return []ChunkResult{{
-			Content:     doc.Content,
-			Position:    0,
-			HeadingPath: "",
-		}}
+		// Even below Threshold, if content exceeds MaxSize it must be chunked
+		// to avoid embedding context length errors
+		if len(doc.Content) <= config.MaxSize {
+			return []ChunkResult{{
+				Content:     doc.Content,
+				Position:    0,
+				HeadingPath: "",
+			}}
+		}
 	}
 
 	// If we have sections, chunk by section first

--- a/internal/parser/chunker_test.go
+++ b/internal/parser/chunker_test.go
@@ -219,7 +219,7 @@ func TestChunkBySections_CodeBlockAtomic(t *testing.T) {
 func TestChunkBySections_CodeBlockSmallMergesIntoParent(t *testing.T) {
 	config := DefaultChunkConfig()
 	parentContent := strings.Repeat("Parent context. ", 30) // ~480 chars
-	codeContent := "```\nsmall code\n```"                    // tiny
+	codeContent := "```\nsmall code\n```"                   // tiny
 
 	sections := []Section{
 		{Level: 2, Path: "## Setup", Content: parentContent},
@@ -321,6 +321,126 @@ func TestChunkMarkdown_FallbackToParagraphs(t *testing.T) {
 
 	if len(chunks) < 2 {
 		t.Errorf("expected paragraph-based splitting, got %d chunks", len(chunks))
+	}
+}
+
+func TestChunkMarkdown_BelowThresholdAboveMaxSize(t *testing.T) {
+	// Regression: documents below Threshold but above MaxSize were returned
+	// as a single unchunked blob, causing embedding context length errors.
+	config := ChunkConfig{
+		Threshold:  6000,
+		TargetSize: 3000,
+		MinSize:    800,
+		MaxSize:    4000,
+	}
+
+	// ~5000 chars: below Threshold (6000) but above MaxSize (4000)
+	content := strings.Repeat("This is a paragraph with enough content to be meaningful for testing. ", 70)
+	if len(content) <= config.MaxSize || len(content) >= config.Threshold {
+		t.Fatalf("test content %d chars, need >%d and <%d", len(content), config.MaxSize, config.Threshold)
+	}
+
+	doc, err := ParseMarkdown(content)
+	if err != nil {
+		t.Fatalf("ParseMarkdown() error = %v", err)
+	}
+
+	chunks := ChunkMarkdown(doc, config)
+
+	if len(chunks) < 2 {
+		t.Errorf("content of %d chars (>MaxSize %d) should produce multiple chunks, got %d",
+			len(content), config.MaxSize, len(chunks))
+	}
+
+	for i, chunk := range chunks {
+		if len(chunk.Content) > config.MaxSize {
+			t.Errorf("chunk[%d] length %d exceeds MaxSize %d", i, len(chunk.Content), config.MaxSize)
+		}
+	}
+}
+
+func TestChunkMarkdown_BelowThresholdAboveMaxSize_WithSections(t *testing.T) {
+	config := ChunkConfig{
+		Threshold:  6000,
+		TargetSize: 3000,
+		MinSize:    800,
+		MaxSize:    4000,
+	}
+
+	// Build content with headings that totals ~5000 chars
+	content := "# Title\n\n## Section A\n\n" +
+		strings.Repeat("Content for section A. ", 100) + "\n\n" +
+		"## Section B\n\n" +
+		strings.Repeat("Content for section B. ", 100)
+
+	if len(content) <= config.MaxSize || len(content) >= config.Threshold {
+		t.Fatalf("test content %d chars, need >%d and <%d", len(content), config.MaxSize, config.Threshold)
+	}
+
+	doc, err := ParseMarkdown(content)
+	if err != nil {
+		t.Fatalf("ParseMarkdown() error = %v", err)
+	}
+
+	chunks := ChunkMarkdown(doc, config)
+
+	if len(chunks) < 2 {
+		t.Errorf("sectioned content of %d chars should produce multiple chunks, got %d",
+			len(content), len(chunks))
+	}
+
+	for i, chunk := range chunks {
+		if len(chunk.Content) > config.MaxSize {
+			t.Errorf("chunk[%d] length %d exceeds MaxSize %d", i, len(chunk.Content), config.MaxSize)
+		}
+	}
+}
+
+func TestChunkConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  ChunkConfig
+		wantErr bool
+	}{
+		{
+			name:    "valid defaults",
+			config:  DefaultChunkConfig(),
+			wantErr: false,
+		},
+		{
+			name:    "zero values",
+			config:  ChunkConfig{},
+			wantErr: true,
+		},
+		{
+			name:    "MinSize >= TargetSize",
+			config:  ChunkConfig{MinSize: 3000, TargetSize: 3000, MaxSize: 4000, Threshold: 6000},
+			wantErr: true,
+		},
+		{
+			name:    "TargetSize >= MaxSize",
+			config:  ChunkConfig{MinSize: 800, TargetSize: 4000, MaxSize: 4000, Threshold: 6000},
+			wantErr: true,
+		},
+		{
+			name:    "MaxSize > Threshold",
+			config:  ChunkConfig{MinSize: 800, TargetSize: 3000, MaxSize: 7000, Threshold: 6000},
+			wantErr: true,
+		},
+		{
+			name:    "negative value",
+			config:  ChunkConfig{MinSize: -1, TargetSize: 3000, MaxSize: 4000, Threshold: 6000},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/justfile
+++ b/justfile
@@ -19,6 +19,12 @@ export KNOWHOW_EMBED_MODEL := env_var_or_default("KNOWHOW_EMBED_MODEL", "mxbai-e
 export KNOWHOW_EMBED_DIMENSION := env_var_or_default("KNOWHOW_EMBED_DIMENSION", "1024")
 export OLLAMA_HOST := env_var_or_default("OLLAMA_HOST", "http://localhost:11434")
 
+# Chunk sizes tuned for mxbai-embed-large (512 token context ≈ 2048 chars)
+export KNOWHOW_CHUNK_THRESHOLD := env_var_or_default("KNOWHOW_CHUNK_THRESHOLD", "1200")
+export KNOWHOW_CHUNK_TARGET_SIZE := env_var_or_default("KNOWHOW_CHUNK_TARGET_SIZE", "1000")
+export KNOWHOW_CHUNK_MIN_SIZE := env_var_or_default("KNOWHOW_CHUNK_MIN_SIZE", "200")
+export KNOWHOW_CHUNK_MAX_SIZE := env_var_or_default("KNOWHOW_CHUNK_MAX_SIZE", "1500")
+
 # Server defaults
 export KNOWHOW_SERVER_PORT := env_var_or_default("KNOWHOW_SERVER_PORT", "8484")
 export KNOWHOW_SERVER_URL := env_var_or_default("KNOWHOW_SERVER_URL", "http://localhost:8484/query")


### PR DESCRIPTION
Documents between MaxSize and Threshold were returned as single unchunked blobs, causing embedding context length errors with models like mxbai-embed-large (512 token context). Now falls through to section/paragraph chunking when content exceeds MaxSize.

Also makes chunk sizes configurable via `KNOWHOW_CHUNK_*` environment variables, with justfile defaults tuned for mxbai-embed-large.

## Breaking Changes
- `document.NewService()` now requires a `parser.ChunkConfig` parameter (all call sites updated)

## Test Coverage
- Unit tests added: `TestChunkMarkdown_BelowThresholdAboveMaxSize` — regression test for the core fix
- Integration tests added: None (existing integration tests updated for new `NewService` signature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)