### PR TITLE
feat: first-class folders with query optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,41 @@ mutation {
 }
 ```
 
+## Folders
+
+Documents are organized into first-class folders backed by DB records. Folders are auto-created when documents are added and support explicit CRUD operations.
+
+### Example Prompts
+
+```graphql
+# Create a folder (auto-creates ancestors)
+mutation {
+  createFolder(vaultId: "vault-id", path: "/projects/new-idea") {
+    id path name createdAt
+  }
+}
+
+# List all folders in a vault
+query {
+  vaults { name folders { path name } }
+}
+
+# List immediate children of a folder
+query {
+  vaults { name folders(parentPath: "/projects") { path name } }
+}
+
+# Move a folder (moves all children and documents)
+mutation {
+  moveFolder(vaultId: "vault-id", oldPath: "/guides", newPath: "/docs/guides")
+}
+
+# Delete a folder (cascades to child folders and documents)
+mutation {
+  deleteFolder(vaultId: "vault-id", path: "/guides")
+}
+```
+
 ## MCP Server (AI Agent Integration)
 
 The `knowhow-mcp` binary exposes your knowledge base to AI agents via the [Model Context Protocol](https://modelcontextprotocol.io/). It aggregates one or more knowhow-server instances and provides 4 tools over Streamable HTTP.
@@ -405,6 +440,7 @@ EOF
 | `get_document` | Retrieve a document by path with full content |
 | `list_labels` | List all labels used across documents |
 | `create_memory` | Create a quick memory note under `/memories/` |
+| `list_folders` | Browse the folder structure of a vault |
 
 ### Example Prompts
 
@@ -420,6 +456,9 @@ EOF
 
 # Discover categories
 "List all labels in my knowledge base"
+
+# Browse vault structure
+"Show me the folder structure of my knowledge base"
 
 # Save a quick note
 "Remember that the deploy pipeline requires manual approval for production"

--- a/cmd/knowhow-mcp/tools.go
+++ b/cmd/knowhow-mcp/tools.go
@@ -57,6 +57,17 @@ type documentResponse struct {
 	} `json:"document"`
 }
 
+type foldersResponse struct {
+	Vaults []struct {
+		ID      string `json:"id"`
+		Name    string `json:"name"`
+		Folders []struct {
+			Path string `json:"path"`
+			Name string `json:"name"`
+		} `json:"folders"`
+	} `json:"vaults"`
+}
+
 type createDocumentResponse struct {
 	CreateDocument struct {
 		Path string `json:"path"`
@@ -80,6 +91,10 @@ type GetDocumentInput struct {
 }
 
 type ListLabelsInput struct {
+	Instance *string `json:"instance,omitempty" jsonschema:"description=Instance name (lists all if omitted)"`
+}
+
+type ListFoldersInput struct {
 	Instance *string `json:"instance,omitempty" jsonschema:"description=Instance name (lists all if omitted)"`
 }
 
@@ -166,6 +181,11 @@ func (t *mcpTools) register(server *mcp.Server) {
 		Name:        "list_labels",
 		Description: "List all labels used across documents. Useful for discovering available categories before searching.",
 	}, t.listLabels)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_folders",
+		Description: "List the folder structure of a knowhow vault. Use to browse and understand vault organization before searching.",
+	}, t.listFolders)
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "create_memory",
@@ -350,6 +370,60 @@ func (t *mcpTools) listLabels(ctx context.Context, req *mcp.CallToolRequest, inp
 		return textResult("No labels found."), nil, nil
 	}
 	return textResult(sb.String()), nil, nil
+}
+
+func (t *mcpTools) listFolders(ctx context.Context, req *mcp.CallToolRequest, input ListFoldersInput) (*mcp.CallToolResult, any, error) {
+	instances := t.filterInstances(input.Instance)
+	if input.Instance != nil && len(instances) == 0 {
+		return nil, nil, fmt.Errorf("unknown instance %q", *input.Instance)
+	}
+
+	var sb strings.Builder
+	for _, inst := range instances {
+		var resp foldersResponse
+		if err := inst.client.Do(ctx, `query { vaults { id name folders { path name } } }`, nil, &resp); err != nil {
+			slog.Warn("list folders failed", "instance", inst.name, "error", err)
+			fmt.Fprintf(&sb, "## %s\nError: %v\n\n", inst.name, err)
+			continue
+		}
+
+		for _, v := range resp.Vaults {
+			if len(v.Folders) == 0 {
+				continue
+			}
+			fmt.Fprintf(&sb, "## %s / %s\n", inst.name, v.Name)
+			sb.WriteString(buildFolderTree(v.Folders))
+			sb.WriteString("\n")
+		}
+	}
+
+	if sb.Len() == 0 {
+		return textResult("No folders found."), nil, nil
+	}
+	return textResult(sb.String()), nil, nil
+}
+
+// buildFolderTree formats a flat list of folder paths into an indented tree display.
+func buildFolderTree(folders []struct {
+	Path string `json:"path"`
+	Name string `json:"name"`
+}) string {
+	if len(folders) == 0 {
+		return ""
+	}
+
+	// Sort paths for consistent display
+	sort.Slice(folders, func(i, j int) bool {
+		return folders[i].Path < folders[j].Path
+	})
+
+	var sb strings.Builder
+	for _, f := range folders {
+		depth := strings.Count(strings.Trim(f.Path, "/"), "/")
+		indent := strings.Repeat("  ", depth)
+		fmt.Fprintf(&sb, "%s%s/\n", indent, f.Name)
+	}
+	return sb.String()
 }
 
 func (t *mcpTools) createMemory(ctx context.Context, req *mcp.CallToolRequest, input CreateMemoryInput) (*mcp.CallToolResult, any, error) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   surrealdb:
-    image: surrealdb/surrealdb:v3.0.0-beta.2
+    image: surrealdb/surrealdb:v3.0.2
     container_name: knowhow-surrealdb
     command: start --user root --pass root memory
     ports:

--- a/docs/surrealdb.md
+++ b/docs/surrealdb.md
@@ -168,6 +168,106 @@ ORDER BY rrf_score DESC
 LIMIT $limit;
 ```
 
+## Query Gotchas
+
+### Compound OR in WHERE Clauses
+
+As of v3.0.2, parenthesized OR conditions in WHERE clauses can cause parse errors:
+
+```sql
+-- FAILS: parse error "Unexpected token `an identifier` expected delimiter `)`"
+DELETE FROM folder WHERE vault = type::record("vault", $id)
+  AND (path = $path OR string::starts_with(path, $prefix))
+```
+
+**Workaround**: Split into two separate queries:
+
+```sql
+DELETE FROM folder WHERE vault = type::record("vault", $id) AND path = $path;
+DELETE FROM folder WHERE vault = type::record("vault", $id) AND string::starts_with(path, $prefix);
+```
+
+### Negative Array Indexing
+
+Bracket-based negative indexing (`[-1]`) is unreliable in SurrealQL — it returns NONE instead of the last element. Use `array::last()` or `array::at()` instead:
+
+```sql
+-- BAD: returns NONE
+string::split("/a/b/c", "/")[-1]
+
+-- GOOD: returns "c"
+array::last(string::split("/a/b/c", "/"))
+```
+
+### `STARTS WITH` Operator vs `string::starts_with()`
+
+The `STARTS WITH` operator can fail in compound WHERE clauses. Use the `string::starts_with()` function instead:
+
+```sql
+-- May fail in compound WHERE
+SELECT * FROM folder WHERE vault = $v AND path STARTS WITH $prefix
+
+-- Reliable
+SELECT * FROM folder WHERE vault = $v AND string::starts_with(path, $prefix)
+```
+
+## Performance Patterns
+
+### Batch INSERT to Avoid N+1
+
+Instead of looping over rows in Go and sending one INSERT per iteration, use `INSERT INTO table $rows` with an array parameter. This sends a single query regardless of how many rows are being inserted:
+
+```go
+// BAD: N round-trips for N folders
+for _, f := range folders {
+    surrealdb.Query(ctx, db, `INSERT INTO folder { vault: $v, path: $p, name: $n }`, ...)
+}
+
+// GOOD: 1 round-trip for N folders
+rows := make([]map[string]any, len(folders))
+for i, f := range folders {
+    rows[i] = map[string]any{"vault": vaultRecord, "path": f.Path, "name": f.Name}
+}
+surrealdb.Query(ctx, db, `INSERT INTO folder $rows ON DUPLICATE KEY UPDATE id = id`, map[string]any{"rows": rows})
+```
+
+**Important**: For `record<T>` fields in batch inserts, pass typed `surrealmodels.RecordID` values (not strings). The `type::record()` function doesn't work inside `INSERT ... $rows` — the rows are treated as literal objects.
+
+This also works with `ON DUPLICATE KEY UPDATE id = id` for idempotent upserts.
+
+### Multi-Statement Queries to Reduce Round-Trips
+
+Send multiple statements separated by `;` in a single `surrealdb.Query` call. Each statement returns its own result set in the response array. All statements share the same parameter map:
+
+```go
+// BAD: 4 round-trips
+surrealdb.Query(ctx, db, `DELETE FROM document WHERE vault = $v`, vars)
+surrealdb.Query(ctx, db, `DELETE FROM folder WHERE vault = $v`, vars)
+surrealdb.Query(ctx, db, `DELETE FROM template WHERE vault = $v`, vars)
+surrealdb.Query(ctx, db, `DELETE type::record("vault", $id)`, vars)
+
+// GOOD: 1 round-trip, 4 result sets
+sql := `DELETE FROM document WHERE vault = $v;` +
+    `DELETE FROM folder WHERE vault = $v;` +
+    `DELETE FROM template WHERE vault = $v;` +
+    `DELETE type::record("vault", $id)`
+surrealdb.Query(ctx, db, sql, vars)
+```
+
+**Counting results across statements**: Use `RETURN BEFORE` and iterate all result sets:
+
+```go
+results, err := surrealdb.Query[[]MyType](ctx, db, sql, vars)
+count := 0
+if results != nil {
+    for _, r := range *results {
+        count += len(r.Result)
+    }
+}
+```
+
+**Note**: Multi-statement queries are NOT transactions — each statement commits independently. Use `BEGIN TRANSACTION; ...; COMMIT TRANSACTION;` if atomicity is needed. However, multi-statement is still useful for reducing network latency when atomicity isn't critical.
+
 ## Connection Best Practices
 
 - Use `rews` (reconnecting websocket) for production

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -54,7 +54,7 @@ type readDocInput struct {
 	Path string `json:"path"`
 }
 
-const systemPrompt = `You are a helpful knowledge assistant for the Knowhow knowledge base. You help users find and understand information stored in their documents.
+const systemPromptBase = `You are a helpful knowledge assistant for the Knowhow knowledge base. You help users find and understand information stored in their documents.
 
 You have access to two tools:
 1. kb_search(query) - Search the knowledge base for relevant documents
@@ -81,6 +81,32 @@ If you have enough information to answer the user's question, respond with EXACT
 {"action":"answer"}
 
 Respond with ONLY the JSON, no explanation.`
+
+// buildSystemPrompt constructs the system prompt, optionally appending the vault's folder tree.
+func (s *Service) buildSystemPrompt(ctx context.Context, vaultID string) string {
+	folders, err := s.db.ListFolders(ctx, vaultID)
+	if err != nil {
+		slog.Warn("failed to list folders for system prompt", "vault_id", vaultID, "error", err)
+		return systemPromptBase
+	}
+	if len(folders) == 0 {
+		return systemPromptBase
+	}
+
+	var sb strings.Builder
+	sb.WriteString(systemPromptBase)
+	sb.WriteString("\n\nVault folder structure:\n```\n/\n")
+	for _, f := range folders {
+		depth := strings.Count(strings.Trim(f.Path, "/"), "/")
+		indent := strings.Repeat("  ", depth)
+		sb.WriteString(indent)
+		sb.WriteString("├── ")
+		sb.WriteString(f.Name)
+		sb.WriteString("/\n")
+	}
+	sb.WriteString("```")
+	return sb.String()
+}
 
 type docSource struct {
 	Title string
@@ -128,6 +154,9 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest, emit func(StreamEve
 	}
 	emit(StreamEvent{Type: "message_id", Content: userMsgID})
 
+	// Build dynamic system prompt with folder tree
+	sysPrompt := s.buildSystemPrompt(ctx, req.VaultID)
+
 	// Build conversation history from DB
 	messages, err := s.db.ListMessages(ctx, req.ConversationID)
 	if err != nil {
@@ -170,7 +199,7 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest, emit func(StreamEve
 			intentQuery = intentPrompt
 		}
 
-		decision, err := s.detectIntent(ctx, history, intentQuery, i == 0)
+		decision, err := s.detectIntent(ctx, history, intentQuery, i == 0, sysPrompt)
 		if err != nil {
 			slog.Warn("intent detection failed, falling back to direct answer", "error", err)
 			emit(StreamEvent{Type: "error", Content: "Knowledge base search unavailable, answering from general knowledge"})
@@ -222,7 +251,7 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest, emit func(StreamEve
 	history := s.buildHistory(messages, toolContext.String())
 	var answer strings.Builder
 
-	err = s.model.GenerateWithSystemStreamMultiTurn(ctx, systemPrompt, history, req.Content, func(token string) error {
+	err = s.model.GenerateWithSystemStreamMultiTurn(ctx, sysPrompt, history, req.Content, func(token string) error {
 		answer.WriteString(token)
 		emit(StreamEvent{Type: "token", Content: token})
 		return nil
@@ -297,10 +326,10 @@ func (s *Service) buildHistory(messages []models.Message, toolContext string) []
 	return history
 }
 
-func (s *Service) detectIntent(ctx context.Context, history []llm.ChatMessage, query string, firstTurn bool) (*toolAction, error) {
-	prompt := systemPrompt
+func (s *Service) detectIntent(ctx context.Context, history []llm.ChatMessage, query string, firstTurn bool, sysPrompt string) (*toolAction, error) {
+	prompt := sysPrompt
 	if !firstTurn {
-		prompt = systemPrompt + "\n\n" + intentPrompt
+		prompt = sysPrompt + "\n\n" + intentPrompt
 	}
 
 	// For intent detection, append the intent prompt to the user query

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 	var err error
 	testContainer, err = testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "surrealdb/surrealdb:v3.0.0-beta.1",
+			Image:        "surrealdb/surrealdb:v3.0.2",
 			ExposedPorts: []string{"8000/tcp"},
 			Cmd:          []string{"start", "--log", "info", "--user", "root", "--pass", "root"},
 			WaitingFor:   wait.ForLog("Started web server").WithStartupTimeout(60 * time.Second),

--- a/internal/db/queries_folder.go
+++ b/internal/db/queries_folder.go
@@ -1,0 +1,198 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/raphi011/knowhow/internal/models"
+	"github.com/surrealdb/surrealdb.go"
+)
+
+// CreateFolder creates a single folder record. Returns the created folder.
+func (c *Client) CreateFolder(ctx context.Context, vaultID, folderPath string) (*models.Folder, error) {
+	name := path.Base(folderPath)
+
+	sql := `
+		INSERT INTO folder {
+			vault: type::record("vault", $vault_id),
+			path: $path,
+			name: $name
+		} ON DUPLICATE KEY UPDATE id = id
+		RETURN AFTER
+	`
+	results, err := surrealdb.Query[[]models.Folder](ctx, c.DB(), sql, map[string]any{
+		"vault_id": bareID("vault", vaultID),
+		"path":     folderPath,
+		"name":     name,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create folder: %w", err)
+	}
+	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
+		return nil, fmt.Errorf("create folder: no result returned")
+	}
+	return &(*results)[0].Result[0], nil
+}
+
+// EnsureFolders idempotently creates all ancestor folders for a document path.
+// For example, given "/guides/sub/file.md", it creates "/guides" and "/guides/sub".
+// All folders are inserted in a single batched query to avoid N+1 round-trips.
+func (c *Client) EnsureFolders(ctx context.Context, vaultID, docPath string) error {
+	docPath = models.NormalizePath(docPath)
+	dir := path.Dir(docPath)
+	if dir == "/" || dir == "." {
+		return nil // root-level document, no folders to create
+	}
+	return c.EnsureFolderPath(ctx, vaultID, dir)
+}
+
+// EnsureFolderPath idempotently creates a folder and all its ancestors.
+// For example, given "/guides/sub", it creates "/guides" and "/guides/sub".
+// All folders are inserted in a single batched query to avoid N+1 round-trips.
+func (c *Client) EnsureFolderPath(ctx context.Context, vaultID, folderPath string) error {
+	folderPath = models.NormalizePath(folderPath)
+	if folderPath == "/" || folderPath == "." {
+		return nil
+	}
+
+	// Collect the target folder and all its ancestors
+	var folders []string
+	for cur := folderPath; cur != "/" && cur != "."; cur = path.Dir(cur) {
+		folders = append(folders, cur)
+	}
+
+	// Build batch of folder rows for a single INSERT
+	rows := make([]map[string]any, len(folders))
+	vid := bareID("vault", vaultID)
+	for i, fp := range folders {
+		rows[i] = map[string]any{
+			"vault": newRecordID("vault", vid),
+			"path":  fp,
+			"name":  path.Base(fp),
+		}
+	}
+
+	sql := `INSERT INTO folder $folders ON DUPLICATE KEY UPDATE id = id`
+	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
+		"folders": rows,
+	}); err != nil {
+		return fmt.Errorf("ensure folder path %q: %w", folderPath, err)
+	}
+
+	return nil
+}
+
+// ListFolders returns all folders in a vault, ordered by path.
+func (c *Client) ListFolders(ctx context.Context, vaultID string) ([]models.Folder, error) {
+	sql := `SELECT * FROM folder WHERE vault = type::record("vault", $vault_id) ORDER BY path ASC`
+	results, err := surrealdb.Query[[]models.Folder](ctx, c.DB(), sql, map[string]any{
+		"vault_id": bareID("vault", vaultID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list folders: %w", err)
+	}
+	if results == nil || len(*results) == 0 {
+		return nil, nil
+	}
+	return (*results)[0].Result, nil
+}
+
+// GetFolderByPath returns a single folder by vault and path, or nil if not found.
+func (c *Client) GetFolderByPath(ctx context.Context, vaultID, folderPath string) (*models.Folder, error) {
+	sql := `SELECT * FROM folder WHERE vault = type::record("vault", $vault_id) AND path = $path LIMIT 1`
+	results, err := surrealdb.Query[[]models.Folder](ctx, c.DB(), sql, map[string]any{
+		"vault_id": bareID("vault", vaultID),
+		"path":     folderPath,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get folder by path: %w", err)
+	}
+	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
+		return nil, nil
+	}
+	return &(*results)[0].Result[0], nil
+}
+
+// DeleteFolder deletes a single folder and all its children (paths starting with folderPath + "/").
+func (c *Client) DeleteFolder(ctx context.Context, vaultID, folderPath string) error {
+	_, err := c.deleteFolderTree(ctx, vaultID, folderPath)
+	return err
+}
+
+// DeleteFoldersByPrefix deletes all folders whose path starts with the given prefix
+// or matches the prefix itself (without trailing slash). Returns the number of deleted folders.
+func (c *Client) DeleteFoldersByPrefix(ctx context.Context, vaultID, prefix string) (int, error) {
+	folderPath := strings.TrimSuffix(prefix, "/")
+	return c.deleteFolderTree(ctx, vaultID, folderPath)
+}
+
+// deleteFolderTree deletes a folder and all its children in a single multi-statement query.
+// Two statements are needed because SurrealDB v3 doesn't support parenthesized OR in WHERE.
+// Returns the total number of deleted folders.
+func (c *Client) deleteFolderTree(ctx context.Context, vaultID, folderPath string) (int, error) {
+	prefix := folderPath + "/"
+
+	// Multi-statement: delete parent + children in one round-trip.
+	// Each statement returns its own result set.
+	sql := `DELETE FROM folder WHERE vault = type::record("vault", $vault_id) AND path = $path RETURN BEFORE;` +
+		`DELETE FROM folder WHERE vault = type::record("vault", $vault_id) AND string::starts_with(path, $prefix) RETURN BEFORE`
+	results, err := surrealdb.Query[[]models.Folder](ctx, c.DB(), sql, map[string]any{
+		"vault_id": bareID("vault", vaultID),
+		"path":     folderPath,
+		"prefix":   prefix,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("delete folder tree %q: %w", folderPath, err)
+	}
+
+	return countMultiResults(results), nil
+}
+
+// MoveFoldersByPrefix renames all folders whose path starts with oldPrefix,
+// replacing oldPrefix with newPrefix. Also updates the name field.
+// Accepts folder paths (e.g. "/guides", "/docs") — trailing slashes are handled internally.
+// Returns the number of moved folders.
+func (c *Client) MoveFoldersByPrefix(ctx context.Context, vaultID, oldPath, newPath string) (int, error) {
+	oldFolderPath := strings.TrimSuffix(oldPath, "/")
+	newFolderPath := strings.TrimSuffix(newPath, "/")
+	oldPrefix := oldFolderPath + "/"
+	newPrefix := newFolderPath + "/"
+
+	// Multi-statement: update root folder + children in one round-trip.
+	// Statement 1: rename the root folder itself (RETURN BEFORE for counting).
+	// Statement 2: rewrite child paths by replacing the old prefix with the new one.
+	sql := `UPDATE folder SET path = $new_path, name = $new_name WHERE vault = type::record("vault", $vault_id) AND path = $old_path RETURN BEFORE;` +
+		`UPDATE folder SET
+			path = string::concat($new_prefix, string::slice(path, string::len($old_prefix))),
+			name = array::last(string::split(string::concat($new_prefix, string::slice(path, string::len($old_prefix))), "/"))
+		WHERE vault = type::record("vault", $vault_id)
+		AND string::starts_with(path, $old_prefix)
+		RETURN BEFORE`
+	results, err := surrealdb.Query[[]models.Folder](ctx, c.DB(), sql, map[string]any{
+		"vault_id":   bareID("vault", vaultID),
+		"old_path":   oldFolderPath,
+		"new_path":   newFolderPath,
+		"new_name":   path.Base(newFolderPath),
+		"old_prefix": oldPrefix,
+		"new_prefix": newPrefix,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("move folders by prefix: %w", err)
+	}
+
+	return countMultiResults(results), nil
+}
+
+// countMultiResults sums Result lengths across multi-statement query results.
+func countMultiResults[T any](results *[]surrealdb.QueryResult[[]T]) int {
+	if results == nil {
+		return 0
+	}
+	count := 0
+	for _, r := range *results {
+		count += len(r.Result)
+	}
+	return count
+}

--- a/internal/db/queries_proposal.go
+++ b/internal/db/queries_proposal.go
@@ -60,47 +60,31 @@ func (c *Client) ListProposals(ctx context.Context, vaultID string, status *stri
 	start := c.startOp()
 	defer c.recordTiming("db.list_proposals", start)
 
-	var sql string
-	vars := map[string]any{
+	return c.listProposals(ctx, `vault = type::record("vault", $vault_id)`, map[string]any{
 		"vault_id": bareID("vault", vaultID),
-	}
-
-	if status != nil {
-		sql = `SELECT * FROM document_proposal WHERE vault = type::record("vault", $vault_id) AND status = $status ORDER BY created_at DESC`
-		vars["status"] = *status
-	} else {
-		sql = `SELECT * FROM document_proposal WHERE vault = type::record("vault", $vault_id) ORDER BY created_at DESC`
-	}
-
-	results, err := surrealdb.Query[[]models.DocumentProposal](ctx, c.DB(), sql, vars)
-	if err != nil {
-		return nil, fmt.Errorf("list proposals: %w", err)
-	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	}, status)
 }
 
 func (c *Client) ListProposalsByDocument(ctx context.Context, documentID string, status *string) ([]models.DocumentProposal, error) {
 	start := c.startOp()
 	defer c.recordTiming("db.list_proposals_by_document", start)
 
-	var sql string
-	vars := map[string]any{
+	return c.listProposals(ctx, `document = type::record("document", $document_id)`, map[string]any{
 		"document_id": documentID,
-	}
+	}, status)
+}
 
+func (c *Client) listProposals(ctx context.Context, filter string, vars map[string]any, status *string) ([]models.DocumentProposal, error) {
+	sql := "SELECT * FROM document_proposal WHERE " + filter
 	if status != nil {
-		sql = `SELECT * FROM document_proposal WHERE document = type::record("document", $document_id) AND status = $status ORDER BY created_at DESC`
+		sql += " AND status = $status"
 		vars["status"] = *status
-	} else {
-		sql = `SELECT * FROM document_proposal WHERE document = type::record("document", $document_id) ORDER BY created_at DESC`
 	}
+	sql += " ORDER BY created_at DESC"
 
 	results, err := surrealdb.Query[[]models.DocumentProposal](ctx, c.DB(), sql, vars)
 	if err != nil {
-		return nil, fmt.Errorf("list proposals by document: %w", err)
+		return nil, fmt.Errorf("list proposals: %w", err)
 	}
 	if results == nil || len(*results) == 0 {
 		return nil, nil

--- a/internal/db/queries_vault.go
+++ b/internal/db/queries_vault.go
@@ -95,22 +95,14 @@ func (c *Client) ListVaults(ctx context.Context) ([]models.Vault, error) {
 }
 
 func (c *Client) DeleteVault(ctx context.Context, id string) error {
-	// Delete all documents in vault (cascade events will handle chunks, wiki_links, relations)
-	sql := `DELETE FROM document WHERE vault = type::record("vault", $id)`
+	// Single multi-statement query: delete all vault data + the vault itself.
+	// Document cascade events handle chunks, wiki_links, and relations.
+	sql := `DELETE FROM document WHERE vault = type::record("vault", $id);` +
+		`DELETE FROM folder WHERE vault = type::record("vault", $id);` +
+		`DELETE FROM template WHERE vault = type::record("vault", $id);` +
+		`DELETE type::record("vault", $id)`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"id": id}); err != nil {
-		return fmt.Errorf("delete vault documents: %w", err)
-	}
-
-	// Delete templates scoped to this vault
-	sql = `DELETE FROM template WHERE vault = type::record("vault", $id)`
-	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"id": id}); err != nil {
-		return fmt.Errorf("delete vault templates: %w", err)
-	}
-
-	// Delete the vault itself
-	sql = `DELETE type::record("vault", $id)`
-	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"id": id}); err != nil {
-		return fmt.Errorf("delete vault: %w", err)
+		return fmt.Errorf("delete vault (documents+folders+templates+vault): %w", err)
 	}
 	return nil
 }

--- a/internal/db/queries_wikilink.go
+++ b/internal/db/queries_wikilink.go
@@ -9,31 +9,36 @@ import (
 	surrealmodels "github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
-// CreateWikiLinks creates wiki-link records for a document.
+// CreateWikiLinks creates wiki-link records for a document in a single batch INSERT.
 func (c *Client) CreateWikiLinks(ctx context.Context, fromDocID, vaultID string, links []WikiLinkInput) error {
+	if len(links) == 0 {
+		return nil
+	}
+
+	fromDoc := newRecordID("document", bareID("document", fromDocID))
+	vault := newRecordID("vault", bareID("vault", vaultID))
+
+	rows := make([]map[string]any, len(links))
 	for i, link := range links {
-		sql := `
-			CREATE wiki_link SET
-				from_doc = type::record("document", $from_doc_id),
-				to_doc = $to_doc,
-				raw_target = $raw_target,
-				vault = type::record("vault", $vault_id)
-		`
 		var toDoc any
 		if link.ToDocID != nil {
 			toDoc = newRecordID("document", *link.ToDocID)
 		} else {
 			toDoc = surrealmodels.None
 		}
-
-		if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
-			"from_doc_id": fromDocID,
-			"to_doc":      toDoc,
-			"raw_target":  link.RawTarget,
-			"vault_id":    bareID("vault", vaultID),
-		}); err != nil {
-			return fmt.Errorf("create wiki link %d: %w", i, err)
+		rows[i] = map[string]any{
+			"from_doc":   fromDoc,
+			"to_doc":     toDoc,
+			"raw_target": link.RawTarget,
+			"vault":      vault,
 		}
+	}
+
+	sql := `INSERT INTO wiki_link $links RETURN NONE`
+	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
+		"links": rows,
+	}); err != nil {
+		return fmt.Errorf("create wiki links: %w", err)
 	}
 	return nil
 }

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -77,6 +77,19 @@ func SchemaSQL(dimension int) string {
     };
 
     -- ==========================================================================
+    -- FOLDER TABLE
+    -- ==========================================================================
+    DEFINE TABLE IF NOT EXISTS folder SCHEMAFULL;
+
+    DEFINE FIELD IF NOT EXISTS vault      ON folder TYPE record<vault>;
+    DEFINE FIELD IF NOT EXISTS path       ON folder TYPE string;
+    DEFINE FIELD IF NOT EXISTS name       ON folder TYPE string;
+    DEFINE FIELD IF NOT EXISTS created_at ON folder TYPE datetime DEFAULT time::now();
+
+    DEFINE INDEX IF NOT EXISTS idx_folder_vault_path ON folder FIELDS vault, path UNIQUE;
+    DEFINE INDEX IF NOT EXISTS idx_folder_vault      ON folder FIELDS vault;
+
+    -- ==========================================================================
     -- CHUNK TABLE
     -- ==========================================================================
     DEFINE TABLE IF NOT EXISTS chunk SCHEMAFULL;

--- a/internal/document/service.go
+++ b/internal/document/service.go
@@ -93,6 +93,11 @@ func (s *Service) Create(ctx context.Context, input models.DocumentInput) (*mode
 		Metadata:    metadata,
 	}
 
+	// Auto-create parent folders before document upsert
+	if err := s.db.EnsureFolders(ctx, input.VaultID, path); err != nil {
+		return nil, fmt.Errorf("ensure parent folders: %w", err)
+	}
+
 	doc, created, err := s.db.UpsertDocument(ctx, dbInput)
 	if err != nil {
 		return nil, fmt.Errorf("upsert document: %w", err)
@@ -217,7 +222,17 @@ func (s *Service) DeleteByPrefix(ctx context.Context, vaultID, pathPrefix string
 	if prefix == "/" {
 		return 0, fmt.Errorf("delete by prefix: refusing to delete root prefix")
 	}
-	return s.db.DeleteDocumentsByPrefix(ctx, vaultID, prefix)
+	count, err := s.db.DeleteDocumentsByPrefix(ctx, vaultID, prefix)
+	if err != nil {
+		return 0, err
+	}
+
+	// Clean up folder records under the same prefix
+	if _, err := s.db.DeleteFoldersByPrefix(ctx, vaultID, prefix); err != nil {
+		return count, fmt.Errorf("delete folder records: %w", err)
+	}
+
+	return count, nil
 }
 
 // MoveByPrefix renames all documents whose path starts with oldPrefix,
@@ -240,7 +255,21 @@ func (s *Service) MoveByPrefix(ctx context.Context, vaultID, oldPrefix, newPrefi
 	if oldNorm == newNorm {
 		return 0, nil
 	}
-	return s.db.MoveDocumentsByPrefix(ctx, vaultID, oldNorm, newNorm)
+	count, err := s.db.MoveDocumentsByPrefix(ctx, vaultID, oldNorm, newNorm)
+	if err != nil {
+		return 0, err
+	}
+
+	// Move folder records to match
+	if _, err := s.db.MoveFoldersByPrefix(ctx, vaultID, oldNorm, newNorm); err != nil {
+		return count, fmt.Errorf("move folder records: %w", err)
+	}
+	// Ensure destination ancestor folders exist
+	if err := s.db.EnsureFolderPath(ctx, vaultID, strings.TrimSuffix(newNorm, "/")); err != nil {
+		return count, fmt.Errorf("ensure destination folders: %w", err)
+	}
+
+	return count, nil
 }
 
 // Move changes a document's path.
@@ -258,7 +287,18 @@ func (s *Service) Move(ctx context.Context, vaultID, oldPath, newPath string) (*
 		return nil, fmt.Errorf("extract doc id: %w", err)
 	}
 
-	return s.db.MoveDocument(ctx, docID, models.NormalizePath(newPath))
+	normalizedNew := models.NormalizePath(newPath)
+	doc, err = s.db.MoveDocument(ctx, docID, normalizedNew)
+	if err != nil {
+		return nil, fmt.Errorf("move document: %w", err)
+	}
+
+	// Ensure destination folders exist
+	if err := s.db.EnsureFolders(ctx, vaultID, normalizedNew); err != nil {
+		return nil, fmt.Errorf("ensure destination folders: %w", err)
+	}
+
+	return doc, nil
 }
 
 func (s *Service) processWikiLinks(ctx context.Context, docID, vaultID, content string) error {

--- a/internal/graph/generated.go
+++ b/internal/graph/generated.go
@@ -136,9 +136,10 @@ type ComplexityRoot struct {
 	}
 
 	Folder struct {
-		DocCount func(childComplexity int) int
-		Name     func(childComplexity int) int
-		Path     func(childComplexity int) int
+		CreatedAt func(childComplexity int) int
+		ID        func(childComplexity int) int
+		Name      func(childComplexity int) int
+		Path      func(childComplexity int) int
 	}
 
 	Me struct {
@@ -151,17 +152,20 @@ type ComplexityRoot struct {
 		ApproveProposalHunks    func(childComplexity int, input ApproveHunksInput) int
 		CreateConversation      func(childComplexity int, vaultID string) int
 		CreateDocument          func(childComplexity int, vaultID string, file FileInput, source *string) int
+		CreateFolder            func(childComplexity int, vaultID string, path string) int
 		CreateRelation          func(childComplexity int, input RelationInput) int
 		CreateTemplate          func(childComplexity int, input TemplateInput) int
 		CreateVault             func(childComplexity int, input VaultInput) int
 		DeleteConversation      func(childComplexity int, id string) int
 		DeleteDocument          func(childComplexity int, vaultID string, path string) int
 		DeleteDocumentsByPrefix func(childComplexity int, vaultID string, pathPrefix string) int
+		DeleteFolder            func(childComplexity int, vaultID string, path string) int
 		DeleteRelation          func(childComplexity int, id string) int
 		DeleteTemplate          func(childComplexity int, id string) int
 		DeleteVault             func(childComplexity int, id string) int
 		MoveDocument            func(childComplexity int, vaultID string, oldPath string, newPath string) int
 		MoveDocumentsByPrefix   func(childComplexity int, vaultID string, oldPrefix string, newPrefix string) int
+		MoveFolder              func(childComplexity int, vaultID string, oldPath string, newPath string) int
 		ProposeDocumentUpdate   func(childComplexity int, input ProposeDocumentUpdateInput) int
 		RejectProposal          func(childComplexity int, id string, notes *string) int
 		RenameConversation      func(childComplexity int, id string, title string) int
@@ -292,6 +296,9 @@ type MutationResolver interface {
 	ApproveProposal(ctx context.Context, id string, notes *string) (*Document, error)
 	ApproveProposalHunks(ctx context.Context, input ApproveHunksInput) (*Document, error)
 	RejectProposal(ctx context.Context, id string, notes *string) (bool, error)
+	CreateFolder(ctx context.Context, vaultID string, path string) (*Folder, error)
+	DeleteFolder(ctx context.Context, vaultID string, path string) (bool, error)
+	MoveFolder(ctx context.Context, vaultID string, oldPath string, newPath string) (bool, error)
 	CreateConversation(ctx context.Context, vaultID string) (*Conversation, error)
 	DeleteConversation(ctx context.Context, id string) (bool, error)
 	RenameConversation(ctx context.Context, id string, title string) (*Conversation, error)
@@ -758,12 +765,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.DocumentProposal.VaultID(childComplexity), true
 
-	case "Folder.docCount":
-		if e.ComplexityRoot.Folder.DocCount == nil {
+	case "Folder.createdAt":
+		if e.ComplexityRoot.Folder.CreatedAt == nil {
 			break
 		}
 
-		return e.ComplexityRoot.Folder.DocCount(childComplexity), true
+		return e.ComplexityRoot.Folder.CreatedAt(childComplexity), true
+	case "Folder.id":
+		if e.ComplexityRoot.Folder.ID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Folder.ID(childComplexity), true
 	case "Folder.name":
 		if e.ComplexityRoot.Folder.Name == nil {
 			break
@@ -834,6 +847,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Mutation.CreateDocument(childComplexity, args["vaultId"].(string), args["file"].(FileInput), args["source"].(*string)), true
+	case "Mutation.createFolder":
+		if e.ComplexityRoot.Mutation.CreateFolder == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createFolder_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Mutation.CreateFolder(childComplexity, args["vaultId"].(string), args["path"].(string)), true
 	case "Mutation.createRelation":
 		if e.ComplexityRoot.Mutation.CreateRelation == nil {
 			break
@@ -900,6 +924,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Mutation.DeleteDocumentsByPrefix(childComplexity, args["vaultId"].(string), args["pathPrefix"].(string)), true
+	case "Mutation.deleteFolder":
+		if e.ComplexityRoot.Mutation.DeleteFolder == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteFolder_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Mutation.DeleteFolder(childComplexity, args["vaultId"].(string), args["path"].(string)), true
 	case "Mutation.deleteRelation":
 		if e.ComplexityRoot.Mutation.DeleteRelation == nil {
 			break
@@ -955,6 +990,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Mutation.MoveDocumentsByPrefix(childComplexity, args["vaultId"].(string), args["oldPrefix"].(string), args["newPrefix"].(string)), true
+	case "Mutation.moveFolder":
+		if e.ComplexityRoot.Mutation.MoveFolder == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_moveFolder_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Mutation.MoveFolder(childComplexity, args["vaultId"].(string), args["oldPath"].(string), args["newPath"].(string)), true
 	case "Mutation.proposeDocumentUpdate":
 		if e.ComplexityRoot.Mutation.ProposeDocumentUpdate == nil {
 			break
@@ -1622,6 +1668,22 @@ func (ec *executionContext) field_Mutation_createDocument_args(ctx context.Conte
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_createFolder_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "vaultId", ec.unmarshalNID2string)
+	if err != nil {
+		return nil, err
+	}
+	args["vaultId"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "path", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["path"] = arg1
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_createRelation_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -1698,6 +1760,22 @@ func (ec *executionContext) field_Mutation_deleteDocumentsByPrefix_args(ctx cont
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_deleteFolder_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "vaultId", ec.unmarshalNID2string)
+	if err != nil {
+		return nil, err
+	}
+	args["vaultId"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "path", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["path"] = arg1
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_deleteRelation_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -1770,6 +1848,27 @@ func (ec *executionContext) field_Mutation_moveDocumentsByPrefix_args(ctx contex
 		return nil, err
 	}
 	args["newPrefix"] = arg2
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_moveFolder_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "vaultId", ec.unmarshalNID2string)
+	if err != nil {
+		return nil, err
+	}
+	args["vaultId"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "oldPath", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["oldPath"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "newPath", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["newPath"] = arg2
 	return args, nil
 }
 
@@ -4217,6 +4316,35 @@ func (ec *executionContext) fieldContext_DocumentProposal_diff(_ context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _Folder_id(ctx context.Context, field graphql.CollectedField, obj *Folder) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Folder_id,
+		func(ctx context.Context) (any, error) {
+			return obj.ID, nil
+		},
+		nil,
+		ec.marshalNID2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Folder_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Folder",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Folder_path(ctx context.Context, field graphql.CollectedField, obj *Folder) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -4275,30 +4403,30 @@ func (ec *executionContext) fieldContext_Folder_name(_ context.Context, field gr
 	return fc, nil
 }
 
-func (ec *executionContext) _Folder_docCount(ctx context.Context, field graphql.CollectedField, obj *Folder) (ret graphql.Marshaler) {
+func (ec *executionContext) _Folder_createdAt(ctx context.Context, field graphql.CollectedField, obj *Folder) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
-		ec.fieldContext_Folder_docCount,
+		ec.fieldContext_Folder_createdAt,
 		func(ctx context.Context) (any, error) {
-			return obj.DocCount, nil
+			return obj.CreatedAt, nil
 		},
 		nil,
-		ec.marshalNInt2int,
+		ec.marshalNDateTime2timeᚐTime,
 		true,
 		true,
 	)
 }
 
-func (ec *executionContext) fieldContext_Folder_docCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Folder_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Folder",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type DateTime does not have child fields")
 		},
 	}
 	return fc, nil
@@ -5302,6 +5430,139 @@ func (ec *executionContext) fieldContext_Mutation_rejectProposal(ctx context.Con
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_rejectProposal_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_createFolder(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_createFolder,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Mutation().CreateFolder(ctx, fc.Args["vaultId"].(string), fc.Args["path"].(string))
+		},
+		nil,
+		ec.marshalNFolder2ᚖgithubᚗcomᚋraphi011ᚋknowhowᚋinternalᚋgraphᚐFolder,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createFolder(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Folder_id(ctx, field)
+			case "path":
+				return ec.fieldContext_Folder_path(ctx, field)
+			case "name":
+				return ec.fieldContext_Folder_name(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Folder_createdAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Folder", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createFolder_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteFolder(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_deleteFolder,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Mutation().DeleteFolder(ctx, fc.Args["vaultId"].(string), fc.Args["path"].(string))
+		},
+		nil,
+		ec.marshalNBoolean2bool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteFolder(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteFolder_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_moveFolder(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_moveFolder,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Mutation().MoveFolder(ctx, fc.Args["vaultId"].(string), fc.Args["oldPath"].(string), fc.Args["newPath"].(string))
+		},
+		nil,
+		ec.marshalNBoolean2bool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_moveFolder(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_moveFolder_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -7694,12 +7955,14 @@ func (ec *executionContext) fieldContext_Vault_folders(ctx context.Context, fiel
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Folder_id(ctx, field)
 			case "path":
 				return ec.fieldContext_Folder_path(ctx, field)
 			case "name":
 				return ec.fieldContext_Folder_name(ctx, field)
-			case "docCount":
-				return ec.fieldContext_Folder_docCount(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Folder_createdAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Folder", field.Name)
 		},
@@ -10506,6 +10769,11 @@ func (ec *executionContext) _Folder(ctx context.Context, sel ast.SelectionSet, o
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Folder")
+		case "id":
+			out.Values[i] = ec._Folder_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "path":
 			out.Values[i] = ec._Folder_path(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -10516,8 +10784,8 @@ func (ec *executionContext) _Folder(ctx context.Context, sel ast.SelectionSet, o
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "docCount":
-			out.Values[i] = ec._Folder_docCount(ctx, field, obj)
+		case "createdAt":
+			out.Values[i] = ec._Folder_createdAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -10715,6 +10983,27 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "rejectProposal":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_rejectProposal(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "createFolder":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createFolder(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteFolder":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteFolder(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "moveFolder":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_moveFolder(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -12320,6 +12609,10 @@ func (ec *executionContext) marshalNFloat2float64(ctx context.Context, sel ast.S
 		}
 	}
 	return graphql.WrapContextMarshaler(ctx, res)
+}
+
+func (ec *executionContext) marshalNFolder2githubᚗcomᚋraphi011ᚋknowhowᚋinternalᚋgraphᚐFolder(ctx context.Context, sel ast.SelectionSet, v Folder) graphql.Marshaler {
+	return ec._Folder(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNFolder2ᚕᚖgithubᚗcomᚋraphi011ᚋknowhowᚋinternalᚋgraphᚐFolderᚄ(ctx context.Context, sel ast.SelectionSet, v []*Folder) graphql.Marshaler {

--- a/internal/graph/helpers.go
+++ b/internal/graph/helpers.go
@@ -74,10 +74,16 @@ func documentToGraphQL(d *models.Document) *Document {
 }
 
 func folderToGraphQL(f models.Folder) Folder {
+	id, err := models.RecordIDString(f.ID)
+	if err != nil {
+		slog.Warn("unexpected folder ID format in GraphQL conversion", "path", f.Path, "error", err)
+		id = fmt.Sprintf("%v", f.ID.ID)
+	}
 	return Folder{
-		Path:     f.Path,
-		Name:     f.Name,
-		DocCount: f.DocCount,
+		ID:        id,
+		Path:      f.Path,
+		Name:      f.Name,
+		CreatedAt: f.CreatedAt,
 	}
 }
 

--- a/internal/graph/models.go
+++ b/internal/graph/models.go
@@ -30,9 +30,10 @@ type Document struct {
 }
 
 type Folder struct {
-	Path     string `json:"path"`
-	Name     string `json:"name"`
-	DocCount int    `json:"docCount"`
+	ID        string    `json:"id"`
+	Path      string    `json:"path"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"createdAt"`
 }
 
 type WikiLink struct {

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -62,9 +62,10 @@ type QueryResult {
 }
 
 type Folder {
+  id: ID!
   path: String!
   name: String!
-  docCount: Int!
+  createdAt: DateTime!
 }
 
 type WikiLink {
@@ -339,6 +340,11 @@ type Mutation {
   approveProposal(id: ID!, notes: String): Document!
   approveProposalHunks(input: ApproveHunksInput!): Document!
   rejectProposal(id: ID!, notes: String): Boolean!
+
+  # Folders
+  createFolder(vaultId: ID!, path: String!): Folder!
+  deleteFolder(vaultId: ID!, path: String!): Boolean!
+  moveFolder(vaultId: ID!, oldPath: String!, newPath: String!): Boolean!
 
   # Conversations
   createConversation(vaultId: ID!): Conversation!

--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -450,6 +450,41 @@ func (r *mutationResolver) RejectProposal(ctx context.Context, id string, notes 
 	return true, nil
 }
 
+// CreateFolder is the resolver for the createFolder field.
+func (r *mutationResolver) CreateFolder(ctx context.Context, vaultID string, path string) (*Folder, error) {
+	if err := auth.RequireVaultAccess(ctx, vaultID); err != nil {
+		return nil, err
+	}
+	folder, err := r.vaultService.CreateFolder(ctx, vaultID, path)
+	if err != nil {
+		return nil, err
+	}
+	f := folderToGraphQL(*folder)
+	return &f, nil
+}
+
+// DeleteFolder is the resolver for the deleteFolder field.
+func (r *mutationResolver) DeleteFolder(ctx context.Context, vaultID string, path string) (bool, error) {
+	if err := auth.RequireVaultAccess(ctx, vaultID); err != nil {
+		return false, err
+	}
+	if err := r.vaultService.DeleteFolder(ctx, vaultID, path); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// MoveFolder is the resolver for the moveFolder field.
+func (r *mutationResolver) MoveFolder(ctx context.Context, vaultID string, oldPath string, newPath string) (bool, error) {
+	if err := auth.RequireVaultAccess(ctx, vaultID); err != nil {
+		return false, err
+	}
+	if err := r.vaultService.MoveFolder(ctx, vaultID, oldPath, newPath); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // CreateConversation is the resolver for the createConversation field.
 func (r *mutationResolver) CreateConversation(ctx context.Context, vaultID string) (*Conversation, error) {
 	if err := auth.RequireVaultAccess(ctx, vaultID); err != nil {

--- a/internal/integration/folder_test.go
+++ b/internal/integration/folder_test.go
@@ -1,0 +1,530 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/raphi011/knowhow/internal/document"
+	"github.com/raphi011/knowhow/internal/models"
+	"github.com/raphi011/knowhow/internal/parser"
+	"github.com/raphi011/knowhow/internal/vault"
+)
+
+// setupVault is a test helper that creates a user and vault, returning the vault ID.
+func setupVault(t *testing.T, ctx context.Context, suffix string) (string, *vault.Service) {
+	t.Helper()
+	user, err := testDB.CreateUser(ctx, models.UserInput{Name: "folder-test-user-" + suffix})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	userID := models.MustRecordIDString(user.ID)
+
+	vaultSvc := vault.NewService(testDB)
+	v, err := vaultSvc.Create(ctx, userID, models.VaultInput{Name: "folder-test-" + suffix})
+	if err != nil {
+		t.Fatalf("create vault: %v", err)
+	}
+	vaultID := models.MustRecordIDString(v.ID)
+	return vaultID, vaultSvc
+}
+
+// TestFolderAutoCreate verifies that creating a document with a nested path
+// automatically creates all parent folders.
+func TestFolderAutoCreate(t *testing.T) {
+	ctx := context.Background()
+	vaultID, vaultSvc := setupVault(t, ctx, "autocreate-"+fmt.Sprint(time.Now().UnixNano()))
+
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
+
+	// Create a document at /guides/sub/file.md
+	_, err := docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID,
+		Path:    "/guides/sub/file.md",
+		Content: "# Guide",
+		Source:  models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create doc: %v", err)
+	}
+
+	// Verify folders /guides and /guides/sub were created
+	folders, err := vaultSvc.ListFolders(ctx, vaultID, nil)
+	if err != nil {
+		t.Fatalf("list folders: %v", err)
+	}
+
+	folderPaths := make(map[string]bool)
+	for _, f := range folders {
+		folderPaths[f.Path] = true
+	}
+
+	if !folderPaths["/guides"] {
+		t.Error("expected /guides folder to be auto-created")
+	}
+	if !folderPaths["/guides/sub"] {
+		t.Error("expected /guides/sub folder to be auto-created")
+	}
+
+	// Cleanup
+	if err := vaultSvc.Delete(ctx, vaultID); err != nil {
+		t.Fatalf("cleanup vault: %v", err)
+	}
+}
+
+// TestFolderRootDocNoFolders verifies that a root-level document creates no folders.
+func TestFolderRootDocNoFolders(t *testing.T) {
+	ctx := context.Background()
+	vaultID, vaultSvc := setupVault(t, ctx, "rootdoc-"+fmt.Sprint(time.Now().UnixNano()))
+
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
+
+	_, err := docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID,
+		Path:    "/readme.md",
+		Content: "# Readme",
+		Source:  models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create doc: %v", err)
+	}
+
+	folders, err := vaultSvc.ListFolders(ctx, vaultID, nil)
+	if err != nil {
+		t.Fatalf("list folders: %v", err)
+	}
+	if len(folders) != 0 {
+		t.Errorf("expected no folders for root-level doc, got %d: %v", len(folders), folders)
+	}
+
+	if err := vaultSvc.Delete(ctx, vaultID); err != nil {
+		t.Fatalf("cleanup vault: %v", err)
+	}
+}
+
+// TestFolderEnsureIdempotency verifies that EnsureFolders is idempotent.
+func TestFolderEnsureIdempotency(t *testing.T) {
+	ctx := context.Background()
+	vaultID, vaultSvc := setupVault(t, ctx, "idempotent-"+fmt.Sprint(time.Now().UnixNano()))
+
+	// Ensure folders twice for the same path
+	if err := testDB.EnsureFolders(ctx, vaultID, "/guides/sub/file.md"); err != nil {
+		t.Fatalf("first EnsureFolders: %v", err)
+	}
+	if err := testDB.EnsureFolders(ctx, vaultID, "/guides/sub/other.md"); err != nil {
+		t.Fatalf("second EnsureFolders: %v", err)
+	}
+
+	folders, err := vaultSvc.ListFolders(ctx, vaultID, nil)
+	if err != nil {
+		t.Fatalf("list folders: %v", err)
+	}
+
+	// Should have exactly 2 folders: /guides and /guides/sub (no duplicates)
+	if len(folders) != 2 {
+		t.Errorf("expected 2 folders, got %d: %v", len(folders), folders)
+	}
+
+	if err := vaultSvc.Delete(ctx, vaultID); err != nil {
+		t.Fatalf("cleanup vault: %v", err)
+	}
+}
+
+// TestFolderEmptyPersistence verifies that empty folders persist after doc deletion.
+func TestFolderEmptyPersistence(t *testing.T) {
+	ctx := context.Background()
+	vaultID, vaultSvc := setupVault(t, ctx, "empty-"+fmt.Sprint(time.Now().UnixNano()))
+
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
+
+	// Create a document to auto-create folders
+	_, err := docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID,
+		Path:    "/notes/file.md",
+		Content: "# Note",
+		Source:  models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create doc: %v", err)
+	}
+
+	// Delete the document (single doc delete does NOT clean up folders)
+	if err := docSvc.Delete(ctx, vaultID, "/notes/file.md"); err != nil {
+		t.Fatalf("delete doc: %v", err)
+	}
+
+	// Folder should still exist
+	folders, err := vaultSvc.ListFolders(ctx, vaultID, nil)
+	if err != nil {
+		t.Fatalf("list folders: %v", err)
+	}
+	if len(folders) != 1 {
+		t.Errorf("expected 1 folder (empty /notes), got %d", len(folders))
+	}
+
+	if err := vaultSvc.Delete(ctx, vaultID); err != nil {
+		t.Fatalf("cleanup vault: %v", err)
+	}
+}
+
+// TestFolderExplicitCreate verifies that folders can be created explicitly (empty).
+func TestFolderExplicitCreate(t *testing.T) {
+	ctx := context.Background()
+	vaultID, vaultSvc := setupVault(t, ctx, "explicit-"+fmt.Sprint(time.Now().UnixNano()))
+
+	folder, err := vaultSvc.CreateFolder(ctx, vaultID, "/projects/new-idea")
+	if err != nil {
+		t.Fatalf("create folder: %v", err)
+	}
+	if folder.Path != "/projects/new-idea" {
+		t.Errorf("folder path: got %q, want %q", folder.Path, "/projects/new-idea")
+	}
+	if folder.Name != "new-idea" {
+		t.Errorf("folder name: got %q, want %q", folder.Name, "new-idea")
+	}
+
+	// Ancestor /projects should also exist
+	folders, err := vaultSvc.ListFolders(ctx, vaultID, nil)
+	if err != nil {
+		t.Fatalf("list folders: %v", err)
+	}
+	folderPaths := make(map[string]bool)
+	for _, f := range folders {
+		folderPaths[f.Path] = true
+	}
+	if !folderPaths["/projects"] {
+		t.Error("expected /projects ancestor folder to be auto-created")
+	}
+	if !folderPaths["/projects/new-idea"] {
+		t.Error("expected /projects/new-idea folder to exist")
+	}
+
+	if err := vaultSvc.Delete(ctx, vaultID); err != nil {
+		t.Fatalf("cleanup vault: %v", err)
+	}
+}
+
+// TestFolderDeleteCascade verifies that deleting a folder cascades to child
+// folders and documents.
+func TestFolderDeleteCascade(t *testing.T) {
+	ctx := context.Background()
+	vaultID, vaultSvc := setupVault(t, ctx, "cascade-"+fmt.Sprint(time.Now().UnixNano()))
+
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
+
+	// Create docs under /guides/
+	for _, p := range []string{"/guides/a.md", "/guides/sub/b.md"} {
+		_, err := docSvc.Create(ctx, models.DocumentInput{
+			VaultID: vaultID,
+			Path:    p,
+			Content: "# Doc at " + p,
+			Source:  models.SourceManual,
+		})
+		if err != nil {
+			t.Fatalf("create doc %s: %v", p, err)
+		}
+	}
+
+	// Also create a doc outside /guides/
+	_, err := docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID,
+		Path:    "/other/c.md",
+		Content: "# Other",
+		Source:  models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create other doc: %v", err)
+	}
+
+	// Delete /guides folder — should cascade
+	if err := vaultSvc.DeleteFolder(ctx, vaultID, "/guides"); err != nil {
+		t.Fatalf("delete folder: %v", err)
+	}
+
+	// Verify /guides docs are gone
+	for _, p := range []string{"/guides/a.md", "/guides/sub/b.md"} {
+		doc, err := testDB.GetDocumentByPath(ctx, vaultID, p)
+		if err != nil {
+			t.Fatalf("get doc %s: %v", p, err)
+		}
+		if doc != nil {
+			t.Errorf("doc %s should be deleted after folder cascade", p)
+		}
+	}
+
+	// Verify /guides folders are gone
+	folders, err := vaultSvc.ListFolders(ctx, vaultID, nil)
+	if err != nil {
+		t.Fatalf("list folders: %v", err)
+	}
+	for _, f := range folders {
+		if f.Path == "/guides" || f.Path == "/guides/sub" {
+			t.Errorf("folder %s should be deleted", f.Path)
+		}
+	}
+
+	// Verify /other/c.md still exists
+	doc, err := testDB.GetDocumentByPath(ctx, vaultID, "/other/c.md")
+	if err != nil {
+		t.Fatalf("get other doc: %v", err)
+	}
+	if doc == nil {
+		t.Error("doc /other/c.md should still exist")
+	}
+
+	if err := vaultSvc.Delete(ctx, vaultID); err != nil {
+		t.Fatalf("cleanup vault: %v", err)
+	}
+}
+
+// TestFolderMoveBasic verifies that moving a folder updates folder records,
+// child folder records, and documents.
+func TestFolderMoveBasic(t *testing.T) {
+	ctx := context.Background()
+	vaultID, vaultSvc := setupVault(t, ctx, "move-"+fmt.Sprint(time.Now().UnixNano()))
+
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
+
+	// Create docs under /guides/ and /guides/sub/
+	for _, p := range []string{"/guides/a.md", "/guides/sub/b.md"} {
+		_, err := docSvc.Create(ctx, models.DocumentInput{
+			VaultID: vaultID,
+			Path:    p,
+			Content: "# Doc at " + p,
+			Source:  models.SourceManual,
+		})
+		if err != nil {
+			t.Fatalf("create doc %s: %v", p, err)
+		}
+	}
+
+	// Also create a doc outside /guides/ that should not be affected
+	_, err := docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID,
+		Path:    "/other/c.md",
+		Content: "# Other",
+		Source:  models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create other doc: %v", err)
+	}
+
+	// Move /guides to /docs
+	if err := vaultSvc.MoveFolder(ctx, vaultID, "/guides", "/docs"); err != nil {
+		t.Fatalf("move folder: %v", err)
+	}
+
+	// Verify folder records were moved
+	folders, err := vaultSvc.ListFolders(ctx, vaultID, nil)
+	if err != nil {
+		t.Fatalf("list folders: %v", err)
+	}
+	folderPaths := make(map[string]bool)
+	for _, f := range folders {
+		folderPaths[f.Path] = true
+	}
+	if folderPaths["/guides"] || folderPaths["/guides/sub"] {
+		t.Error("old folder paths should not exist after move")
+	}
+	if !folderPaths["/docs"] {
+		t.Error("expected /docs folder after move")
+	}
+	if !folderPaths["/docs/sub"] {
+		t.Error("expected /docs/sub folder after move")
+	}
+
+	// Verify documents were moved
+	for _, p := range []string{"/docs/a.md", "/docs/sub/b.md"} {
+		doc, err := testDB.GetDocumentByPath(ctx, vaultID, p)
+		if err != nil {
+			t.Fatalf("get doc %s: %v", p, err)
+		}
+		if doc == nil {
+			t.Errorf("expected document at %s after move", p)
+		}
+	}
+
+	// Verify old document paths are gone
+	for _, p := range []string{"/guides/a.md", "/guides/sub/b.md"} {
+		doc, err := testDB.GetDocumentByPath(ctx, vaultID, p)
+		if err != nil {
+			t.Fatalf("get doc %s: %v", p, err)
+		}
+		if doc != nil {
+			t.Errorf("document at old path %s should not exist after move", p)
+		}
+	}
+
+	// Verify /other/c.md is unaffected
+	doc, err := testDB.GetDocumentByPath(ctx, vaultID, "/other/c.md")
+	if err != nil {
+		t.Fatalf("get other doc: %v", err)
+	}
+	if doc == nil {
+		t.Error("doc /other/c.md should still exist")
+	}
+
+	if err := vaultSvc.Delete(ctx, vaultID); err != nil {
+		t.Fatalf("cleanup vault: %v", err)
+	}
+}
+
+// TestFolderMoveCreatesAncestors verifies that moving a folder to a nested
+// destination creates ancestor folders at the destination.
+func TestFolderMoveCreatesAncestors(t *testing.T) {
+	ctx := context.Background()
+	vaultID, vaultSvc := setupVault(t, ctx, "move-ancestors-"+fmt.Sprint(time.Now().UnixNano()))
+
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
+
+	_, err := docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID,
+		Path:    "/guides/a.md",
+		Content: "# Guide",
+		Source:  models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create doc: %v", err)
+	}
+
+	// Move /guides to /archive/old/guides — should create /archive and /archive/old
+	if err := vaultSvc.MoveFolder(ctx, vaultID, "/guides", "/archive/old/guides"); err != nil {
+		t.Fatalf("move folder: %v", err)
+	}
+
+	folders, err := vaultSvc.ListFolders(ctx, vaultID, nil)
+	if err != nil {
+		t.Fatalf("list folders: %v", err)
+	}
+	folderPaths := make(map[string]bool)
+	for _, f := range folders {
+		folderPaths[f.Path] = true
+	}
+
+	for _, expected := range []string{"/archive", "/archive/old", "/archive/old/guides"} {
+		if !folderPaths[expected] {
+			t.Errorf("expected folder %s to exist after move", expected)
+		}
+	}
+
+	if err := vaultSvc.Delete(ctx, vaultID); err != nil {
+		t.Fatalf("cleanup vault: %v", err)
+	}
+}
+
+// TestFolderListByParent verifies that ListFolders with parentPath filters
+// to immediate children only.
+func TestFolderListByParent(t *testing.T) {
+	ctx := context.Background()
+	vaultID, vaultSvc := setupVault(t, ctx, "listparent-"+fmt.Sprint(time.Now().UnixNano()))
+
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
+
+	// Create a nested structure: /a/b/c/file.md
+	_, err := docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID,
+		Path:    "/a/b/c/file.md",
+		Content: "# Deep",
+		Source:  models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create doc: %v", err)
+	}
+
+	// Also create /a/sibling/file.md
+	_, err = docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID,
+		Path:    "/a/sibling/file.md",
+		Content: "# Sibling",
+		Source:  models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create doc: %v", err)
+	}
+
+	// List children of /a — should return /a/b and /a/sibling (not /a/b/c)
+	parentPath := "/a"
+	children, err := vaultSvc.ListFolders(ctx, vaultID, &parentPath)
+	if err != nil {
+		t.Fatalf("list folders by parent: %v", err)
+	}
+
+	childPaths := make(map[string]bool)
+	for _, f := range children {
+		childPaths[f.Path] = true
+	}
+
+	if !childPaths["/a/b"] {
+		t.Error("expected /a/b as child of /a")
+	}
+	if !childPaths["/a/sibling"] {
+		t.Error("expected /a/sibling as child of /a")
+	}
+	if childPaths["/a/b/c"] {
+		t.Error("/a/b/c should not be an immediate child of /a")
+	}
+	if len(children) != 2 {
+		t.Errorf("expected 2 children of /a, got %d", len(children))
+	}
+
+	if err := vaultSvc.Delete(ctx, vaultID); err != nil {
+		t.Fatalf("cleanup vault: %v", err)
+	}
+}
+
+// TestFolderListAll verifies that ListFolders returns all vault folders.
+func TestFolderListAll(t *testing.T) {
+	ctx := context.Background()
+	vaultID, vaultSvc := setupVault(t, ctx, "listall-"+fmt.Sprint(time.Now().UnixNano()))
+
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig())
+
+	paths := []string{
+		"/guides/getting-started.md",
+		"/guides/advanced/topic.md",
+		"/memories/note.md",
+		"/projects/alpha.md",
+	}
+	for _, p := range paths {
+		_, err := docSvc.Create(ctx, models.DocumentInput{
+			VaultID: vaultID,
+			Path:    p,
+			Content: "# Doc",
+			Source:  models.SourceManual,
+		})
+		if err != nil {
+			t.Fatalf("create doc %s: %v", p, err)
+		}
+	}
+
+	folders, err := vaultSvc.ListFolders(ctx, vaultID, nil)
+	if err != nil {
+		t.Fatalf("list folders: %v", err)
+	}
+
+	expected := map[string]bool{
+		"/guides":          true,
+		"/guides/advanced": true,
+		"/memories":        true,
+		"/projects":        true,
+	}
+
+	got := make(map[string]bool)
+	for _, f := range folders {
+		got[f.Path] = true
+	}
+
+	for path := range expected {
+		if !got[path] {
+			t.Errorf("missing expected folder: %s", path)
+		}
+	}
+	if len(folders) != len(expected) {
+		t.Errorf("folder count: got %d, want %d", len(folders), len(expected))
+	}
+
+	if err := vaultSvc.Delete(ctx, vaultID); err != nil {
+		t.Fatalf("cleanup vault: %v", err)
+	}
+}

--- a/internal/integration/lifecycle_test.go
+++ b/internal/integration/lifecycle_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 	var err error
 	testContainer, err = testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "surrealdb/surrealdb:v3.0.0-beta.1",
+			Image:        "surrealdb/surrealdb:v3.0.2",
 			ExposedPorts: []string{"8000/tcp"},
 			Cmd:          []string{"start", "--log", "info", "--user", "root", "--pass", "root"},
 			WaitingFor:   wait.ForLog("Started web server").WithStartupTimeout(60 * time.Second),

--- a/internal/models/document.go
+++ b/internal/models/document.go
@@ -55,9 +55,11 @@ type DocumentInput struct {
 	Metadata    map[string]any `json:"metadata,omitempty"`
 }
 
-// Folder is a virtual folder derived from document paths.
+// Folder is a first-class folder record backed by the folder table.
 type Folder struct {
-	Path     string `json:"path"`
-	Name     string `json:"name"`
-	DocCount int    `json:"doc_count"`
+	ID        surrealmodels.RecordID `json:"id"`
+	Vault     surrealmodels.RecordID `json:"vault"`
+	Path      string                 `json:"path"`
+	Name      string                 `json:"name"`
+	CreatedAt time.Time              `json:"created_at"`
 }

--- a/internal/vault/service.go
+++ b/internal/vault/service.go
@@ -3,14 +3,13 @@ package vault
 import (
 	"context"
 	"fmt"
-	"path"
 	"strings"
 
 	"github.com/raphi011/knowhow/internal/db"
 	"github.com/raphi011/knowhow/internal/models"
 )
 
-// Service manages vault CRUD and derived folder listing.
+// Service manages vault CRUD and folder operations.
 type Service struct {
 	db *db.Client
 }
@@ -40,57 +39,93 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 	return s.db.DeleteVault(ctx, id)
 }
 
-// ListFolders derives virtual folders from document paths in a vault.
+// ListFolders returns all folders in a vault. If parentPath is provided, filters
+// to immediate children of that path.
 func (s *Service) ListFolders(ctx context.Context, vaultID string, parentPath *string) ([]models.Folder, error) {
-	paths, err := s.db.ListDocumentPaths(ctx, vaultID)
+	folders, err := s.db.ListFolders(ctx, vaultID)
 	if err != nil {
-		return nil, fmt.Errorf("list document paths: %w", err)
+		return nil, fmt.Errorf("list folders: %w", err)
 	}
 
-	return deriveFolders(paths, parentPath), nil
+	if parentPath == nil {
+		return folders, nil
+	}
+
+	// Filter to immediate children of parentPath
+	prefix := *parentPath
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	var filtered []models.Folder
+	for _, f := range folders {
+		if !strings.HasPrefix(f.Path, prefix) {
+			continue
+		}
+		// Check it's an immediate child (no further "/" after prefix)
+		rel := strings.TrimPrefix(f.Path, prefix)
+		if rel != "" && !strings.Contains(rel, "/") {
+			filtered = append(filtered, f)
+		}
+	}
+	return filtered, nil
 }
 
-// deriveFolders computes virtual folders from document paths.
-func deriveFolders(paths []string, parentPath *string) []models.Folder {
-	prefix := "/"
-	if parentPath != nil {
-		prefix = *parentPath
-		if !strings.HasSuffix(prefix, "/") {
-			prefix += "/"
-		}
+// CreateFolder creates a folder and all its ancestor folders.
+func (s *Service) CreateFolder(ctx context.Context, vaultID, folderPath string) (*models.Folder, error) {
+	folderPath = models.NormalizePath(folderPath)
+
+	// EnsureFolderPath creates the target folder + all ancestors in one batch
+	if err := s.db.EnsureFolderPath(ctx, vaultID, folderPath); err != nil {
+		return nil, fmt.Errorf("ensure folder path: %w", err)
+	}
+	folder, err := s.db.GetFolderByPath(ctx, vaultID, folderPath)
+	if err != nil {
+		return nil, fmt.Errorf("get created folder: %w", err)
+	}
+	if folder == nil {
+		return nil, fmt.Errorf("folder not found after creation: %s", folderPath)
+	}
+	return folder, nil
+}
+
+// DeleteFolder deletes a folder, all child folders, and all documents under the folder prefix.
+func (s *Service) DeleteFolder(ctx context.Context, vaultID, folderPath string) error {
+	folderPath = models.NormalizePath(folderPath)
+
+	// Delete child documents
+	prefix := folderPath + "/"
+	if _, err := s.db.DeleteDocumentsByPrefix(ctx, vaultID, prefix); err != nil {
+		return fmt.Errorf("delete folder documents: %w", err)
 	}
 
-	// Count docs per immediate child folder
-	folderCounts := make(map[string]int)
-	for _, p := range paths {
-		if !strings.HasPrefix(p, prefix) {
-			continue
-		}
-
-		// Get the relative part after prefix
-		rel := strings.TrimPrefix(p, prefix)
-		if rel == "" {
-			continue
-		}
-
-		// Extract the first path segment (immediate child folder)
-		parts := strings.SplitN(rel, "/", 2)
-		if len(parts) < 2 {
-			// This is a file directly in the parent folder, not a subfolder
-			continue
-		}
-
-		folderPath := prefix + parts[0]
-		folderCounts[folderPath]++
+	// Delete folder records (self + children)
+	if err := s.db.DeleteFolder(ctx, vaultID, folderPath); err != nil {
+		return fmt.Errorf("delete folder: %w", err)
 	}
 
-	folders := make([]models.Folder, 0, len(folderCounts))
-	for fp, count := range folderCounts {
-		folders = append(folders, models.Folder{
-			Path:     fp,
-			Name:     path.Base(fp),
-			DocCount: count,
-		})
+	return nil
+}
+
+// MoveFolder moves a folder and all its children (folders + documents) from oldPath to newPath.
+func (s *Service) MoveFolder(ctx context.Context, vaultID, oldPath, newPath string) error {
+	oldPath = models.NormalizePath(oldPath)
+	newPath = models.NormalizePath(newPath)
+
+	// Move folder records
+	if _, err := s.db.MoveFoldersByPrefix(ctx, vaultID, oldPath, newPath); err != nil {
+		return fmt.Errorf("move folder records: %w", err)
 	}
-	return folders
+
+	// Move documents
+	if _, err := s.db.MoveDocumentsByPrefix(ctx, vaultID, oldPath+"/", newPath+"/"); err != nil {
+		return fmt.Errorf("move folder documents: %w", err)
+	}
+
+	// Ensure destination ancestor folders exist
+	if err := s.db.EnsureFolderPath(ctx, vaultID, newPath); err != nil {
+		return fmt.Errorf("ensure destination folders: %w", err)
+	}
+
+	return nil
 }

--- a/web/app/lib/knowhow/mutations.ts
+++ b/web/app/lib/knowhow/mutations.ts
@@ -85,6 +85,37 @@ export function deleteDocumentsByPrefix(vaultId: string, pathPrefix: string) {
   );
 }
 
+export function createFolder(vaultId: string, path: string) {
+  return graphqlMutation(
+    `mutation ($vaultId: ID!, $path: String!) {
+      createFolder(vaultId: $vaultId, path: $path) { id }
+    }`,
+    { vaultId, path },
+  );
+}
+
+export function deleteFolder(vaultId: string, path: string) {
+  return graphqlMutation(
+    `mutation ($vaultId: ID!, $path: String!) {
+      deleteFolder(vaultId: $vaultId, path: $path)
+    }`,
+    { vaultId, path },
+  );
+}
+
+export function moveFolder(
+  vaultId: string,
+  oldPath: string,
+  newPath: string,
+) {
+  return graphqlMutation(
+    `mutation ($vaultId: ID!, $oldPath: String!, $newPath: String!) {
+      moveFolder(vaultId: $vaultId, oldPath: $oldPath, newPath: $newPath)
+    }`,
+    { vaultId, oldPath, newPath },
+  );
+}
+
 export function moveDocumentsByPrefix(
   vaultId: string,
   oldPrefix: string,

--- a/web/components/doc-tree.tsx
+++ b/web/components/doc-tree.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/app/lib/knowhow/dnd-utils";
 import {
   createDocument,
+  createFolder,
   deleteDocument,
   moveDocument,
   deleteDocumentsByPrefix,
@@ -349,12 +350,16 @@ function DocTree({ tree, activePath, vaultId, documents }: DocTreeProps) {
       }
       router.refresh();
     } else if (editing.type === "new-folder") {
-      // Folders are virtual (derived from document paths), so no server call
-      // needed. Just expand the UI to show the new folder.
       const folderPath = editing.parentPath
         ? `${editing.parentPath}/${name}`
         : name;
+      const result = await createFolder(vaultId, folderPath);
+      if (!result.success) {
+        setEditingError(result.error);
+        return;
+      }
       setExpanded((prev) => new Set([...prev, folderPath]));
+      router.refresh();
     } else if (editing.type === "rename") {
       const node = findNode(tree, editing.currentPath);
       if (!node) {


### PR DESCRIPTION
Replace virtual folder derivation with a SurrealDB `folder` table. Folders are now first-class DB records with auto-creation on document create, cascade deletion, move/rename support, and an MCP `list_folders` tool for AI agents.

## Breaking Changes
- `Folder` GraphQL type changed: added `id`, `createdAt`; removed `docCount`
- SurrealDB upgraded from v3.0.0-beta to v3.0.2

## Key Changes

**Data layer:**
- New `folder` table with `vault+path` UNIQUE index
- `EnsureFolders` auto-creates ancestor folders on document create/move
- Cascade delete folders on vault deletion

**Service layer:**
- `CreateFolder`, `DeleteFolder`, `MoveFolder` on vault service
- Folder lifecycle hooks in document service (create/move/delete)

**GraphQL:**
- Mutations: `createFolder`, `deleteFolder`, `moveFolder`
- Updated `Folder` type with `id` and `createdAt`

**AI/MCP:**
- MCP `list_folders` tool for agents to browse vault structure
- Dynamic system prompt injects vault folder tree

**Frontend:**
- Wired "New Folder" action to `createFolder` mutation
- Added `deleteFolder`, `moveFolder` mutation helpers

**Query optimizations (reduced DB round-trips):**
- `EnsureFolders`: N+1 INSERT loop → single `INSERT INTO $rows`
- `CreateWikiLinks`: N+1 CREATE loop → single `INSERT INTO $links`
- `DeleteVault`: 4 round-trips → 1 multi-statement query
- `DeleteFolder`/`MoveFoldersByPrefix`: 2 round-trips → 1 multi-statement
- Consolidated `ListProposals`/`ListProposalsByDocument` into shared helper
- Fixed `array::last()` instead of unreliable `[-1]` negative indexing

**SurrealDB docs:** Documented batch INSERT, multi-statement queries, and three v3 gotchas (OR clauses, negative indexing, STARTS WITH)

## Test Coverage
- Unit tests added: none (logic covered by integration tests)
- Integration tests added: 7 new tests in `folder_test.go` (auto-create, root doc, idempotency, empty persistence, explicit create, cascade delete, list all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)