### PR TITLE
feat: structured tool metadata + ToolCard UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server in Go that provides a persistent knowledge layer for AI agents, backed by SurrealDB. Includes a Next.js web frontend for browsing and editing documents.
 
+## Project Status
+
+This project is in active development with no production users. **Don't worry about backwards compatibility** — breaking changes to APIs, DB schema, SSE events, etc. are fine. Prefer clean designs over compatibility shims.
+
 ## Tech Stack
 
 - **Backend**: Go, GraphQL (gqlgen), SurrealDB

--- a/docs/plans/2026-03-04-tool-call-rendering-design.md
+++ b/docs/plans/2026-03-04-tool-call-rendering-design.md
@@ -44,7 +44,7 @@ type StreamEvent struct {
     Type    string          `json:"type"`
     Content string          `json:"content"`
     Tool    string          `json:"tool,omitempty"`
-    Meta    json.RawMessage `json:"meta,omitempty"` // NEW: structured metadata for tool_result
+    Meta    *ToolResultMeta `json:"meta,omitempty"` // NEW: structured metadata for tool_result
 }
 ```
 
@@ -127,7 +127,7 @@ Run `just generate`. Add model mappings to `gqlgen.yml` if needed.
 
 ### 3c. Helper — `internal/graph/helpers.go`
 
-Add `toolResultMetaFromJSON(s string) *ToolResultMeta` that unmarshals the JSON string. Call from `messageToGraphQL` when `m.ToolMeta != nil`.
+Add `toolResultMetaFromJSON(s *string) *ToolResultMeta` that unmarshals the JSON string. Call from `messageToGraphQL`; the helper handles nil internally.
 
 ---
 

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/raphi011/knowhow/internal/db"
 	"github.com/raphi011/knowhow/internal/llm"
@@ -17,9 +18,36 @@ const maxToolIterations = 5
 
 // StreamEvent is sent to the client via SSE.
 type StreamEvent struct {
-	Type    string `json:"type"`           // "token" | "tool_call" | "tool_result" | "done" | "error" | "message_id" | "conversation_id"
-	Content string `json:"content"`        // token text, tool result, error message, or message ID
-	Tool    string `json:"tool,omitempty"` // tool name for tool_call/tool_result events
+	Type    string          `json:"type"`           // "token" | "tool_call" | "tool_result" | "done" | "error" | "message_id" | "conversation_id"
+	Content string          `json:"content"`        // token text, tool result, error message, or message ID
+	Tool    string          `json:"tool,omitempty"` // tool name for tool_call/tool_result events
+	Meta    *ToolResultMeta `json:"meta,omitempty"` // structured metadata for tool_result events
+}
+
+// ToolResultMeta contains structured metadata about a tool execution result.
+type ToolResultMeta struct {
+	DurationMs     int64        `json:"durationMs"`
+	ResultCount    *int         `json:"resultCount,omitempty"`
+	ChunkCount     *int         `json:"chunkCount,omitempty"`
+	MatchedDocs    []ToolDocRef `json:"matchedDocs,omitempty"`
+	DocumentPath   *string      `json:"documentPath,omitempty"`
+	DocumentTitle  *string      `json:"documentTitle,omitempty"`
+	ContentLength  *int         `json:"contentLength,omitempty"`
+	WebResultCount *int         `json:"webResultCount,omitempty"`
+	WebSources     []ToolWebRef `json:"webSources,omitempty"`
+}
+
+// ToolDocRef references a matched KB document.
+type ToolDocRef struct {
+	Title string  `json:"title"`
+	Path  string  `json:"path"`
+	Score float64 `json:"score"`
+}
+
+// ToolWebRef references a web search result.
+type ToolWebRef struct {
+	Title string `json:"title"`
+	URL   string `json:"url"`
 }
 
 // Service orchestrates the agent loop: intent detection → tool execution → streaming answer.
@@ -183,7 +211,7 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest, emit func(StreamEve
 	}
 
 	// Store user message
-	userMsg, err := s.db.CreateMessage(ctx, req.ConversationID, models.RoleUser, req.Content, req.DocRefs, nil, nil)
+	userMsg, err := s.db.CreateMessage(ctx, req.ConversationID, models.RoleUser, req.Content, req.DocRefs, nil, nil, nil)
 	if err != nil {
 		return fmt.Errorf("create user message: %w", err)
 	}
@@ -250,7 +278,7 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest, emit func(StreamEve
 		}
 
 		if decision.Action == "tool" {
-			result, toolSources, err := s.executeTool(ctx, req.VaultID, decision, emit)
+			result, toolSources, meta, err := s.executeTool(ctx, req.VaultID, decision, emit)
 			if err != nil {
 				slog.Warn("tool execution failed", "tool", decision.Tool, "error", err)
 				emit(StreamEvent{Type: "error", Content: fmt.Sprintf("tool %s failed: %v", decision.Tool, err)})
@@ -268,13 +296,26 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest, emit func(StreamEve
 			toolInput, err := json.Marshal(decision.Input)
 			if err != nil {
 				slog.Error("failed to marshal tool input", "tool", decision.Tool, "error", err)
+				toolInput = []byte(decision.Input) // fallback: use raw bytes to avoid storing empty string
 			}
 			toolInputStr := string(toolInput)
-			_, err = s.db.CreateMessage(ctx, req.ConversationID, models.RoleToolCall, "", nil, &decision.Tool, &toolInputStr)
+			_, err = s.db.CreateMessage(ctx, req.ConversationID, models.RoleToolCall, "", nil, &decision.Tool, &toolInputStr, nil)
 			if err != nil {
 				slog.Error("failed to store tool call message", "conversation_id", req.ConversationID, "tool", decision.Tool, "error", err)
 			}
-			_, err = s.db.CreateMessage(ctx, req.ConversationID, models.RoleToolResult, result, nil, &decision.Tool, nil)
+
+			// Marshal meta to JSON for storage
+			var toolMetaStr *string
+			if meta != nil {
+				metaJSON, metaErr := json.Marshal(meta)
+				if metaErr != nil {
+					slog.Error("failed to marshal tool meta", "tool", decision.Tool, "error", metaErr)
+				} else {
+					s := string(metaJSON)
+					toolMetaStr = &s
+				}
+			}
+			_, err = s.db.CreateMessage(ctx, req.ConversationID, models.RoleToolResult, result, nil, &decision.Tool, nil, toolMetaStr)
 			if err != nil {
 				slog.Error("failed to store tool result message", "conversation_id", req.ConversationID, "tool", decision.Tool, "error", err)
 			}
@@ -314,7 +355,7 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest, emit func(StreamEve
 	}
 
 	// Store assistant message
-	assistantMsg, err := s.db.CreateMessage(ctx, req.ConversationID, models.RoleAssistant, answer.String(), nil, nil, nil)
+	assistantMsg, err := s.db.CreateMessage(ctx, req.ConversationID, models.RoleAssistant, answer.String(), nil, nil, nil, nil)
 	if err != nil {
 		slog.Error("failed to store assistant message", "conversation_id", req.ConversationID, "error", err)
 		emit(StreamEvent{Type: "error", Content: "Warning: response may not be saved to conversation history"})
@@ -410,29 +451,37 @@ func buildHistoryText(history []llm.ChatMessage, currentQuery string) string {
 	return sb.String()
 }
 
-func (s *Service) executeTool(ctx context.Context, vaultID string, action *toolAction, emit func(StreamEvent)) (string, []docSource, error) {
+func intPtr(v int) *int { return &v }
+
+func (s *Service) executeTool(ctx context.Context, vaultID string, action *toolAction, emit func(StreamEvent)) (string, []docSource, *ToolResultMeta, error) {
 	switch action.Tool {
 	case "kb_search":
 		var input searchInput
 		if err := json.Unmarshal(action.Input, &input); err != nil {
-			return "", nil, fmt.Errorf("parse search input: %w", err)
+			return "", nil, nil, fmt.Errorf("parse search input: %w", err)
 		}
 		emit(StreamEvent{Type: "tool_call", Content: input.Query, Tool: "kb_search"})
 
+		start := time.Now()
 		results, err := s.search.Search(ctx, search.SearchInput{
 			VaultID: vaultID,
 			Query:   input.Query,
 			Limit:   5,
 		})
+		durationMs := time.Since(start).Milliseconds()
 		if err != nil {
-			return "", nil, fmt.Errorf("search: %w", err)
+			return "", nil, nil, fmt.Errorf("search: %w", err)
 		}
 
 		var sb strings.Builder
 		var sources []docSource
+		var matchedDocs []ToolDocRef
+		totalChunks := 0
 		for _, r := range results {
 			fmt.Fprintf(&sb, "## %s (%s)\n", r.Title, r.Path)
 			sources = append(sources, docSource{Title: r.Title, Path: r.Path})
+			matchedDocs = append(matchedDocs, ToolDocRef{Title: r.Title, Path: r.Path, Score: r.Score})
+			totalChunks += len(r.MatchedChunks)
 			for _, ch := range r.MatchedChunks {
 				sb.WriteString(ch.Snippet)
 				sb.WriteString("\n\n")
@@ -443,49 +492,77 @@ func (s *Service) executeTool(ctx context.Context, vaultID string, action *toolA
 		if result == "" {
 			result = "No results found."
 		}
-		emit(StreamEvent{Type: "tool_result", Content: fmt.Sprintf("%d results", len(results)), Tool: "kb_search"})
-		return result, sources, nil
+
+		meta := &ToolResultMeta{
+			DurationMs:  durationMs,
+			ResultCount: intPtr(len(results)),
+			ChunkCount:  intPtr(totalChunks),
+			MatchedDocs: matchedDocs,
+		}
+		emit(StreamEvent{Type: "tool_result", Content: fmt.Sprintf("%d results", len(results)), Tool: "kb_search", Meta: meta})
+		return result, sources, meta, nil
 
 	case "read_document":
 		var input readDocInput
 		if err := json.Unmarshal(action.Input, &input); err != nil {
-			return "", nil, fmt.Errorf("parse read_document input: %w", err)
+			return "", nil, nil, fmt.Errorf("parse read_document input: %w", err)
 		}
 		emit(StreamEvent{Type: "tool_call", Content: input.Path, Tool: "read_document"})
 
+		start := time.Now()
 		doc, err := s.db.GetDocumentByPath(ctx, vaultID, input.Path)
+		durationMs := time.Since(start).Milliseconds()
 		if err != nil {
-			return "", nil, fmt.Errorf("read document: %w", err)
+			return "", nil, nil, fmt.Errorf("read document: %w", err)
 		}
 		if doc == nil {
-			emit(StreamEvent{Type: "tool_result", Content: "not found", Tool: "read_document"})
-			return fmt.Sprintf("Document not found: %s", input.Path), nil, nil
+			meta := &ToolResultMeta{DurationMs: durationMs}
+			emit(StreamEvent{Type: "tool_result", Content: "not found", Tool: "read_document", Meta: meta})
+			return fmt.Sprintf("Document not found: %s", input.Path), nil, meta, nil
 		}
 
-		emit(StreamEvent{Type: "tool_result", Content: doc.Path, Tool: "read_document"})
-		return fmt.Sprintf("# %s\n\n%s", doc.Title, doc.ContentBody), []docSource{{Title: doc.Title, Path: doc.Path}}, nil
+		contentLen := len(doc.ContentBody)
+		meta := &ToolResultMeta{
+			DurationMs:    durationMs,
+			DocumentPath:  &doc.Path,
+			DocumentTitle: &doc.Title,
+			ContentLength: &contentLen,
+		}
+		emit(StreamEvent{Type: "tool_result", Content: doc.Path, Tool: "read_document", Meta: meta})
+		return fmt.Sprintf("# %s\n\n%s", doc.Title, doc.ContentBody), []docSource{{Title: doc.Title, Path: doc.Path}}, meta, nil
 
 	case "web_search":
 		var input webSearchInput
 		if err := json.Unmarshal(action.Input, &input); err != nil {
-			return "", nil, fmt.Errorf("parse web_search input: %w", err)
+			return "", nil, nil, fmt.Errorf("parse web_search input: %w", err)
 		}
 		if s.tavily == nil {
-			return "", nil, fmt.Errorf("web search not configured")
+			return "", nil, nil, fmt.Errorf("web search not configured")
 		}
 		emit(StreamEvent{Type: "tool_call", Content: input.Query, Tool: "web_search"})
 
-		result, err := s.tavily.Search(ctx, input.Query)
+		start := time.Now()
+		result, webResults, err := s.tavily.Search(ctx, input.Query)
+		durationMs := time.Since(start).Milliseconds()
 		if err != nil {
-			return "", nil, fmt.Errorf("web search: %w", err)
+			return "", nil, nil, fmt.Errorf("web search: %w", err)
 		}
 
-		emit(StreamEvent{Type: "tool_result", Content: "Web search complete", Tool: "web_search"})
-		// web_search returns no docSources since results are external, not KB documents
-		return result, nil, nil
+		var webSources []ToolWebRef
+		for _, r := range webResults {
+			webSources = append(webSources, ToolWebRef{Title: r.Title, URL: r.URL})
+		}
+
+		meta := &ToolResultMeta{
+			DurationMs:     durationMs,
+			WebResultCount: intPtr(len(webResults)),
+			WebSources:     webSources,
+		}
+		emit(StreamEvent{Type: "tool_result", Content: "Web search complete", Tool: "web_search", Meta: meta})
+		return result, nil, meta, nil
 
 	default:
-		return "", nil, fmt.Errorf("unknown tool: %s", action.Tool)
+		return "", nil, nil, fmt.Errorf("unknown tool: %s", action.Tool)
 	}
 }
 

--- a/internal/agent/tavily.go
+++ b/internal/agent/tavily.go
@@ -43,8 +43,8 @@ type tavilyResult struct {
 	Content string `json:"content"`
 }
 
-// Search performs a web search via Tavily and returns formatted markdown results.
-func (c *tavilyClient) Search(ctx context.Context, query string) (string, error) {
+// Search performs a web search via Tavily and returns formatted markdown results alongside the parsed result entries.
+func (c *tavilyClient) Search(ctx context.Context, query string) (string, []tavilyResult, error) {
 	reqBody := tavilyRequest{
 		APIKey:        c.apiKey,
 		Query:         query,
@@ -55,32 +55,32 @@ func (c *tavilyClient) Search(ctx context.Context, query string) (string, error)
 
 	body, err := json.Marshal(reqBody)
 	if err != nil {
-		return "", fmt.Errorf("marshal request: %w", err)
+		return "", nil, fmt.Errorf("marshal request: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.tavily.com/search", bytes.NewReader(body))
 	if err != nil {
-		return "", fmt.Errorf("create request: %w", err)
+		return "", nil, fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("execute request: %w", err)
+		return "", nil, fmt.Errorf("execute request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		if readErr != nil {
-			return "", fmt.Errorf("tavily API returned %d (failed to read body: %w)", resp.StatusCode, readErr)
+			return "", nil, fmt.Errorf("tavily API returned %d (failed to read body: %w)", resp.StatusCode, readErr)
 		}
-		return "", fmt.Errorf("tavily API returned %d: %s", resp.StatusCode, string(respBody))
+		return "", nil, fmt.Errorf("tavily API returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	var tavilyResp tavilyResponse
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&tavilyResp); err != nil {
-		return "", fmt.Errorf("decode response: %w", err)
+		return "", nil, fmt.Errorf("decode response: %w", err)
 	}
 
 	var sb strings.Builder
@@ -93,7 +93,7 @@ func (c *tavilyClient) Search(ctx context.Context, query string) (string, error)
 
 	result := sb.String()
 	if result == "" {
-		return "No web results found.", nil
+		return "No web results found.", tavilyResp.Results, nil
 	}
-	return result, nil
+	return result, tavilyResp.Results, nil
 }

--- a/internal/agent/tavily_test.go
+++ b/internal/agent/tavily_test.go
@@ -52,7 +52,7 @@ func TestTavilySearch_Success(t *testing.T) {
 	// Override the URL by using a custom transport
 	client.httpClient.Transport = rewriteURLTransport{url: srv.URL, base: srv.Client().Transport}
 
-	result, err := client.Search(context.Background(), "what is Go")
+	result, results, err := client.Search(context.Background(), "what is Go")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -66,6 +66,9 @@ func TestTavilySearch_Success(t *testing.T) {
 	if !strings.Contains(result, "### [Go Wiki](https://en.wikipedia.org/wiki/Go)") {
 		t.Errorf("expected Go Wiki result, got: %s", result)
 	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 structured results, got %d", len(results))
+	}
 }
 
 func TestTavilySearch_AnswerOnly(t *testing.T) {
@@ -76,12 +79,15 @@ func TestTavilySearch_AnswerOnly(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestClient("key", srv)
-	result, err := client.Search(context.Background(), "test")
+	result, results, err := client.Search(context.Background(), "test")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result != "**Summary:** Just an answer.\n\n" {
 		t.Errorf("unexpected result: %q", result)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 structured results, got %d", len(results))
 	}
 }
 
@@ -93,12 +99,15 @@ func TestTavilySearch_NoResults(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestClient("key", srv)
-	result, err := client.Search(context.Background(), "obscure query")
+	result, results, err := client.Search(context.Background(), "obscure query")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result != "No web results found." {
 		t.Errorf("expected fallback message, got: %q", result)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 structured results, got %d", len(results))
 	}
 }
 
@@ -110,7 +119,7 @@ func TestTavilySearch_APIError(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestClient("bad-key", srv)
-	_, err := client.Search(context.Background(), "test")
+	_, _, err := client.Search(context.Background(), "test")
 	if err == nil {
 		t.Fatal("expected error for 401 response")
 	}
@@ -133,7 +142,7 @@ func TestTavilySearch_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
-	_, err := client.Search(ctx, "test")
+	_, _, err := client.Search(ctx, "test")
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
 	}
@@ -146,7 +155,7 @@ func TestTavilySearch_InvalidJSON(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestClient("key", srv)
-	_, err := client.Search(context.Background(), "test")
+	_, _, err := client.Search(context.Background(), "test")
 	if err == nil {
 		t.Fatal("expected error for invalid JSON")
 	}
@@ -162,7 +171,7 @@ func TestTavilySearch_Integration(t *testing.T) {
 	}
 
 	client := newTavilyClient(apiKey)
-	result, err := client.Search(context.Background(), "what is the Go programming language")
+	result, _, err := client.Search(context.Background(), "what is the Go programming language")
 	if err != nil {
 		t.Fatalf("search failed: %v", err)
 	}

--- a/internal/db/queries_conversation.go
+++ b/internal/db/queries_conversation.go
@@ -80,7 +80,7 @@ func (c *Client) DeleteConversation(ctx context.Context, id string) error {
 	return nil
 }
 
-func (c *Client) CreateMessage(ctx context.Context, conversationID string, role models.MessageRole, content string, docRefs []string, toolName, toolInput *string) (*models.Message, error) {
+func (c *Client) CreateMessage(ctx context.Context, conversationID string, role models.MessageRole, content string, docRefs []string, toolName, toolInput, toolMeta *string) (*models.Message, error) {
 	if docRefs == nil {
 		docRefs = []string{}
 	}
@@ -91,7 +91,8 @@ func (c *Client) CreateMessage(ctx context.Context, conversationID string, role 
 			content = $content,
 			doc_refs = $doc_refs,
 			tool_name = $tool_name,
-			tool_input = $tool_input
+			tool_input = $tool_input,
+			tool_meta = $tool_meta
 		RETURN AFTER
 	`
 	results, err := surrealdb.Query[[]models.Message](ctx, c.DB(), sql, map[string]any{
@@ -101,6 +102,7 @@ func (c *Client) CreateMessage(ctx context.Context, conversationID string, role 
 		"doc_refs":        docRefs,
 		"tool_name":       optionalString(toolName),
 		"tool_input":      optionalString(toolInput),
+		"tool_meta":       optionalString(toolMeta),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create message: %w", err)

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -215,6 +215,7 @@ func SchemaSQL(dimension int) string {
     DEFINE FIELD IF NOT EXISTS doc_refs     ON message TYPE array<string> DEFAULT [];
     DEFINE FIELD IF NOT EXISTS tool_name    ON message TYPE option<string>;
     DEFINE FIELD IF NOT EXISTS tool_input   ON message TYPE option<string>;
+    DEFINE FIELD IF NOT EXISTS tool_meta    ON message TYPE option<string>;
     DEFINE FIELD IF NOT EXISTS created_at   ON message TYPE datetime DEFAULT time::now();
 
     DEFINE INDEX IF NOT EXISTS idx_message_conversation ON message FIELDS conversation;

--- a/internal/graph/generated.go
+++ b/internal/graph/generated.go
@@ -46,6 +46,7 @@ type ComplexityRoot struct {
 		ID        func(childComplexity int) int
 		Role      func(childComplexity int) int
 		ToolInput func(childComplexity int) int
+		ToolMeta  func(childComplexity int) int
 		ToolName  func(childComplexity int) int
 	}
 
@@ -237,6 +238,29 @@ type ComplexityRoot struct {
 		VaultID      func(childComplexity int) int
 	}
 
+	ToolDocRef struct {
+		Path  func(childComplexity int) int
+		Score func(childComplexity int) int
+		Title func(childComplexity int) int
+	}
+
+	ToolResultMeta struct {
+		ChunkCount     func(childComplexity int) int
+		ContentLength  func(childComplexity int) int
+		DocumentPath   func(childComplexity int) int
+		DocumentTitle  func(childComplexity int) int
+		DurationMs     func(childComplexity int) int
+		MatchedDocs    func(childComplexity int) int
+		ResultCount    func(childComplexity int) int
+		WebResultCount func(childComplexity int) int
+		WebSources     func(childComplexity int) int
+	}
+
+	ToolWebRef struct {
+		Title func(childComplexity int) int
+		URL   func(childComplexity int) int
+	}
+
 	User struct {
 		CreatedAt func(childComplexity int) int
 		Email     func(childComplexity int) int
@@ -373,6 +397,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.ChatMessage.ToolInput(childComplexity), true
+	case "ChatMessage.toolMeta":
+		if e.ComplexityRoot.ChatMessage.ToolMeta == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ChatMessage.ToolMeta(childComplexity), true
 	case "ChatMessage.toolName":
 		if e.ComplexityRoot.ChatMessage.ToolName == nil {
 			break
@@ -1368,6 +1398,93 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.Template.VaultID(childComplexity), true
 
+	case "ToolDocRef.path":
+		if e.ComplexityRoot.ToolDocRef.Path == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ToolDocRef.Path(childComplexity), true
+	case "ToolDocRef.score":
+		if e.ComplexityRoot.ToolDocRef.Score == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ToolDocRef.Score(childComplexity), true
+	case "ToolDocRef.title":
+		if e.ComplexityRoot.ToolDocRef.Title == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ToolDocRef.Title(childComplexity), true
+
+	case "ToolResultMeta.chunkCount":
+		if e.ComplexityRoot.ToolResultMeta.ChunkCount == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ToolResultMeta.ChunkCount(childComplexity), true
+	case "ToolResultMeta.contentLength":
+		if e.ComplexityRoot.ToolResultMeta.ContentLength == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ToolResultMeta.ContentLength(childComplexity), true
+	case "ToolResultMeta.documentPath":
+		if e.ComplexityRoot.ToolResultMeta.DocumentPath == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ToolResultMeta.DocumentPath(childComplexity), true
+	case "ToolResultMeta.documentTitle":
+		if e.ComplexityRoot.ToolResultMeta.DocumentTitle == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ToolResultMeta.DocumentTitle(childComplexity), true
+	case "ToolResultMeta.durationMs":
+		if e.ComplexityRoot.ToolResultMeta.DurationMs == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ToolResultMeta.DurationMs(childComplexity), true
+	case "ToolResultMeta.matchedDocs":
+		if e.ComplexityRoot.ToolResultMeta.MatchedDocs == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ToolResultMeta.MatchedDocs(childComplexity), true
+	case "ToolResultMeta.resultCount":
+		if e.ComplexityRoot.ToolResultMeta.ResultCount == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ToolResultMeta.ResultCount(childComplexity), true
+	case "ToolResultMeta.webResultCount":
+		if e.ComplexityRoot.ToolResultMeta.WebResultCount == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ToolResultMeta.WebResultCount(childComplexity), true
+	case "ToolResultMeta.webSources":
+		if e.ComplexityRoot.ToolResultMeta.WebSources == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ToolResultMeta.WebSources(childComplexity), true
+
+	case "ToolWebRef.title":
+		if e.ComplexityRoot.ToolWebRef.Title == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ToolWebRef.Title(childComplexity), true
+	case "ToolWebRef.url":
+		if e.ComplexityRoot.ToolWebRef.URL == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ToolWebRef.URL(childComplexity), true
+
 	case "User.createdAt":
 		if e.ComplexityRoot.User.CreatedAt == nil {
 			break
@@ -2325,6 +2442,55 @@ func (ec *executionContext) fieldContext_ChatMessage_toolInput(_ context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _ChatMessage_toolMeta(ctx context.Context, field graphql.CollectedField, obj *ChatMessage) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ChatMessage_toolMeta,
+		func(ctx context.Context) (any, error) {
+			return obj.ToolMeta, nil
+		},
+		nil,
+		ec.marshalOToolResultMeta2ᚖgithubᚗcomᚋraphi011ᚋknowhowᚋinternalᚋgraphᚐToolResultMeta,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_ChatMessage_toolMeta(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ChatMessage",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "durationMs":
+				return ec.fieldContext_ToolResultMeta_durationMs(ctx, field)
+			case "resultCount":
+				return ec.fieldContext_ToolResultMeta_resultCount(ctx, field)
+			case "chunkCount":
+				return ec.fieldContext_ToolResultMeta_chunkCount(ctx, field)
+			case "matchedDocs":
+				return ec.fieldContext_ToolResultMeta_matchedDocs(ctx, field)
+			case "documentPath":
+				return ec.fieldContext_ToolResultMeta_documentPath(ctx, field)
+			case "documentTitle":
+				return ec.fieldContext_ToolResultMeta_documentTitle(ctx, field)
+			case "contentLength":
+				return ec.fieldContext_ToolResultMeta_contentLength(ctx, field)
+			case "webResultCount":
+				return ec.fieldContext_ToolResultMeta_webResultCount(ctx, field)
+			case "webSources":
+				return ec.fieldContext_ToolResultMeta_webSources(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ToolResultMeta", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ChatMessage_createdAt(ctx context.Context, field graphql.CollectedField, obj *ChatMessage) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -2651,6 +2817,8 @@ func (ec *executionContext) fieldContext_Conversation_messages(_ context.Context
 				return ec.fieldContext_ChatMessage_toolName(ctx, field)
 			case "toolInput":
 				return ec.fieldContext_ChatMessage_toolInput(ctx, field)
+			case "toolMeta":
+				return ec.fieldContext_ChatMessage_toolMeta(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_ChatMessage_createdAt(ctx, field)
 			}
@@ -7530,6 +7698,426 @@ func (ec *executionContext) fieldContext_Template_updatedAt(_ context.Context, f
 	return fc, nil
 }
 
+func (ec *executionContext) _ToolDocRef_title(ctx context.Context, field graphql.CollectedField, obj *ToolDocRef) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ToolDocRef_title,
+		func(ctx context.Context) (any, error) {
+			return obj.Title, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ToolDocRef_title(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolDocRef",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ToolDocRef_path(ctx context.Context, field graphql.CollectedField, obj *ToolDocRef) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ToolDocRef_path,
+		func(ctx context.Context) (any, error) {
+			return obj.Path, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ToolDocRef_path(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolDocRef",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ToolDocRef_score(ctx context.Context, field graphql.CollectedField, obj *ToolDocRef) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ToolDocRef_score,
+		func(ctx context.Context) (any, error) {
+			return obj.Score, nil
+		},
+		nil,
+		ec.marshalNFloat2float64,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ToolDocRef_score(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolDocRef",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ToolResultMeta_durationMs(ctx context.Context, field graphql.CollectedField, obj *ToolResultMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ToolResultMeta_durationMs,
+		func(ctx context.Context) (any, error) {
+			return obj.DurationMs, nil
+		},
+		nil,
+		ec.marshalNInt2int,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ToolResultMeta_durationMs(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolResultMeta",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ToolResultMeta_resultCount(ctx context.Context, field graphql.CollectedField, obj *ToolResultMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ToolResultMeta_resultCount,
+		func(ctx context.Context) (any, error) {
+			return obj.ResultCount, nil
+		},
+		nil,
+		ec.marshalOInt2ᚖint,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_ToolResultMeta_resultCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolResultMeta",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ToolResultMeta_chunkCount(ctx context.Context, field graphql.CollectedField, obj *ToolResultMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ToolResultMeta_chunkCount,
+		func(ctx context.Context) (any, error) {
+			return obj.ChunkCount, nil
+		},
+		nil,
+		ec.marshalOInt2ᚖint,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_ToolResultMeta_chunkCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolResultMeta",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ToolResultMeta_matchedDocs(ctx context.Context, field graphql.CollectedField, obj *ToolResultMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ToolResultMeta_matchedDocs,
+		func(ctx context.Context) (any, error) {
+			return obj.MatchedDocs, nil
+		},
+		nil,
+		ec.marshalOToolDocRef2ᚕᚖgithubᚗcomᚋraphi011ᚋknowhowᚋinternalᚋgraphᚐToolDocRefᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_ToolResultMeta_matchedDocs(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolResultMeta",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "title":
+				return ec.fieldContext_ToolDocRef_title(ctx, field)
+			case "path":
+				return ec.fieldContext_ToolDocRef_path(ctx, field)
+			case "score":
+				return ec.fieldContext_ToolDocRef_score(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ToolDocRef", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ToolResultMeta_documentPath(ctx context.Context, field graphql.CollectedField, obj *ToolResultMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ToolResultMeta_documentPath,
+		func(ctx context.Context) (any, error) {
+			return obj.DocumentPath, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_ToolResultMeta_documentPath(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolResultMeta",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ToolResultMeta_documentTitle(ctx context.Context, field graphql.CollectedField, obj *ToolResultMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ToolResultMeta_documentTitle,
+		func(ctx context.Context) (any, error) {
+			return obj.DocumentTitle, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_ToolResultMeta_documentTitle(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolResultMeta",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ToolResultMeta_contentLength(ctx context.Context, field graphql.CollectedField, obj *ToolResultMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ToolResultMeta_contentLength,
+		func(ctx context.Context) (any, error) {
+			return obj.ContentLength, nil
+		},
+		nil,
+		ec.marshalOInt2ᚖint,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_ToolResultMeta_contentLength(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolResultMeta",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ToolResultMeta_webResultCount(ctx context.Context, field graphql.CollectedField, obj *ToolResultMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ToolResultMeta_webResultCount,
+		func(ctx context.Context) (any, error) {
+			return obj.WebResultCount, nil
+		},
+		nil,
+		ec.marshalOInt2ᚖint,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_ToolResultMeta_webResultCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolResultMeta",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ToolResultMeta_webSources(ctx context.Context, field graphql.CollectedField, obj *ToolResultMeta) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ToolResultMeta_webSources,
+		func(ctx context.Context) (any, error) {
+			return obj.WebSources, nil
+		},
+		nil,
+		ec.marshalOToolWebRef2ᚕᚖgithubᚗcomᚋraphi011ᚋknowhowᚋinternalᚋgraphᚐToolWebRefᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_ToolResultMeta_webSources(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolResultMeta",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "title":
+				return ec.fieldContext_ToolWebRef_title(ctx, field)
+			case "url":
+				return ec.fieldContext_ToolWebRef_url(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ToolWebRef", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ToolWebRef_title(ctx context.Context, field graphql.CollectedField, obj *ToolWebRef) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ToolWebRef_title,
+		func(ctx context.Context) (any, error) {
+			return obj.Title, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ToolWebRef_title(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolWebRef",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ToolWebRef_url(ctx context.Context, field graphql.CollectedField, obj *ToolWebRef) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ToolWebRef_url,
+		func(ctx context.Context) (any, error) {
+			return obj.URL, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ToolWebRef_url(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolWebRef",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _User_id(ctx context.Context, field graphql.CollectedField, obj *User) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -9930,6 +10518,8 @@ func (ec *executionContext) _ChatMessage(ctx context.Context, sel ast.SelectionS
 			out.Values[i] = ec._ChatMessage_toolName(ctx, field, obj)
 		case "toolInput":
 			out.Values[i] = ec._ChatMessage_toolInput(ctx, field, obj)
+		case "toolMeta":
+			out.Values[i] = ec._ChatMessage_toolMeta(ctx, field, obj)
 		case "createdAt":
 			out.Values[i] = ec._ChatMessage_createdAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -11697,6 +12287,154 @@ func (ec *executionContext) _Template(ctx context.Context, sel ast.SelectionSet,
 	return out
 }
 
+var toolDocRefImplementors = []string{"ToolDocRef"}
+
+func (ec *executionContext) _ToolDocRef(ctx context.Context, sel ast.SelectionSet, obj *ToolDocRef) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, toolDocRefImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ToolDocRef")
+		case "title":
+			out.Values[i] = ec._ToolDocRef_title(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "path":
+			out.Values[i] = ec._ToolDocRef_path(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "score":
+			out.Values[i] = ec._ToolDocRef_score(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var toolResultMetaImplementors = []string{"ToolResultMeta"}
+
+func (ec *executionContext) _ToolResultMeta(ctx context.Context, sel ast.SelectionSet, obj *ToolResultMeta) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, toolResultMetaImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ToolResultMeta")
+		case "durationMs":
+			out.Values[i] = ec._ToolResultMeta_durationMs(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "resultCount":
+			out.Values[i] = ec._ToolResultMeta_resultCount(ctx, field, obj)
+		case "chunkCount":
+			out.Values[i] = ec._ToolResultMeta_chunkCount(ctx, field, obj)
+		case "matchedDocs":
+			out.Values[i] = ec._ToolResultMeta_matchedDocs(ctx, field, obj)
+		case "documentPath":
+			out.Values[i] = ec._ToolResultMeta_documentPath(ctx, field, obj)
+		case "documentTitle":
+			out.Values[i] = ec._ToolResultMeta_documentTitle(ctx, field, obj)
+		case "contentLength":
+			out.Values[i] = ec._ToolResultMeta_contentLength(ctx, field, obj)
+		case "webResultCount":
+			out.Values[i] = ec._ToolResultMeta_webResultCount(ctx, field, obj)
+		case "webSources":
+			out.Values[i] = ec._ToolResultMeta_webSources(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var toolWebRefImplementors = []string{"ToolWebRef"}
+
+func (ec *executionContext) _ToolWebRef(ctx context.Context, sel ast.SelectionSet, obj *ToolWebRef) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, toolWebRefImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ToolWebRef")
+		case "title":
+			out.Values[i] = ec._ToolWebRef_title(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "url":
+			out.Values[i] = ec._ToolWebRef_url(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var userImplementors = []string{"User"}
 
 func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj *User) graphql.Marshaler {
@@ -12980,6 +13718,26 @@ func (ec *executionContext) unmarshalNTemplateInput2githubᚗcomᚋraphi011ᚋkn
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) marshalNToolDocRef2ᚖgithubᚗcomᚋraphi011ᚋknowhowᚋinternalᚋgraphᚐToolDocRef(ctx context.Context, sel ast.SelectionSet, v *ToolDocRef) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ToolDocRef(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNToolWebRef2ᚖgithubᚗcomᚋraphi011ᚋknowhowᚋinternalᚋgraphᚐToolWebRef(ctx context.Context, sel ast.SelectionSet, v *ToolWebRef) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ToolWebRef(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNUser2githubᚗcomᚋraphi011ᚋknowhowᚋinternalᚋgraphᚐUser(ctx context.Context, sel ast.SelectionSet, v User) graphql.Marshaler {
 	return ec._User(ctx, sel, &v)
 }
@@ -13406,6 +14164,51 @@ func (ec *executionContext) marshalOTemplate2ᚖgithubᚗcomᚋraphi011ᚋknowho
 		return graphql.Null
 	}
 	return ec._Template(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOToolDocRef2ᚕᚖgithubᚗcomᚋraphi011ᚋknowhowᚋinternalᚋgraphᚐToolDocRefᚄ(ctx context.Context, sel ast.SelectionSet, v []*ToolDocRef) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNToolDocRef2ᚖgithubᚗcomᚋraphi011ᚋknowhowᚋinternalᚋgraphᚐToolDocRef(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalOToolResultMeta2ᚖgithubᚗcomᚋraphi011ᚋknowhowᚋinternalᚋgraphᚐToolResultMeta(ctx context.Context, sel ast.SelectionSet, v *ToolResultMeta) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._ToolResultMeta(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOToolWebRef2ᚕᚖgithubᚗcomᚋraphi011ᚋknowhowᚋinternalᚋgraphᚐToolWebRefᚄ(ctx context.Context, sel ast.SelectionSet, v []*ToolWebRef) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNToolWebRef2ᚖgithubᚗcomᚋraphi011ᚋknowhowᚋinternalᚋgraphᚐToolWebRef(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalOVault2ᚖgithubᚗcomᚋraphi011ᚋknowhowᚋinternalᚋgraphᚐVault(ctx context.Context, sel ast.SelectionSet, v *Vault) graphql.Marshaler {

--- a/internal/graph/helpers.go
+++ b/internal/graph/helpers.go
@@ -2,10 +2,12 @@ package graph
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
 
+	"github.com/raphi011/knowhow/internal/agent"
 	"github.com/raphi011/knowhow/internal/db"
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/raphi011/knowhow/internal/parser"
@@ -496,8 +498,43 @@ func messageToGraphQL(m *models.Message) *ChatMessage {
 		DocRefs:   docRefs,
 		ToolName:  m.ToolName,
 		ToolInput: m.ToolInput,
+		ToolMeta:  toolResultMetaFromJSON(m.ToolMeta),
 		CreatedAt: m.CreatedAt,
 	}
+}
+
+func toolResultMetaFromJSON(s *string) *ToolResultMeta {
+	if s == nil || *s == "" {
+		return nil
+	}
+	var src agent.ToolResultMeta
+	if err := json.Unmarshal([]byte(*s), &src); err != nil {
+		slog.Warn("failed to unmarshal tool_meta JSON", "error", err, "raw", *s)
+		return nil
+	}
+	meta := &ToolResultMeta{
+		DurationMs:     int(src.DurationMs),
+		ResultCount:    src.ResultCount,
+		ChunkCount:     src.ChunkCount,
+		DocumentPath:   src.DocumentPath,
+		DocumentTitle:  src.DocumentTitle,
+		ContentLength:  src.ContentLength,
+		WebResultCount: src.WebResultCount,
+	}
+	for _, d := range src.MatchedDocs {
+		meta.MatchedDocs = append(meta.MatchedDocs, &ToolDocRef{
+			Title: d.Title,
+			Path:  d.Path,
+			Score: d.Score,
+		})
+	}
+	for _, w := range src.WebSources {
+		meta.WebSources = append(meta.WebSources, &ToolWebRef{
+			Title: w.Title,
+			URL:   w.URL,
+		})
+	}
+	return meta
 }
 
 func searchResultToGraphQL(r search.SearchResult) SearchResult {

--- a/internal/graph/model_gen.go
+++ b/internal/graph/model_gen.go
@@ -7,13 +7,14 @@ import (
 )
 
 type ChatMessage struct {
-	ID        string    `json:"id"`
-	Role      string    `json:"role"`
-	Content   string    `json:"content"`
-	DocRefs   []string  `json:"docRefs"`
-	ToolName  *string   `json:"toolName,omitempty"`
-	ToolInput *string   `json:"toolInput,omitempty"`
-	CreatedAt time.Time `json:"createdAt"`
+	ID        string          `json:"id"`
+	Role      string          `json:"role"`
+	Content   string          `json:"content"`
+	DocRefs   []string        `json:"docRefs"`
+	ToolName  *string         `json:"toolName,omitempty"`
+	ToolInput *string         `json:"toolInput,omitempty"`
+	ToolMeta  *ToolResultMeta `json:"toolMeta,omitempty"`
+	CreatedAt time.Time       `json:"createdAt"`
 }
 
 type Conversation struct {
@@ -29,4 +30,27 @@ type Mutation struct {
 }
 
 type Query struct {
+}
+
+type ToolDocRef struct {
+	Title string  `json:"title"`
+	Path  string  `json:"path"`
+	Score float64 `json:"score"`
+}
+
+type ToolResultMeta struct {
+	DurationMs     int           `json:"durationMs"`
+	ResultCount    *int          `json:"resultCount,omitempty"`
+	ChunkCount     *int          `json:"chunkCount,omitempty"`
+	MatchedDocs    []*ToolDocRef `json:"matchedDocs,omitempty"`
+	DocumentPath   *string       `json:"documentPath,omitempty"`
+	DocumentTitle  *string       `json:"documentTitle,omitempty"`
+	ContentLength  *int          `json:"contentLength,omitempty"`
+	WebResultCount *int          `json:"webResultCount,omitempty"`
+	WebSources     []*ToolWebRef `json:"webSources,omitempty"`
+}
+
+type ToolWebRef struct {
+	Title string `json:"title"`
+	URL   string `json:"url"`
 }

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -154,7 +154,31 @@ type ChatMessage {
   docRefs: [String!]!
   toolName: String
   toolInput: String
+  toolMeta: ToolResultMeta
   createdAt: DateTime!
+}
+
+type ToolResultMeta {
+  durationMs: Int!
+  resultCount: Int
+  chunkCount: Int
+  matchedDocs: [ToolDocRef!]
+  documentPath: String
+  documentTitle: String
+  contentLength: Int
+  webResultCount: Int
+  webSources: [ToolWebRef!]
+}
+
+type ToolDocRef {
+  title: String!
+  path: String!
+  score: Float!
+}
+
+type ToolWebRef {
+  title: String!
+  url: String!
 }
 
 # =============================================================================

--- a/internal/models/conversation.go
+++ b/internal/models/conversation.go
@@ -35,5 +35,6 @@ type Message struct {
 	DocRefs      []string               `json:"doc_refs"`
 	ToolName     *string                `json:"tool_name,omitempty"`
 	ToolInput    *string                `json:"tool_input,omitempty"`
+	ToolMeta     *string                `json:"tool_meta,omitempty"`
 	CreatedAt    time.Time              `json:"created_at"`
 }

--- a/web/components/domain/agent-chat-context.tsx
+++ b/web/components/domain/agent-chat-context.tsx
@@ -4,6 +4,18 @@ import { createContext, useContext, useEffect, useReducer, useRef } from "react"
 
 // --- Types ---
 
+export type ToolResultMeta = {
+  durationMs: number;
+  resultCount?: number;
+  chunkCount?: number;
+  matchedDocs?: { title: string; path: string; score: number }[];
+  documentPath?: string;
+  documentTitle?: string;
+  contentLength?: number;
+  webResultCount?: number;
+  webSources?: { title: string; url: string }[];
+};
+
 export type StreamEvent = {
   type:
     | "token"
@@ -15,6 +27,7 @@ export type StreamEvent = {
     | "conversation_id";
   content: string;
   tool?: string;
+  meta?: ToolResultMeta;
 };
 
 export type ChatMessage = {
@@ -24,6 +37,7 @@ export type ChatMessage = {
   docRefs: string[];
   toolName?: string;
   toolInput?: string;
+  toolMeta?: ToolResultMeta;
   createdAt: string;
 };
 
@@ -36,10 +50,10 @@ export type Conversation = {
   messages: ChatMessage[];
 };
 
-type ToolEvent = {
+export type ToolExecution = {
   tool: string;
-  type: "call" | "result";
-  content: string;
+  callContent: string;
+  result?: { content: string; meta?: ToolResultMeta };
 };
 
 type State = {
@@ -47,7 +61,7 @@ type State = {
   activeConversationId: string | null;
   isStreaming: boolean;
   streamingContent: string;
-  toolEvents: ToolEvent[];
+  toolExecutions: ToolExecution[];
   error: string | null;
 };
 
@@ -61,7 +75,13 @@ type Action =
   | { type: "ADD_MESSAGE"; id: string; message: ChatMessage }
   | { type: "STREAM_START" }
   | { type: "STREAM_TOKEN"; content: string }
-  | { type: "STREAM_TOOL"; event: ToolEvent }
+  | { type: "STREAM_TOOL_CALL"; tool: string; content: string }
+  | {
+      type: "STREAM_TOOL_RESULT";
+      tool: string;
+      content: string;
+      meta?: ToolResultMeta;
+    }
   | { type: "STREAM_END" }
   | { type: "SET_ERROR"; error: string | null };
 
@@ -74,7 +94,7 @@ function reducer(state: State, action: Action): State {
         ...state,
         activeConversationId: action.id,
         streamingContent: "",
-        toolEvents: [],
+        toolExecutions: [],
         error: null,
       };
     case "ADD_CONVERSATION":
@@ -124,7 +144,7 @@ function reducer(state: State, action: Action): State {
         ...state,
         isStreaming: true,
         streamingContent: "",
-        toolEvents: [],
+        toolExecutions: [],
         error: null,
       };
     case "STREAM_TOKEN":
@@ -132,11 +152,34 @@ function reducer(state: State, action: Action): State {
         ...state,
         streamingContent: state.streamingContent + action.content,
       };
-    case "STREAM_TOOL":
+    case "STREAM_TOOL_CALL":
       return {
         ...state,
-        toolEvents: [...state.toolEvents, action.event],
+        toolExecutions: [
+          ...state.toolExecutions,
+          { tool: action.tool, callContent: action.content },
+        ],
       };
+    case "STREAM_TOOL_RESULT": {
+      // Find the last execution with matching tool that has no result yet
+      const execs = [...state.toolExecutions];
+      let matched = false;
+      for (let i = execs.length - 1; i >= 0; i--) {
+        const exec = execs[i];
+        if (exec && exec.tool === action.tool && !exec.result) {
+          execs[i] = {
+            ...exec,
+            result: { content: action.content, meta: action.meta },
+          };
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) {
+        console.warn("STREAM_TOOL_RESULT: no matching unresolved tool execution", action.tool);
+      }
+      return { ...state, toolExecutions: execs };
+    }
     case "STREAM_END":
       return { ...state, isStreaming: false };
     case "SET_ERROR":
@@ -145,6 +188,17 @@ function reducer(state: State, action: Action): State {
 }
 
 // --- GraphQL helpers ---
+
+const TOOL_META_FIELDS = `toolMeta {
+  durationMs resultCount chunkCount
+  matchedDocs { title path score }
+  documentPath documentTitle contentLength
+  webResultCount
+  webSources { title url }
+}`;
+
+const MESSAGE_FIELDS = `id role content docRefs toolName toolInput ${TOOL_META_FIELDS} createdAt`;
+const CONVERSATION_FIELDS = `id vaultId title createdAt updatedAt messages { ${MESSAGE_FIELDS} }`;
 
 async function graphqlQuery<T>(
   query: string,
@@ -164,7 +218,9 @@ async function graphqlQuery<T>(
   }
   if (json.errors?.length)
     throw new Error(json.errors[0]?.message ?? "Unknown GraphQL error");
-  return json.data as T;
+  if (!json.data)
+    throw new Error("GraphQL response missing 'data' field");
+  return json.data;
 }
 
 async function graphqlMutate<T>(
@@ -191,7 +247,7 @@ const initialState: State = {
   activeConversationId: null,
   isStreaming: false,
   streamingContent: "",
-  toolEvents: [],
+  toolExecutions: [],
   error: null,
 };
 
@@ -220,10 +276,7 @@ export function AgentChatProvider({
         conversations: Conversation[];
       }>(
         `query ($vaultId: ID!) {
-          conversations(vaultId: $vaultId) {
-            id vaultId title createdAt updatedAt
-            messages { id role content docRefs toolName toolInput createdAt }
-          }
+          conversations(vaultId: $vaultId) { ${CONVERSATION_FIELDS} }
         }`,
         { vaultId: vid },
       );
@@ -237,10 +290,7 @@ export function AgentChatProvider({
             conversation: Conversation | null;
           }>(
             `query ($id: ID!) {
-              conversation(id: $id) {
-                id vaultId title createdAt updatedAt
-                messages { id role content docRefs toolName toolInput createdAt }
-              }
+              conversation(id: $id) { ${CONVERSATION_FIELDS} }
             }`,
             { id: first.id },
           );
@@ -274,10 +324,7 @@ export function AgentChatProvider({
         createConversation: Conversation;
       }>(
         `mutation ($vaultId: ID!) {
-          createConversation(vaultId: $vaultId) {
-            id vaultId title createdAt updatedAt
-            messages { id role content docRefs toolName toolInput createdAt }
-          }
+          createConversation(vaultId: $vaultId) { ${CONVERSATION_FIELDS} }
         }`,
         { vaultId: vid },
       );
@@ -301,10 +348,7 @@ export function AgentChatProvider({
           conversation: Conversation | null;
         }>(
           `query ($id: ID!) {
-            conversation(id: $id) {
-              id vaultId title createdAt updatedAt
-              messages { id role content docRefs toolName toolInput createdAt }
-            }
+            conversation(id: $id) { ${CONVERSATION_FIELDS} }
           }`,
           { id },
         );
@@ -413,8 +457,8 @@ export function AgentChatProvider({
             let event: StreamEvent;
             try {
               event = JSON.parse(jsonStr);
-            } catch {
-              // Skip malformed SSE lines
+            } catch (parseErr) {
+              console.warn("Skipping malformed SSE event", jsonStr, parseErr);
               continue;
             }
 
@@ -424,22 +468,17 @@ export function AgentChatProvider({
                 break;
               case "tool_call":
                 dispatch({
-                  type: "STREAM_TOOL",
-                  event: {
-                    tool: event.tool ?? "",
-                    type: "call",
-                    content: event.content,
-                  },
+                  type: "STREAM_TOOL_CALL",
+                  tool: event.tool ?? "",
+                  content: event.content,
                 });
                 break;
               case "tool_result":
                 dispatch({
-                  type: "STREAM_TOOL",
-                  event: {
-                    tool: event.tool ?? "",
-                    type: "result",
-                    content: event.content,
-                  },
+                  type: "STREAM_TOOL_RESULT",
+                  tool: event.tool ?? "",
+                  content: event.content,
+                  meta: event.meta,
                 });
                 break;
               case "conversation_id":
@@ -462,10 +501,7 @@ export function AgentChatProvider({
                       conversation: Conversation | null;
                     }>(
                       `query ($id: ID!) {
-                        conversation(id: $id) {
-                          id vaultId title createdAt updatedAt
-                          messages { id role content docRefs toolName toolInput createdAt }
-                        }
+                        conversation(id: $id) { ${CONVERSATION_FIELDS} }
                       }`,
                       { id: newConvId },
                     );

--- a/web/components/domain/agent-chat-panel.tsx
+++ b/web/components/domain/agent-chat-panel.tsx
@@ -6,18 +6,86 @@ import {
   PlusIcon,
   PaperAirplaneIcon,
   TrashIcon,
-  MagnifyingGlassIcon,
   DocumentTextIcon,
-  GlobeAltIcon,
 } from "@heroicons/react/20/solid";
 import { cn } from "@/lib/utils";
-import { useAgentChat } from "@/components/domain/agent-chat-context";
+import {
+  useAgentChat,
+  type ChatMessage,
+} from "@/components/domain/agent-chat-context";
 import { MarkdownRenderer } from "@/components/domain/markdown-renderer";
 import { DocRefAutocomplete } from "@/components/domain/doc-ref-autocomplete";
+import { ToolCard } from "@/components/domain/tool-card";
 
 type AgentChatPanelProps = {
   vaultId: string | null;
 };
+
+// Pair adjacent tool_call + tool_result messages into ToolCard-compatible entries
+type PairedEntry =
+  | { type: "message"; message: ChatMessage }
+  | {
+      type: "tool_card";
+      tool: string;
+      callContent: string;
+      result?: {
+        content: string;
+        meta?: ChatMessage["toolMeta"];
+      };
+    };
+
+/** Extract display-friendly content from the stored JSON tool input. */
+function extractCallContent(toolInput: string | undefined, tool: string): string {
+  if (!toolInput) return "";
+  try {
+    const parsed = JSON.parse(toolInput) as Record<string, unknown>;
+    if (tool === "kb_search" || tool === "web_search") return String(parsed.query ?? toolInput);
+    if (tool === "read_document") return String(parsed.path ?? toolInput);
+  } catch { /* not JSON, use as-is */ }
+  return toolInput;
+}
+
+function pairMessages(messages: ChatMessage[]): PairedEntry[] {
+  const entries: PairedEntry[] = [];
+  let i = 0;
+
+  while (i < messages.length) {
+    const msg = messages[i]!;
+
+    if (msg.role === "tool_call") {
+      const tool = msg.toolName ?? "kb_search";
+      const callContent = extractCallContent(msg.toolInput, tool);
+
+      // Look ahead for a matching tool_result
+      const next = messages[i + 1];
+      if (next?.role === "tool_result" && next.toolName === msg.toolName) {
+        entries.push({
+          type: "tool_card",
+          tool,
+          callContent,
+          result: { content: next.content, meta: next.toolMeta },
+        });
+        i += 2;
+        continue;
+      }
+      // Orphaned tool_call (no matching result)
+      entries.push({ type: "tool_card", tool, callContent });
+      i++;
+      continue;
+    }
+
+    if (msg.role === "tool_result") {
+      // Orphaned tool_result (no preceding call) — skip it
+      i++;
+      continue;
+    }
+
+    entries.push({ type: "message", message: msg });
+    i++;
+  }
+
+  return entries;
+}
 
 function AgentChatPanel({ vaultId }: AgentChatPanelProps) {
   const t = useTranslations("docs");
@@ -31,6 +99,7 @@ function AgentChatPanel({ vaultId }: AgentChatPanelProps) {
     (c) => c.id === chat.activeConversationId,
   );
   const activeMessages = activeConv?.messages ?? [];
+  const pairedEntries = pairMessages(activeMessages);
 
   // Load conversations when vault changes
   useEffect(() => {
@@ -43,7 +112,7 @@ function AgentChatPanel({ vaultId }: AgentChatPanelProps) {
   // Auto-scroll to bottom
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [chat.streamingContent, activeMessages.length]);
+  }, [chat.streamingContent, activeMessages.length, chat.toolExecutions.length]);
 
   function handleSend() {
     const trimmed = input.trim();
@@ -128,17 +197,29 @@ function AgentChatPanel({ vaultId }: AgentChatPanelProps) {
             {t("agentPlaceholder")}
           </div>
         )}
-        {activeMessages.map((msg) =>
-          msg.role === "tool_call" || msg.role === "tool_result" ? (
-            <ToolMessage key={msg.id} message={msg} />
+
+        {/* Persisted messages — paired as ToolCards or ChatBubbles */}
+        {pairedEntries.map((entry, i) =>
+          entry.type === "tool_card" ? (
+            <ToolCard
+              key={`tool-${i}`}
+              tool={entry.tool}
+              callContent={entry.callContent}
+              result={entry.result}
+            />
           ) : (
-            <ChatBubble key={msg.id} message={msg} />
+            <ChatBubble key={entry.message.id} message={entry.message} />
           ),
         )}
 
-        {/* Tool indicators */}
-        {chat.toolEvents.map((event, i) => (
-          <ToolIndicator key={i} event={event} />
+        {/* Streaming tool executions */}
+        {chat.toolExecutions.map((exec, i) => (
+          <ToolCard
+            key={`stream-tool-${i}`}
+            tool={exec.tool}
+            callContent={exec.callContent}
+            result={exec.result}
+          />
         ))}
 
         {/* Streaming content */}
@@ -154,15 +235,17 @@ function AgentChatPanel({ vaultId }: AgentChatPanelProps) {
         )}
 
         {/* Typing indicator */}
-        {chat.isStreaming && !chat.streamingContent && chat.toolEvents.length === 0 && (
-          <div className="mb-2">
-            <div className="flex gap-1 rounded-lg bg-slate-50 px-3 py-2 dark:bg-slate-800">
-              <span className="size-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:0ms]" />
-              <span className="size-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:150ms]" />
-              <span className="size-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:300ms]" />
+        {chat.isStreaming &&
+          !chat.streamingContent &&
+          chat.toolExecutions.length === 0 && (
+            <div className="mb-2">
+              <div className="flex gap-1 rounded-lg bg-slate-50 px-3 py-2 dark:bg-slate-800">
+                <span className="size-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:0ms]" />
+                <span className="size-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:150ms]" />
+                <span className="size-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:300ms]" />
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
         {/* Error */}
         {chat.error && (
@@ -190,7 +273,7 @@ function AgentChatPanel({ vaultId }: AgentChatPanelProps) {
                   onClick={() => removeDocRef(ref)}
                   className="ml-0.5 hover:text-red-500"
                 >
-                  ×
+                  x
                 </button>
               </span>
             ))}
@@ -275,67 +358,6 @@ function ChatBubble({
           <MarkdownRenderer content={message.content} className="prose-xs" />
         )}
       </div>
-    </div>
-  );
-}
-
-function toolIcon(tool: string) {
-  if (tool === "kb_search") return <MagnifyingGlassIcon className="size-3" />;
-  if (tool === "web_search") return <GlobeAltIcon className="size-3" />;
-  return <DocumentTextIcon className="size-3" />;
-}
-
-function ToolIndicator({
-  event,
-}: {
-  event: { tool: string; type: string; content: string };
-}) {
-  const t = useTranslations("docs");
-
-  let label: string;
-  if (event.type === "call") {
-    if (event.tool === "kb_search") label = t("agentToolSearching", { query: event.content });
-    else if (event.tool === "web_search") label = t("agentToolWebSearching", { query: event.content });
-    else label = t("agentToolReading", { path: event.content });
-  } else {
-    if (event.tool === "kb_search") label = t("agentToolFound", { count: event.content });
-    else if (event.tool === "web_search") label = t("agentToolWebSearched");
-    else label = t("agentToolRead", { path: event.content });
-  }
-
-  return (
-    <div className="mb-1.5 flex items-center gap-1.5 rounded bg-amber-50 px-2 py-1 text-[10px] text-amber-700 dark:bg-amber-950 dark:text-amber-300">
-      {toolIcon(event.tool)}
-      <span className="truncate">{label}</span>
-    </div>
-  );
-}
-
-function ToolMessage({
-  message,
-}: {
-  message: { role: string; content: string; toolName?: string; toolInput?: string };
-}) {
-  const t = useTranslations("docs");
-  const tool = message.toolName ?? "kb_search";
-  const isCall = message.role === "tool_call";
-
-  let label: string;
-  if (isCall) {
-    const input = message.toolInput ?? "";
-    if (tool === "kb_search") label = t("agentToolSearching", { query: input });
-    else if (tool === "web_search") label = t("agentToolWebSearching", { query: input });
-    else label = t("agentToolReading", { path: input });
-  } else {
-    if (tool === "kb_search") label = t("agentToolFound", { count: message.content });
-    else if (tool === "web_search") label = t("agentToolWebSearched");
-    else label = t("agentToolRead", { path: message.content });
-  }
-
-  return (
-    <div className="mb-1.5 flex items-center gap-1.5 rounded bg-amber-50 px-2 py-1 text-[10px] text-amber-700 dark:bg-amber-950 dark:text-amber-300">
-      {toolIcon(tool)}
-      <span className="truncate">{label}</span>
     </div>
   );
 }

--- a/web/components/domain/tool-card.tsx
+++ b/web/components/domain/tool-card.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  MagnifyingGlassIcon,
+  DocumentTextIcon,
+  GlobeAltIcon,
+  ChevronDownIcon,
+} from "@heroicons/react/20/solid";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import type { ToolResultMeta } from "@/components/domain/agent-chat-context";
+
+type ToolCardProps = {
+  tool: string;
+  callContent: string;
+  result?: { content: string; meta?: ToolResultMeta };
+};
+
+function ToolCard({ tool, callContent, result }: ToolCardProps) {
+  const t = useTranslations("docs");
+  const [expanded, setExpanded] = useState(false);
+  const inflight = !result;
+  const meta = result?.meta;
+  const hasExpandableContent =
+    (meta?.matchedDocs && meta.matchedDocs.length > 0) ||
+    (meta?.webSources && meta.webSources.length > 0);
+
+  return (
+    <div
+      className={cn(
+        "mb-2 rounded-xl border px-3 py-2",
+        "border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900",
+        inflight && "animate-pulse",
+      )}
+    >
+      {/* Header row */}
+      <div className="flex items-center gap-2">
+        {/* Icon */}
+        <span className="flex-shrink-0 text-slate-400 dark:text-slate-500">
+          {inflight ? <Spinner /> : toolIcon(tool)}
+        </span>
+
+        {/* Tool label */}
+        <span className="text-[11px] font-medium text-slate-700 dark:text-slate-300">
+          {toolLabel(t, tool)}
+        </span>
+
+        {/* Query/path text */}
+        <span className="min-w-0 flex-1 truncate text-[11px] text-slate-500 dark:text-slate-400">
+          {callContent}
+        </span>
+
+        {/* Metadata badges */}
+        {meta && (
+          <div className="flex flex-shrink-0 items-center gap-1">
+            <MetaBadges t={t} tool={tool} meta={meta} />
+          </div>
+        )}
+
+        {/* Expand chevron */}
+        {hasExpandableContent && (
+          <button
+            type="button"
+            onClick={() => setExpanded(!expanded)}
+            className="flex-shrink-0 rounded p-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-300"
+          >
+            <ChevronDownIcon
+              className={cn(
+                "size-3.5 transition-transform duration-200",
+                expanded && "rotate-180",
+              )}
+            />
+          </button>
+        )}
+      </div>
+
+      {/* Expandable detail section */}
+      {hasExpandableContent && (
+        <div
+          className={cn(
+            "grid transition-all duration-200 motion-safe:transition-all",
+            expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+          )}
+        >
+          <div className="overflow-hidden">
+            <div className="pt-2">
+              {meta?.matchedDocs && meta.matchedDocs.length > 0 && (
+                <ul className="space-y-0.5">
+                  {meta.matchedDocs.map((doc) => (
+                    <li key={doc.path} className="flex items-center gap-1.5">
+                      <a
+                        href={`/docs${doc.path}`}
+                        className="min-w-0 truncate text-[10px] text-primary-600 hover:underline dark:text-primary-400"
+                      >
+                        {doc.title}
+                      </a>
+                      <span className="flex-shrink-0 text-[9px] text-slate-400">
+                        {(doc.score * 100).toFixed(0)}%
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {meta?.webSources && meta.webSources.length > 0 && (
+                <ul className="space-y-0.5">
+                  {meta.webSources.map((src) => (
+                    <li key={src.url}>
+                      <a
+                        href={src.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="truncate text-[10px] text-primary-600 hover:underline dark:text-primary-400"
+                      >
+                        {src.title}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Spinner() {
+  return (
+    <svg
+      className="size-3.5 animate-spin text-slate-400"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+      />
+    </svg>
+  );
+}
+
+function toolIcon(tool: string) {
+  if (tool === "kb_search")
+    return <MagnifyingGlassIcon className="size-3.5" />;
+  if (tool === "web_search") return <GlobeAltIcon className="size-3.5" />;
+  return <DocumentTextIcon className="size-3.5" />;
+}
+
+function toolLabel(
+  t: ReturnType<typeof useTranslations<"docs">>,
+  tool: string,
+) {
+  if (tool === "kb_search") return t("agentToolKbSearch");
+  if (tool === "web_search") return t("agentToolWebSearch");
+  return t("agentToolReadDoc");
+}
+
+function MetaBadges({
+  t,
+  tool,
+  meta,
+}: {
+  t: ReturnType<typeof useTranslations<"docs">>;
+  tool: string;
+  meta: ToolResultMeta;
+}) {
+  return (
+    <>
+      {tool === "kb_search" && meta.resultCount != null && (
+        <Badge variant="subtle" size="sm">
+          {t("agentToolDocs", { count: meta.resultCount })}
+        </Badge>
+      )}
+      {tool === "kb_search" && meta.chunkCount != null && (
+        <Badge variant="subtle" size="sm">
+          {t("agentToolChunks", { count: meta.chunkCount })}
+        </Badge>
+      )}
+      {tool === "read_document" && meta.documentTitle && (
+        <Badge variant="subtle" size="sm">
+          {meta.documentTitle}
+        </Badge>
+      )}
+      {tool === "read_document" && meta.contentLength != null && (
+        <Badge variant="subtle" size="sm">
+          {t("agentToolSize", {
+            size: Math.round(meta.contentLength / 1024),
+          })}
+        </Badge>
+      )}
+      {tool === "web_search" && meta.webResultCount != null && (
+        <Badge variant="subtle" size="sm">
+          {t("agentToolWebResults", { count: meta.webResultCount })}
+        </Badge>
+      )}
+      {tool === "read_document" &&
+        !meta.documentTitle &&
+        !meta.contentLength && (
+          <Badge variant="warning" size="sm">
+            {t("agentToolNotFound")}
+          </Badge>
+        )}
+      <Badge variant="subtle" size="sm">
+        {t("agentToolDuration", { ms: meta.durationMs })}
+      </Badge>
+    </>
+  );
+}
+
+export { ToolCard };
+export type { ToolCardProps };

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -105,7 +105,16 @@
     "agentToolFound": "{count} gefunden",
     "agentToolRead": "Gelesen: {path}",
     "agentToolWebSearching": "Websuche: {query}",
-    "agentToolWebSearched": "Websuche abgeschlossen"
+    "agentToolWebSearched": "Websuche abgeschlossen",
+    "agentToolKbSearch": "Wissenssuche",
+    "agentToolReadDoc": "Dokument gelesen",
+    "agentToolWebSearch": "Websuche",
+    "agentToolDocs": "{count} {count, plural, one {Dokument} other {Dokumente}}",
+    "agentToolChunks": "{count} {count, plural, one {Abschnitt} other {Abschnitte}}",
+    "agentToolDuration": "{ms}ms",
+    "agentToolSize": "{size}KB",
+    "agentToolWebResults": "{count} {count, plural, one {Ergebnis} other {Ergebnisse}}",
+    "agentToolNotFound": "Nicht gefunden"
   },
   "dnd": {
     "dropFilesHere": ".md-Dateien hier ablegen",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -105,7 +105,16 @@
     "agentToolFound": "Found {count}",
     "agentToolRead": "Read: {path}",
     "agentToolWebSearching": "Searching web: {query}",
-    "agentToolWebSearched": "Web search complete"
+    "agentToolWebSearched": "Web search complete",
+    "agentToolKbSearch": "Knowledge Search",
+    "agentToolReadDoc": "Document Read",
+    "agentToolWebSearch": "Web Search",
+    "agentToolDocs": "{count} {count, plural, one {doc} other {docs}}",
+    "agentToolChunks": "{count} {count, plural, one {chunk} other {chunks}}",
+    "agentToolDuration": "{ms}ms",
+    "agentToolSize": "{size}KB",
+    "agentToolWebResults": "{count} {count, plural, one {result} other {results}}",
+    "agentToolNotFound": "Not found"
   },
   "dnd": {
     "dropFilesHere": "Drop .md files here",


### PR DESCRIPTION
## Summary

- **Backend**: Add `ToolResultMeta` with timing, matched docs, web sources. Each tool in `executeTool` now emits structured metadata alongside SSE events. Tavily returns raw results for structured extraction. `tool_meta` stored as JSON in DB.
- **GraphQL**: New `ToolResultMeta`, `ToolDocRef`, `ToolWebRef` types exposed on `ChatMessage.toolMeta`
- **Frontend state**: Replace flat `toolEvents[]` with paired `toolExecutions[]` — each execution tracks a tool call + its optional result with metadata
- **ToolCard component**: Replaces `ToolIndicator`/`ToolMessage` — shows spinner while inflight, metadata badges (doc count, chunks, duration, size) when complete, expandable matched doc/web source list
- **i18n**: New keys for tool labels and metadata badges (EN + DE)

## Test plan

- [ ] `just build-all` — Go compiles
- [ ] `just test` — Go unit tests pass
- [ ] `just web-lint` — TypeScript + ESLint clean
- [ ] `just web-test` — web unit tests pass
- [ ] Manual: send chat query, verify spinner → completed card transition
- [ ] Manual: reload page, verify persisted messages render as completed ToolCards

🤖 Generated with [Claude Code](https://claude.com/claude-code)