### PR TITLE
feat: Tavily web search + inline tool rendering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,9 @@ KNOWHOW_EMBED_DIMENSION=768
 # Ollama (local models)
 # OLLAMA_HOST=http://localhost:11434
 
+# Tavily (web search for agent)
+# TAVILY_API_KEY=tvly-...
+
 # AWS Bedrock (see bedrock-setup.sh for Teleport setup)
 # KNOWHOW_BEDROCK_MODEL_PROVIDER=anthropic        # For LLM inference profiles
 # KNOWHOW_BEDROCK_EMBED_MODEL_PROVIDER=amazon     # For embedding inference profiles

--- a/helm/knowhow/templates/deployment.yaml
+++ b/helm/knowhow/templates/deployment.yaml
@@ -119,6 +119,12 @@ spec:
                   name: {{ .Values.apiKeys.existingSecret }}
                   key: google-ai-api-key
                   optional: true
+            - name: TAVILY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.apiKeys.existingSecret }}
+                  key: tavily-api-key
+                  optional: true
             {{- else }}
             {{- if .Values.apiKeys.openaiApiKey }}
             - name: OPENAI_API_KEY
@@ -140,6 +146,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "knowhow.fullname" . }}-api-keys
                   key: google-ai-api-key
+            {{- end }}
+            {{- if .Values.apiKeys.tavilyApiKey }}
+            - name: TAVILY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "knowhow.fullname" . }}-api-keys
+                  key: tavily-api-key
             {{- end }}
             {{- end }}
             # AWS Bedrock

--- a/helm/knowhow/templates/secret.yaml
+++ b/helm/knowhow/templates/secret.yaml
@@ -10,7 +10,7 @@ stringData:
   user: {{ .Values.surrealdb.user | quote }}
   password: {{ .Values.surrealdb.password | quote }}
 {{- end }}
-{{- if and (or .Values.apiKeys.openaiApiKey .Values.apiKeys.anthropicApiKey) (not .Values.apiKeys.existingSecret) }}
+{{- if and (or .Values.apiKeys.openaiApiKey .Values.apiKeys.anthropicApiKey .Values.apiKeys.tavilyApiKey) (not .Values.apiKeys.existingSecret) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -25,5 +25,8 @@ stringData:
   {{- end }}
   {{- if .Values.apiKeys.anthropicApiKey }}
   anthropic-api-key: {{ .Values.apiKeys.anthropicApiKey | quote }}
+  {{- end }}
+  {{- if .Values.apiKeys.tavilyApiKey }}
+  tavily-api-key: {{ .Values.apiKeys.tavilyApiKey | quote }}
   {{- end }}
 {{- end }}

--- a/helm/knowhow/values.yaml
+++ b/helm/knowhow/values.yaml
@@ -49,6 +49,7 @@ apiKeys:
   openaiApiKey: ""
   anthropicApiKey: ""
   googleAiApiKey: ""
+  tavilyApiKey: ""
 
 # AWS Bedrock settings
 bedrock:

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -27,11 +27,16 @@ type Service struct {
 	db     *db.Client
 	model  *llm.Model
 	search *search.Service
+	tavily *tavilyClient
 }
 
 // NewService creates a new agent service.
-func NewService(db *db.Client, model *llm.Model, search *search.Service) *Service {
-	return &Service{db: db, model: model, search: search}
+func NewService(db *db.Client, model *llm.Model, search *search.Service, tavilyAPIKey string) *Service {
+	s := &Service{db: db, model: model, search: search}
+	if tavilyAPIKey != "" {
+		s.tavily = newTavilyClient(tavilyAPIKey)
+	}
+	return s
 }
 
 // Available returns true if the agent has an LLM model configured.
@@ -42,7 +47,7 @@ func (s *Service) Available() bool {
 // toolAction is the LLM's decision from intent detection.
 type toolAction struct {
 	Action string          `json:"action"` // "tool" or "answer"
-	Tool   string          `json:"tool"`   // "kb_search" or "read_document"
+	Tool   string          `json:"tool"`   // "kb_search", "read_document", or "web_search"
 	Input  json.RawMessage `json:"input"`
 }
 
@@ -54,11 +59,26 @@ type readDocInput struct {
 	Path string `json:"path"`
 }
 
-const systemPromptBase = `You are a helpful knowledge assistant for the Knowhow knowledge base. You help users find and understand information stored in their documents.
+type webSearchInput struct {
+	Query string `json:"query"`
+}
 
-You have access to two tools:
+// buildSystemPromptBase constructs the base system prompt, conditionally including web_search when Tavily is configured.
+func (s *Service) buildSystemPromptBase() string {
+	base := `You are a helpful knowledge assistant for the Knowhow knowledge base. You help users find and understand information stored in their documents.
+
+You have access to the following tools:
 1. kb_search(query) - Search the knowledge base for relevant documents
-2. read_document(path) - Read the full content of a specific document by path
+2. read_document(path) - Read the full content of a specific document by path`
+
+	if s.tavily != nil {
+		base += `
+3. web_search(query) - Search the web for information not found in the knowledge base
+
+IMPORTANT: NEVER call web_search directly. If kb_search returns no or insufficient results, tell the user and ask "Would you like me to search the web?" Only call web_search after the user explicitly confirms.`
+	}
+
+	base += `
 
 When the user asks a question:
 - If you need to find relevant information, use kb_search first
@@ -69,32 +89,51 @@ Always cite document paths when referencing information from the knowledge base.
 Be concise and helpful. Answer based on the knowledge base content when available.
 Do not include a sources section at the end of your response — one will be added automatically.`
 
-const intentPrompt = `Based on the conversation so far, decide your next action.
+	return base
+}
+
+// buildIntentPrompt constructs the intent-detection prompt with tool options matching the available tools.
+func (s *Service) buildIntentPrompt() string {
+	base := `Based on the conversation so far, decide your next action.
 
 If you need to search for information, respond with EXACTLY this JSON (no other text):
 {"action":"tool","tool":"kb_search","input":{"query":"your search query"}}
 
 If you need to read a specific document, respond with EXACTLY this JSON (no other text):
-{"action":"tool","tool":"read_document","input":{"path":"/document/path"}}
+{"action":"tool","tool":"read_document","input":{"path":"/document/path"}}`
+
+	if s.tavily != nil {
+		base += `
+
+If the user has explicitly asked you to search the web, respond with EXACTLY this JSON (no other text):
+{"action":"tool","tool":"web_search","input":{"query":"your search query"}}`
+	}
+
+	base += `
 
 If you have enough information to answer the user's question, respond with EXACTLY this JSON (no other text):
 {"action":"answer"}
 
 Respond with ONLY the JSON, no explanation.`
 
+	return base
+}
+
 // buildSystemPrompt constructs the system prompt, optionally appending the vault's folder tree.
 func (s *Service) buildSystemPrompt(ctx context.Context, vaultID string) string {
+	base := s.buildSystemPromptBase()
+
 	folders, err := s.db.ListFolders(ctx, vaultID)
 	if err != nil {
 		slog.Warn("failed to list folders for system prompt", "vault_id", vaultID, "error", err)
-		return systemPromptBase
+		return base
 	}
 	if len(folders) == 0 {
-		return systemPromptBase
+		return base
 	}
 
 	var sb strings.Builder
-	sb.WriteString(systemPromptBase)
+	sb.WriteString(base)
 	sb.WriteString("\n\nVault folder structure:\n```\n/\n")
 	for _, f := range folders {
 		depth := strings.Count(strings.Trim(f.Path, "/"), "/")
@@ -196,7 +235,7 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest, emit func(StreamEve
 		// Intent detection (non-streaming)
 		intentQuery := req.Content
 		if i > 0 {
-			intentQuery = intentPrompt
+			intentQuery = s.buildIntentPrompt()
 		}
 
 		decision, err := s.detectIntent(ctx, history, intentQuery, i == 0, sysPrompt)
@@ -327,15 +366,17 @@ func (s *Service) buildHistory(messages []models.Message, toolContext string) []
 }
 
 func (s *Service) detectIntent(ctx context.Context, history []llm.ChatMessage, query string, firstTurn bool, sysPrompt string) (*toolAction, error) {
+	intentPr := s.buildIntentPrompt()
+
 	prompt := sysPrompt
 	if !firstTurn {
-		prompt = sysPrompt + "\n\n" + intentPrompt
+		prompt = sysPrompt + "\n\n" + intentPr
 	}
 
 	// For intent detection, append the intent prompt to the user query
 	fullQuery := query
 	if firstTurn {
-		fullQuery = query + "\n\n" + intentPrompt
+		fullQuery = query + "\n\n" + intentPr
 	}
 
 	response, err := s.model.GenerateWithSystem(ctx, prompt, buildHistoryText(history, fullQuery))
@@ -423,6 +464,25 @@ func (s *Service) executeTool(ctx context.Context, vaultID string, action *toolA
 
 		emit(StreamEvent{Type: "tool_result", Content: doc.Path, Tool: "read_document"})
 		return fmt.Sprintf("# %s\n\n%s", doc.Title, doc.ContentBody), []docSource{{Title: doc.Title, Path: doc.Path}}, nil
+
+	case "web_search":
+		var input webSearchInput
+		if err := json.Unmarshal(action.Input, &input); err != nil {
+			return "", nil, fmt.Errorf("parse web_search input: %w", err)
+		}
+		if s.tavily == nil {
+			return "", nil, fmt.Errorf("web search not configured")
+		}
+		emit(StreamEvent{Type: "tool_call", Content: input.Query, Tool: "web_search"})
+
+		result, err := s.tavily.Search(ctx, input.Query)
+		if err != nil {
+			return "", nil, fmt.Errorf("web search: %w", err)
+		}
+
+		emit(StreamEvent{Type: "tool_result", Content: "Web search complete", Tool: "web_search"})
+		// web_search returns no docSources since results are external, not KB documents
+		return result, nil, nil
 
 	default:
 		return "", nil, fmt.Errorf("unknown tool: %s", action.Tool)

--- a/internal/agent/tavily.go
+++ b/internal/agent/tavily.go
@@ -1,0 +1,99 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// tavilyClient wraps the Tavily search API.
+type tavilyClient struct {
+	apiKey     string
+	httpClient *http.Client
+}
+
+func newTavilyClient(apiKey string) *tavilyClient {
+	return &tavilyClient{
+		apiKey:     apiKey,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+type tavilyRequest struct {
+	APIKey      string `json:"api_key"`
+	Query       string `json:"query"`
+	SearchDepth string `json:"search_depth"`
+	MaxResults  int    `json:"max_results"`
+	IncludeAnswer bool `json:"include_answer"`
+}
+
+type tavilyResponse struct {
+	Answer  string         `json:"answer"`
+	Results []tavilyResult `json:"results"`
+}
+
+type tavilyResult struct {
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	Content string `json:"content"`
+}
+
+// Search performs a web search via Tavily and returns formatted markdown results.
+func (c *tavilyClient) Search(ctx context.Context, query string) (string, error) {
+	reqBody := tavilyRequest{
+		APIKey:        c.apiKey,
+		Query:         query,
+		SearchDepth:   "basic",
+		MaxResults:    5,
+		IncludeAnswer: true,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.tavily.com/search", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		if readErr != nil {
+			return "", fmt.Errorf("tavily API returned %d (failed to read body: %w)", resp.StatusCode, readErr)
+		}
+		return "", fmt.Errorf("tavily API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var tavilyResp tavilyResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&tavilyResp); err != nil {
+		return "", fmt.Errorf("decode response: %w", err)
+	}
+
+	var sb strings.Builder
+	if tavilyResp.Answer != "" {
+		fmt.Fprintf(&sb, "**Summary:** %s\n\n", tavilyResp.Answer)
+	}
+	for _, r := range tavilyResp.Results {
+		fmt.Fprintf(&sb, "### [%s](%s)\n%s\n\n", r.Title, r.URL, r.Content)
+	}
+
+	result := sb.String()
+	if result == "" {
+		return "No web results found.", nil
+	}
+	return result, nil
+}

--- a/internal/agent/tavily_test.go
+++ b/internal/agent/tavily_test.go
@@ -1,0 +1,202 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestTavilySearch_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected application/json, got %s", ct)
+		}
+
+		var req tavilyRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.APIKey != "test-key" {
+			t.Errorf("expected api key test-key, got %s", req.APIKey)
+		}
+		if req.Query != "what is Go" {
+			t.Errorf("expected query 'what is Go', got %s", req.Query)
+		}
+		if req.MaxResults != 5 {
+			t.Errorf("expected max_results 5, got %d", req.MaxResults)
+		}
+
+		resp := tavilyResponse{
+			Answer: "Go is a programming language.",
+			Results: []tavilyResult{
+				{Title: "Go Website", URL: "https://go.dev", Content: "The Go programming language"},
+				{Title: "Go Wiki", URL: "https://en.wikipedia.org/wiki/Go", Content: "Go is a statically typed language"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := &tavilyClient{
+		apiKey:     "test-key",
+		httpClient: srv.Client(),
+	}
+	// Override the URL by using a custom transport
+	client.httpClient.Transport = rewriteURLTransport{url: srv.URL, base: srv.Client().Transport}
+
+	result, err := client.Search(context.Background(), "what is Go")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "**Summary:** Go is a programming language.") {
+		t.Errorf("expected summary in result, got: %s", result)
+	}
+	if !strings.Contains(result, "### [Go Website](https://go.dev)") {
+		t.Errorf("expected Go Website result, got: %s", result)
+	}
+	if !strings.Contains(result, "### [Go Wiki](https://en.wikipedia.org/wiki/Go)") {
+		t.Errorf("expected Go Wiki result, got: %s", result)
+	}
+}
+
+func TestTavilySearch_AnswerOnly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := tavilyResponse{Answer: "Just an answer."}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := newTestClient("key", srv)
+	result, err := client.Search(context.Background(), "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "**Summary:** Just an answer.\n\n" {
+		t.Errorf("unexpected result: %q", result)
+	}
+}
+
+func TestTavilySearch_NoResults(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := tavilyResponse{}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := newTestClient("key", srv)
+	result, err := client.Search(context.Background(), "obscure query")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "No web results found." {
+		t.Errorf("expected fallback message, got: %q", result)
+	}
+}
+
+func TestTavilySearch_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"Invalid API key"}`))
+	}))
+	defer srv.Close()
+
+	client := newTestClient("bad-key", srv)
+	_, err := client.Search(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected 401 in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Invalid API key") {
+		t.Errorf("expected error body in message, got: %v", err)
+	}
+}
+
+func TestTavilySearch_ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := tavilyResponse{Answer: "should not reach"}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := newTestClient("key", srv)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := client.Search(ctx, "test")
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestTavilySearch_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	client := newTestClient("key", srv)
+	_, err := client.Search(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "decode response") {
+		t.Errorf("expected decode error, got: %v", err)
+	}
+}
+
+func TestTavilySearch_Integration(t *testing.T) {
+	apiKey := os.Getenv("TAVILY_API_KEY")
+	if apiKey == "" {
+		t.Skip("TAVILY_API_KEY not set, skipping integration test")
+	}
+
+	client := newTavilyClient(apiKey)
+	result, err := client.Search(context.Background(), "what is the Go programming language")
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+
+	if result == "" || result == "No web results found." {
+		t.Error("expected non-empty results from real API")
+	}
+	if !strings.Contains(result, "**Summary:**") {
+		t.Error("expected summary in response")
+	}
+	if !strings.Contains(result, "###") {
+		t.Error("expected at least one result heading")
+	}
+
+	t.Logf("Result preview: %.300s...", result)
+}
+
+// rewriteURLTransport redirects all requests to the test server URL.
+type rewriteURLTransport struct {
+	url  string
+	base http.RoundTripper
+}
+
+func (t rewriteURLTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = strings.TrimPrefix(t.url, "http://")
+	return t.base.RoundTrip(req)
+}
+
+func newTestClient(apiKey string, srv *httptest.Server) *tavilyClient {
+	return &tavilyClient{
+		apiKey: apiKey,
+		httpClient: &http.Client{
+			Transport: rewriteURLTransport{url: srv.URL, base: srv.Client().Transport},
+		},
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	AnthropicAPIKey      string
 	GoogleAIAPIKey       string
 	BedrockModelProvider string // e.g., "anthropic" for inference profiles
+	TavilyAPIKey         string
 
 	// Logging
 	LogFile  string
@@ -104,6 +105,7 @@ func Load() Config {
 		AnthropicAPIKey:      getEnv("ANTHROPIC_API_KEY", ""),
 		GoogleAIAPIKey:       getEnv("GOOGLE_AI_API_KEY", ""),
 		BedrockModelProvider: getEnv("KNOWHOW_BEDROCK_MODEL_PROVIDER", ""),
+		TavilyAPIKey:         getEnv("TAVILY_API_KEY", ""),
 
 		// Logging
 		LogFile:  getEnv("KNOWHOW_LOG_FILE", "/tmp/knowhow.log"),

--- a/internal/graph/resolver.go
+++ b/internal/graph/resolver.go
@@ -91,6 +91,7 @@ func NewResolver(ctx context.Context, cfg config.Config) (*Resolver, error) {
 		"embed_dimension", cfg.EmbedDimension,
 		"semantic_search", embedder != nil,
 		"agent_chat", model != nil,
+		"web_search", cfg.TavilyAPIKey != "",
 		"chunk_threshold", chunkConfig.Threshold,
 		"chunk_target", chunkConfig.TargetSize,
 		"chunk_min", chunkConfig.MinSize,
@@ -103,7 +104,7 @@ func NewResolver(ctx context.Context, cfg config.Config) (*Resolver, error) {
 	close(workerDone) // safe default: <-workerDone returns immediately if no worker
 
 	searchSvc := search.NewService(dbClient, embedder)
-	agentSvc := agent.NewService(dbClient, model, searchSvc)
+	agentSvc := agent.NewService(dbClient, model, searchSvc, cfg.TavilyAPIKey)
 
 	r := &Resolver{
 		db:              dbClient,

--- a/web/components/domain/agent-chat-panel.tsx
+++ b/web/components/domain/agent-chat-panel.tsx
@@ -8,6 +8,7 @@ import {
   TrashIcon,
   MagnifyingGlassIcon,
   DocumentTextIcon,
+  GlobeAltIcon,
 } from "@heroicons/react/20/solid";
 import { cn } from "@/lib/utils";
 import { useAgentChat } from "@/components/domain/agent-chat-context";
@@ -127,11 +128,13 @@ function AgentChatPanel({ vaultId }: AgentChatPanelProps) {
             {t("agentPlaceholder")}
           </div>
         )}
-        {activeMessages
-          .filter((m) => m.role === "user" || m.role === "assistant")
-          .map((msg) => (
+        {activeMessages.map((msg) =>
+          msg.role === "tool_call" || msg.role === "tool_result" ? (
+            <ToolMessage key={msg.id} message={msg} />
+          ) : (
             <ChatBubble key={msg.id} message={msg} />
-          ))}
+          ),
+        )}
 
         {/* Tool indicators */}
         {chat.toolEvents.map((event, i) => (
@@ -276,31 +279,62 @@ function ChatBubble({
   );
 }
 
+function toolIcon(tool: string) {
+  if (tool === "kb_search") return <MagnifyingGlassIcon className="size-3" />;
+  if (tool === "web_search") return <GlobeAltIcon className="size-3" />;
+  return <DocumentTextIcon className="size-3" />;
+}
+
 function ToolIndicator({
   event,
 }: {
   event: { tool: string; type: string; content: string };
 }) {
   const t = useTranslations("docs");
-  const icon =
-    event.tool === "kb_search" ? (
-      <MagnifyingGlassIcon className="size-3" />
-    ) : (
-      <DocumentTextIcon className="size-3" />
-    );
 
-  const label =
-    event.type === "call"
-      ? event.tool === "kb_search"
-        ? t("agentToolSearching", { query: event.content })
-        : t("agentToolReading", { path: event.content })
-      : event.tool === "kb_search"
-        ? t("agentToolFound", { count: event.content })
-        : t("agentToolRead", { path: event.content });
+  let label: string;
+  if (event.type === "call") {
+    if (event.tool === "kb_search") label = t("agentToolSearching", { query: event.content });
+    else if (event.tool === "web_search") label = t("agentToolWebSearching", { query: event.content });
+    else label = t("agentToolReading", { path: event.content });
+  } else {
+    if (event.tool === "kb_search") label = t("agentToolFound", { count: event.content });
+    else if (event.tool === "web_search") label = t("agentToolWebSearched");
+    else label = t("agentToolRead", { path: event.content });
+  }
 
   return (
     <div className="mb-1.5 flex items-center gap-1.5 rounded bg-amber-50 px-2 py-1 text-[10px] text-amber-700 dark:bg-amber-950 dark:text-amber-300">
-      {icon}
+      {toolIcon(event.tool)}
+      <span className="truncate">{label}</span>
+    </div>
+  );
+}
+
+function ToolMessage({
+  message,
+}: {
+  message: { role: string; content: string; toolName?: string; toolInput?: string };
+}) {
+  const t = useTranslations("docs");
+  const tool = message.toolName ?? "kb_search";
+  const isCall = message.role === "tool_call";
+
+  let label: string;
+  if (isCall) {
+    const input = message.toolInput ?? "";
+    if (tool === "kb_search") label = t("agentToolSearching", { query: input });
+    else if (tool === "web_search") label = t("agentToolWebSearching", { query: input });
+    else label = t("agentToolReading", { path: input });
+  } else {
+    if (tool === "kb_search") label = t("agentToolFound", { count: message.content });
+    else if (tool === "web_search") label = t("agentToolWebSearched");
+    else label = t("agentToolRead", { path: message.content });
+  }
+
+  return (
+    <div className="mb-1.5 flex items-center gap-1.5 rounded bg-amber-50 px-2 py-1 text-[10px] text-amber-700 dark:bg-amber-950 dark:text-amber-300">
+      {toolIcon(tool)}
       <span className="truncate">{label}</span>
     </div>
   );

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -103,7 +103,9 @@
     "agentToolSearching": "Suche: {query}",
     "agentToolReading": "Lese: {path}",
     "agentToolFound": "{count} gefunden",
-    "agentToolRead": "Gelesen: {path}"
+    "agentToolRead": "Gelesen: {path}",
+    "agentToolWebSearching": "Websuche: {query}",
+    "agentToolWebSearched": "Websuche abgeschlossen"
   },
   "dnd": {
     "dropFilesHere": ".md-Dateien hier ablegen",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -103,7 +103,9 @@
     "agentToolSearching": "Searching: {query}",
     "agentToolReading": "Reading: {path}",
     "agentToolFound": "Found {count}",
-    "agentToolRead": "Read: {path}"
+    "agentToolRead": "Read: {path}",
+    "agentToolWebSearching": "Searching web: {query}",
+    "agentToolWebSearched": "Web search complete"
   },
   "dnd": {
     "dropFilesHere": "Drop .md files here",


### PR DESCRIPTION
Add Tavily web search to agent and render tool messages inline in chat history.

**Web search**: Optional `TAVILY_API_KEY` env var enables a `web_search` tool. The agent asks for user confirmation before searching the web — KB results are always tried first.

**Inline tool rendering**: Tool call/result messages are now visible in the conversation timeline (both during streaming and when reloading history). Previously they were filtered out.

## Breaking Changes
- `agent.NewService` signature changed (added `tavilyAPIKey string` parameter)

## Test Coverage
- Unit tests added: N/A (no new testable logic beyond HTTP client)
- Integration tests added: N/A (requires live Tavily API key)
- Verified: `just build-all` ✓, `just test` ✓, `just web-lint` (typecheck) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)