### PR TITLE
Optimize WebDAV efficiency with content_length and lightweight queries

### DIFF
--- a/internal/db/queries_document.go
+++ b/internal/db/queries_document.go
@@ -22,6 +22,7 @@ func (c *Client) CreateDocument(ctx context.Context, input models.DocumentInput)
 			title = $title,
 			content = $content,
 			content_body = $content_body,
+			content_length = $content_length,
 			labels = $labels,
 			doc_type = $doc_type,
 			source = $source,
@@ -31,17 +32,18 @@ func (c *Client) CreateDocument(ctx context.Context, input models.DocumentInput)
 		RETURN AFTER
 	`
 	results, err := surrealdb.Query[[]models.Document](ctx, c.DB(), sql, map[string]any{
-		"vault_id":     bareID("vault", input.VaultID),
-		"path":         input.Path,
-		"title":        input.Title,
-		"content":      input.Content,
-		"content_body": input.ContentBody,
-		"labels":       labels,
-		"doc_type":     optionalString(input.DocType),
-		"source":       string(input.Source),
-		"source_path":  optionalString(input.SourcePath),
-		"content_hash": optionalString(input.ContentHash),
-		"metadata":     optionalObject(input.Metadata),
+		"vault_id":       bareID("vault", input.VaultID),
+		"path":           input.Path,
+		"title":          input.Title,
+		"content":        input.Content,
+		"content_body":   input.ContentBody,
+		"content_length": len(input.Content),
+		"labels":         labels,
+		"doc_type":       optionalString(input.DocType),
+		"source":         string(input.Source),
+		"source_path":    optionalString(input.SourcePath),
+		"content_hash":   optionalString(input.ContentHash),
+		"metadata":       optionalObject(input.Metadata),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create document: %w", err)
@@ -90,9 +92,11 @@ type ListDocumentsFilter struct {
 	Offset  int
 }
 
-func (c *Client) ListDocuments(ctx context.Context, filter ListDocumentsFilter) ([]models.Document, error) {
+// buildDocumentFilter constructs the WHERE clause, variables, and pagination
+// suffix shared by ListDocuments and ListDocumentMetas.
+func buildDocumentFilter(filter ListDocumentsFilter) (whereClause string, vars map[string]any, suffix string) {
 	var conditions []string
-	vars := map[string]any{
+	vars = map[string]any{
 		"vault_id": bareID("vault", filter.VaultID),
 	}
 
@@ -116,8 +120,14 @@ func (c *Client) ListDocuments(ctx context.Context, filter ListDocumentsFilter) 
 		limit = filter.Limit
 	}
 
-	sql := fmt.Sprintf("SELECT * FROM document WHERE %s ORDER BY path ASC LIMIT %d START %d",
-		strings.Join(conditions, " AND "), limit, filter.Offset)
+	whereClause = strings.Join(conditions, " AND ")
+	suffix = fmt.Sprintf("ORDER BY path ASC LIMIT %d START %d", limit, filter.Offset)
+	return
+}
+
+func (c *Client) ListDocuments(ctx context.Context, filter ListDocumentsFilter) ([]models.Document, error) {
+	where, vars, suffix := buildDocumentFilter(filter)
+	sql := fmt.Sprintf("SELECT * FROM document WHERE %s %s", where, suffix)
 
 	results, err := surrealdb.Query[[]models.Document](ctx, c.DB(), sql, vars)
 	if err != nil {
@@ -138,6 +148,7 @@ func (c *Client) UpdateDocument(ctx context.Context, id string, content, content
 		UPDATE type::record("document", $id) SET
 			content = $content,
 			content_body = $content_body,
+			content_length = $content_length,
 			title = $title,
 			source = $source,
 			labels = $labels,
@@ -146,14 +157,15 @@ func (c *Client) UpdateDocument(ctx context.Context, id string, content, content
 		RETURN AFTER
 	`
 	results, err := surrealdb.Query[[]models.Document](ctx, c.DB(), sql, map[string]any{
-		"id":           id,
-		"content":      content,
-		"content_body": contentBody,
-		"title":        title,
-		"source":       string(source),
-		"labels":       labels,
-		"content_hash": optionalString(contentHash),
-		"metadata":     optionalObject(metadata),
+		"id":             id,
+		"content":        content,
+		"content_body":   contentBody,
+		"content_length": len(content),
+		"title":          title,
+		"source":         string(source),
+		"labels":         labels,
+		"content_hash":   optionalString(contentHash),
+		"metadata":       optionalObject(metadata),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("update document: %w", err)
@@ -251,6 +263,38 @@ func (c *Client) ListLabels(ctx context.Context, vaultID string) ([]string, erro
 		return []string{}, nil
 	}
 	return labels, nil
+}
+
+// GetDocumentMetaByPath returns lightweight metadata for a document (no content).
+// Returns nil if the document doesn't exist.
+func (c *Client) GetDocumentMetaByPath(ctx context.Context, vaultID, path string) (*models.DocumentMeta, error) {
+	sql := `SELECT path, content_length, updated_at FROM document WHERE vault = type::record("vault", $vault_id) AND path = $path LIMIT 1`
+	results, err := surrealdb.Query[[]models.DocumentMeta](ctx, c.DB(), sql, map[string]any{
+		"vault_id": bareID("vault", vaultID),
+		"path":     path,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get document meta by path: %w", err)
+	}
+	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
+		return nil, nil
+	}
+	return &(*results)[0].Result[0], nil
+}
+
+// ListDocumentMetas returns lightweight metadata (no content) for documents matching the filter.
+func (c *Client) ListDocumentMetas(ctx context.Context, filter ListDocumentsFilter) ([]models.DocumentMeta, error) {
+	where, vars, suffix := buildDocumentFilter(filter)
+	sql := fmt.Sprintf("SELECT path, content_length, updated_at FROM document WHERE %s %s", where, suffix)
+
+	results, err := surrealdb.Query[[]models.DocumentMeta](ctx, c.DB(), sql, vars)
+	if err != nil {
+		return nil, fmt.Errorf("list document metas: %w", err)
+	}
+	if results == nil || len(*results) == 0 {
+		return nil, nil
+	}
+	return (*results)[0].Result, nil
 }
 
 // UpsertDocument creates or updates a document by vault+path.

--- a/internal/db/queries_folder.go
+++ b/internal/db/queries_folder.go
@@ -99,6 +99,38 @@ func (c *Client) ListFolders(ctx context.Context, vaultID string) ([]models.Fold
 	return (*results)[0].Result, nil
 }
 
+// ListChildFolders returns immediate child folders of parentPath in a vault.
+// Only folders whose path starts with parentPath+"/" are fetched from the DB,
+// then filtered in Go to exclude nested descendants (much faster than loading all folders).
+func (c *Client) ListChildFolders(ctx context.Context, vaultID, parentPath string) ([]models.Folder, error) {
+	prefix := parentPath
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	sql := `SELECT * FROM folder WHERE vault = type::record("vault", $vault_id) AND string::starts_with(path, $prefix) ORDER BY path ASC`
+	results, err := surrealdb.Query[[]models.Folder](ctx, c.DB(), sql, map[string]any{
+		"vault_id": bareID("vault", vaultID),
+		"prefix":   prefix,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list child folders: %w", err)
+	}
+	if results == nil || len(*results) == 0 {
+		return nil, nil
+	}
+
+	// Filter to immediate children only (no additional "/" after prefix)
+	var children []models.Folder
+	for _, f := range (*results)[0].Result {
+		rel := strings.TrimPrefix(f.Path, prefix)
+		if rel != "" && !strings.Contains(rel, "/") {
+			children = append(children, f)
+		}
+	}
+	return children, nil
+}
+
 // GetFolderByPath returns a single folder by vault and path, or nil if not found.
 func (c *Client) GetFolderByPath(ctx context.Context, vaultID, folderPath string) (*models.Folder, error) {
 	sql := `SELECT * FROM folder WHERE vault = type::record("vault", $vault_id) AND path = $path LIMIT 1`

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -46,7 +46,8 @@ func SchemaSQL(dimension int) string {
     DEFINE FIELD IF NOT EXISTS path         ON document TYPE string;
     DEFINE FIELD IF NOT EXISTS title        ON document TYPE string;
     DEFINE FIELD IF NOT EXISTS content      ON document TYPE string;
-    DEFINE FIELD IF NOT EXISTS content_body ON document TYPE string;
+    DEFINE FIELD IF NOT EXISTS content_body    ON document TYPE string;
+    DEFINE FIELD IF NOT EXISTS content_length  ON document TYPE int;
     DEFINE FIELD IF NOT EXISTS labels       ON document TYPE array<string> DEFAULT [];
     DEFINE FIELD IF NOT EXISTS doc_type     ON document TYPE option<string>;
     DEFINE FIELD IF NOT EXISTS source       ON document TYPE string DEFAULT "manual";

--- a/internal/models/document.go
+++ b/internal/models/document.go
@@ -26,20 +26,21 @@ func (s DocumentSource) Valid() bool {
 }
 
 type Document struct {
-	ID          surrealmodels.RecordID `json:"id"`
-	Vault       surrealmodels.RecordID `json:"vault"`
-	Path        string                 `json:"path"`
-	Title       string                 `json:"title"`
-	Content     string                 `json:"content"`
-	ContentBody string                 `json:"content_body"`
-	Labels      []string               `json:"labels"`
-	DocType     *string                `json:"doc_type,omitempty"`
-	Source      DocumentSource         `json:"source"`
-	SourcePath  *string                `json:"source_path,omitempty"`
-	ContentHash *string                `json:"content_hash,omitempty"`
-	Metadata    map[string]any         `json:"metadata,omitempty"`
-	CreatedAt   time.Time              `json:"created_at"`
-	UpdatedAt   time.Time              `json:"updated_at"`
+	ID            surrealmodels.RecordID `json:"id"`
+	Vault         surrealmodels.RecordID `json:"vault"`
+	Path          string                 `json:"path"`
+	Title         string                 `json:"title"`
+	Content       string                 `json:"content"`
+	ContentBody   string                 `json:"content_body"`
+	ContentLength int                    `json:"content_length"`
+	Labels        []string               `json:"labels"`
+	DocType       *string                `json:"doc_type,omitempty"`
+	Source        DocumentSource         `json:"source"`
+	SourcePath    *string                `json:"source_path,omitempty"`
+	ContentHash   *string                `json:"content_hash,omitempty"`
+	Metadata      map[string]any         `json:"metadata,omitempty"`
+	CreatedAt     time.Time              `json:"created_at"`
+	UpdatedAt     time.Time              `json:"updated_at"`
 }
 
 type DocumentInput struct {
@@ -54,6 +55,14 @@ type DocumentInput struct {
 	Labels      []string       `json:"labels,omitempty"`
 	DocType     *string        `json:"doc_type,omitempty"`
 	Metadata    map[string]any `json:"metadata,omitempty"`
+}
+
+// DocumentMeta is a lightweight projection of a document for metadata-only
+// operations (e.g. WebDAV Stat, directory listings) that don't need content.
+type DocumentMeta struct {
+	Path          string    `json:"path"`
+	ContentLength int       `json:"content_length"`
+	UpdatedAt     time.Time `json:"updated_at"`
 }
 
 // Folder is a first-class folder record backed by the folder table.

--- a/internal/vault/service.go
+++ b/internal/vault/service.go
@@ -3,7 +3,6 @@ package vault
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/raphi011/knowhow/internal/db"
 	"github.com/raphi011/knowhow/internal/models"
@@ -39,36 +38,23 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 	return s.db.DeleteVault(ctx, id)
 }
 
-// ListFolders returns all folders in a vault. If parentPath is provided, filters
-// to immediate children of that path.
+// ListFolders returns all folders in a vault. If parentPath is provided, returns
+// only immediate children of that path using a DB-level prefix filter (avoids
+// loading all folders in the vault).
 func (s *Service) ListFolders(ctx context.Context, vaultID string, parentPath *string) ([]models.Folder, error) {
+	if parentPath != nil {
+		folders, err := s.db.ListChildFolders(ctx, vaultID, *parentPath)
+		if err != nil {
+			return nil, fmt.Errorf("list child folders: %w", err)
+		}
+		return folders, nil
+	}
+
 	folders, err := s.db.ListFolders(ctx, vaultID)
 	if err != nil {
 		return nil, fmt.Errorf("list folders: %w", err)
 	}
-
-	if parentPath == nil {
-		return folders, nil
-	}
-
-	// Filter to immediate children of parentPath
-	prefix := *parentPath
-	if !strings.HasSuffix(prefix, "/") {
-		prefix += "/"
-	}
-
-	var filtered []models.Folder
-	for _, f := range folders {
-		if !strings.HasPrefix(f.Path, prefix) {
-			continue
-		}
-		// Check it's an immediate child (no further "/" after prefix)
-		rel := strings.TrimPrefix(f.Path, prefix)
-		if rel != "" && !strings.Contains(rel, "/") {
-			filtered = append(filtered, f)
-		}
-	}
-	return filtered, nil
+	return folders, nil
 }
 
 // CreateFolder creates a folder and all its ancestor folders.

--- a/internal/webdav/fs.go
+++ b/internal/webdav/fs.go
@@ -155,16 +155,16 @@ func (f *FS) Stat(ctx context.Context, name string) (os.FileInfo, error) {
 		return &fileInfo{name: "/", isDir: true, modTime: time.Now()}, nil
 	}
 
-	// Try as document
-	doc, err := f.db.GetDocumentByPath(ctx, f.vaultID, name)
+	// Try as document (lightweight meta query — no content loaded)
+	meta, err := f.db.GetDocumentMetaByPath(ctx, f.vaultID, name)
 	if err != nil {
 		return nil, fmt.Errorf("stat %s: %w", name, err)
 	}
-	if doc != nil {
+	if meta != nil {
 		return &fileInfo{
 			name:    path.Base(name),
-			size:    int64(len(doc.Content)),
-			modTime: doc.UpdatedAt,
+			size:    int64(meta.ContentLength),
+			modTime: meta.UpdatedAt,
 			isDir:   false,
 		}, nil
 	}
@@ -220,13 +220,14 @@ func (f *FS) listDirEntries(ctx context.Context, dirPath string) ([]os.FileInfo,
 		})
 	}
 
-	// List immediate child documents — append "/" for non-root paths so the
-	// DB filter matches documents under this folder (root already ends with "/").
+	// Append "/" for non-root paths so the DB filter matches documents under
+	// this folder (root already ends with "/").
 	folderFilter := dirPath
 	if folderFilter != "/" {
 		folderFilter += "/"
 	}
-	docs, err := f.db.ListDocuments(ctx, db.ListDocumentsFilter{
+	// List immediate child documents (lightweight meta query — no content loaded)
+	metas, err := f.db.ListDocumentMetas(ctx, db.ListDocumentsFilter{
 		VaultID: f.vaultID,
 		Folder:  &folderFilter,
 		Limit:   10000,
@@ -234,19 +235,19 @@ func (f *FS) listDirEntries(ctx context.Context, dirPath string) ([]os.FileInfo,
 	if err != nil {
 		return nil, fmt.Errorf("list documents in %s: %w", dirPath, err)
 	}
-	for _, doc := range docs {
+	for _, meta := range metas {
 		// Only include immediate children, not nested docs
-		rel := strings.TrimPrefix(doc.Path, folderFilter)
+		rel := strings.TrimPrefix(meta.Path, folderFilter)
 		if dirPath == "/" {
-			rel = strings.TrimPrefix(doc.Path, "/")
+			rel = strings.TrimPrefix(meta.Path, "/")
 		}
 		if strings.Contains(rel, "/") {
 			continue // nested doc, skip
 		}
 		entries = append(entries, &fileInfo{
-			name:    path.Base(doc.Path),
-			size:    int64(len(doc.Content)),
-			modTime: doc.UpdatedAt,
+			name:    path.Base(meta.Path),
+			size:    int64(meta.ContentLength),
+			modTime: meta.UpdatedAt,
 			isDir:   false,
 		})
 	}


### PR DESCRIPTION
WebDAV Stat() and directory listings were loading full document content
(SELECT *) just to compute file sizes via len(doc.Content). Similarly,
listing child folders loaded ALL vault folders then filtered in Go.

- Add content_length field to document table, set on CREATE/UPDATE
- Add DocumentMeta lightweight model (path, content_length, updated_at)
- Add GetDocumentMetaByPath and ListDocumentMetas DB queries that
  SELECT only metadata columns, avoiding content transfer
- Add ListChildFolders DB query with prefix-scoped WHERE clause,
  replacing the previous pattern of loading all vault folders
- Update WebDAV Stat() to use GetDocumentMetaByPath
- Update WebDAV listDirEntries() to use ListDocumentMetas
- Update vault.Service.ListFolders() to delegate to ListChildFolders

https://claude.ai/code/session_01SVU6xVPK5ieemcD4R5wQi8