### PR TITLE
feat: harden WebDAV with ETag, content-type, and security limits

### DIFF
--- a/cmd/knowhow-server/main.go
+++ b/cmd/knowhow-server/main.go
@@ -130,6 +130,7 @@ func main() {
 		resolver.DocumentService(),
 		resolver.VaultService(),
 		cfg.NoAuth,
+		10*1024*1024, // 10 MB max PUT body
 	)
 	mux.Handle("/dav/", davHandler)
 	slog.Info("WebDAV endpoint enabled", "path", "/dav/{vaultName}/")

--- a/docs/webdav-go-package.md
+++ b/docs/webdav-go-package.md
@@ -1,0 +1,623 @@
+# Go WebDAV Package Reference (`golang.org/x/net/webdav`)
+
+Technical reference for the Go WebDAV package. Covers API, best practices, performance, security, client quirks, and patterns used in this project.
+
+## Overview
+
+`golang.org/x/net/webdav` provides a DAV Class 1 and 2 compliant WebDAV server. It handles HTTP method dispatch, XML marshalling, property management, and lock coordination — you supply the storage backend via two interfaces: `FileSystem` and `LockSystem`.
+
+**What it does**: PROPFIND, PROPPATCH, MKCOL, GET, HEAD, PUT, DELETE, COPY, MOVE, LOCK, UNLOCK, OPTIONS.
+
+**What it doesn't do**: Authentication, TLS, access control (ACL/RFC 3744), versioning (DeltaV), CalDAV, CardDAV.
+
+## Core Types
+
+### Handler
+
+The main entry point. Implements `http.Handler`.
+
+```go
+type Handler struct {
+    Prefix     string              // URL path prefix to strip (e.g. "/dav/")
+    FileSystem FileSystem          // Required: virtual filesystem
+    LockSystem LockSystem          // Required: lock manager
+    Logger     func(*http.Request, error) // Optional: called for every request
+}
+```
+
+- `Prefix` is stripped from `r.URL.Path` before passing to `FileSystem` methods. If your WebDAV endpoint is at `/dav/files/`, set `Prefix: "/dav/files"`.
+- `Logger` receives `nil` error on success. Useful for structured logging with severity filtering (see project pattern in `handler.go`).
+- Both `FileSystem` and `LockSystem` **must** be set or `ServeHTTP` panics.
+
+### FileSystem
+
+```go
+type FileSystem interface {
+    Mkdir(ctx context.Context, name string, perm os.FileMode) error
+    OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (File, error)
+    RemoveAll(ctx context.Context, name string) error
+    Rename(ctx context.Context, oldName, newName string) error
+    Stat(ctx context.Context, name string) (os.FileInfo, error)
+}
+```
+
+Semantics match the `os` package. Paths are always `/`-separated regardless of OS.
+
+**Error conventions**:
+- Return `os.ErrNotExist` → 404
+- Return `os.ErrPermission` → 403
+- Return `os.ErrExist` → 405 (for Mkdir on existing)
+- Any other error → 500
+
+**Built-in implementations**:
+- `Dir(path)` — wraps a native directory, restricts to subtree
+- `NewMemFS()` — in-memory filesystem (useful for tests)
+
+### File
+
+```go
+type File interface {
+    http.File    // Read, Seek, Readdir, Stat, Close
+    io.Writer    // Write
+}
+```
+
+`http.File` embeds `io.Reader`, `io.Seeker`, `io.Closer` + `Readdir` + `Stat`. Adding `io.Writer` means every File must have a `Write` method — return `os.ErrPermission` for read-only files.
+
+**Readdir contract**:
+- `count <= 0`: return all remaining entries, `nil` error (or underlying error)
+- `count > 0`: return up to `count` entries. Return `io.EOF` when no more entries remain. The handler calls Readdir repeatedly to paginate.
+
+### LockSystem
+
+```go
+type LockSystem interface {
+    Confirm(now time.Time, name0, name1 string, conditions ...Condition) (release func(), err error)
+    Create(now time.Time, details LockDetails) (token string, err error)
+    Refresh(now time.Time, token string, duration time.Duration) (LockDetails, error)
+    Unlock(now time.Time, token string) error
+}
+```
+
+**`Confirm`** is called on every state-changing request. It validates that submitted lock tokens match. Returns a `release` func that must be called when the request finishes (the handler defers it). Two resource names support COPY/MOVE (source + destination).
+
+**`Create`** returns an opaque token (must be an absolute URI per RFC 3986 §4.3). `NewMemLS()` generates `urn:uuid:...` tokens.
+
+**Error → HTTP status mapping**:
+| Error | Status |
+|---|---|
+| `ErrConfirmationFailed` | Try next condition set |
+| `ErrLocked` | 423 Locked |
+| `ErrNoSuchLock` | 412 Precondition Failed |
+| `ErrForbidden` | 403 Forbidden |
+| Other non-nil error | 500 Internal Server Error |
+
+### LockDetails
+
+```go
+type LockDetails struct {
+    Root      string        // Resource being locked
+    Duration  time.Duration // Negative = infinite
+    OwnerXML  string        // Verbatim <owner> XML from LOCK request
+    ZeroDepth bool          // true = zero depth, false = infinite depth
+}
+```
+
+### Dir
+
+```go
+type Dir string // e.g. Dir("/var/webdav")
+```
+
+A `FileSystem` backed by the native filesystem, restricted to the given directory tree. Empty string means current directory. Handles path sanitization to prevent traversal.
+
+### Optional Interfaces
+
+These are checked on `os.FileInfo` objects returned by `Stat()`:
+
+**`ContentTyper`** — Override MIME type detection:
+```go
+type ContentTyper interface {
+    ContentType(ctx context.Context) (string, error)
+}
+```
+If not implemented, the handler opens the file and sniffs the first 512 bytes via `http.DetectContentType`. Return `ErrNotImplemented` to fall back to sniffing.
+
+**`ETager`** — Override ETag generation:
+```go
+type ETager interface {
+    ETag(ctx context.Context) (string, error)
+}
+```
+If not implemented, ETag is computed from `ModTime()` and `Size()`. Return `ErrNotImplemented` to use default.
+
+**`DeadPropsHolder`** — Store custom (dead) properties:
+```go
+type DeadPropsHolder interface {
+    DeadProps() (map[xml.Name]Property, error)
+    Patch([]Proppatch) ([]Propstat, error)
+}
+```
+Dead properties are user-defined XML properties (as opposed to "live" properties like `getcontentlength` which the server computes). Without this interface, PROPPATCH on custom properties returns 403.
+
+### Constants and Sentinel Errors
+
+```go
+// HTTP status codes from RFC 4918
+const (
+    StatusMulti               = 207 // Multi-Status
+    StatusUnprocessableEntity = 422
+    StatusLocked              = 423
+    StatusFailedDependency    = 424
+    StatusInsufficientStorage = 507
+)
+
+// LockSystem errors
+var (
+    ErrConfirmationFailed = errors.New("webdav: confirmation failed")
+    ErrForbidden          = errors.New("webdav: forbidden")
+    ErrLocked             = errors.New("webdav: locked")
+    ErrNoSuchLock         = errors.New("webdav: no such lock")
+)
+
+// Optional interface fallback
+var ErrNotImplemented = errors.New("not implemented")
+```
+
+## Handler Configuration
+
+### Routing
+
+The `Handler` dispatches based on HTTP method. Typical setup:
+
+```go
+mux := http.NewServeMux()
+mux.Handle("/dav/", &webdav.Handler{
+    Prefix:     "/dav",
+    FileSystem: webdav.Dir("/var/webdav"),
+    LockSystem: webdav.NewMemLS(),
+})
+```
+
+**Important**: The prefix should NOT include a trailing slash. The handler strips `Prefix` from `r.URL.Path`, so `/dav/file.txt` becomes `/file.txt`.
+
+### Method Dispatch
+
+| Method | FileSystem calls | Notes |
+|---|---|---|
+| OPTIONS | — | Returns Allow header + DAV compliance classes |
+| GET/HEAD | OpenFile (read) | Serves file content via `http.ServeContent` |
+| PUT | OpenFile (write) | Creates/overwrites file |
+| DELETE | RemoveAll | Recursive for directories |
+| MKCOL | Mkdir | Only creates one level |
+| COPY | Stat + OpenFile (read) + OpenFile (write) | Recursive for directories |
+| MOVE | Rename (or copy+delete fallback) | |
+| PROPFIND | Stat + OpenFile (for Readdir) | Depth 0, 1, or infinity |
+| PROPPATCH | Stat | Modifies dead properties |
+| LOCK | LockSystem.Create | |
+| UNLOCK | LockSystem.Unlock | |
+
+## Implementing FileSystem
+
+### Path Rules
+
+- Always `/`-separated, always start with `/`
+- The handler passes cleaned paths (no `..`, no double slashes)
+- Root is `/`
+
+### Error Mapping
+
+Use `os` sentinel errors for proper HTTP status codes:
+
+```go
+func (fs *MyFS) Stat(ctx context.Context, name string) (os.FileInfo, error) {
+    item, err := fs.db.Get(ctx, name)
+    if err != nil {
+        return nil, fmt.Errorf("stat %s: %w", name, err) // → 500
+    }
+    if item == nil {
+        return nil, os.ErrNotExist // → 404
+    }
+    return itemToFileInfo(item), nil
+}
+```
+
+### OpenFile Flags
+
+The `flag` parameter uses `os` constants:
+- `os.O_RDONLY` (0) — GET, PROPFIND
+- `os.O_RDWR | os.O_CREATE | os.O_TRUNC` — PUT (create/overwrite)
+- `os.O_RDWR | os.O_CREATE` — PUT (conditional create with If-None-Match)
+
+Your implementation should inspect these flags to decide read vs write mode.
+
+## Implementing File
+
+### Minimum Viable File
+
+A read-only file backed by `bytes.Reader`:
+
+```go
+type readOnlyFile struct {
+    name    string
+    content []byte
+    reader  *bytes.Reader
+    modTime time.Time
+}
+
+func (f *readOnlyFile) Read(p []byte) (int, error)  { return f.reader.Read(p) }
+func (f *readOnlyFile) Seek(o int64, w int) (int64, error) { return f.reader.Seek(o, w) }
+func (f *readOnlyFile) Write([]byte) (int, error)   { return 0, os.ErrPermission }
+func (f *readOnlyFile) Close() error                 { return nil }
+func (f *readOnlyFile) Readdir(int) ([]os.FileInfo, error) { return nil, os.ErrInvalid }
+func (f *readOnlyFile) Stat() (os.FileInfo, error) {
+    return &fileInfo{name: f.name, size: int64(len(f.content)), modTime: f.modTime}, nil
+}
+```
+
+### Write-on-Close Pattern
+
+Buffer writes in memory, then persist on `Close()`. This is the pattern used in this project:
+
+```go
+func (f *writeFile) Write(p []byte) (int, error) {
+    f.written = true
+    return f.buf.Write(p)
+}
+
+func (f *writeFile) Close() error {
+    if !f.written {
+        return nil // No data → no-op
+    }
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
+    _, err := f.docService.Create(ctx, ...)
+    return err
+}
+```
+
+**Why buffer + Close()**: The WebDAV handler calls `Write()` potentially many times during a PUT. You don't want to hit the database on every chunk. Flushing on `Close()` gives you the complete content in one shot.
+
+**Caveat**: `Close()` errors are logged by the handler's Logger but cannot change the HTTP status code — the response headers are already sent by the time the file is closed. This is a known limitation.
+
+### Readdir Behavior
+
+The handler calls `Readdir` for PROPFIND with Depth > 0:
+
+```go
+func (d *dirFile) Readdir(count int) ([]os.FileInfo, error) {
+    if count <= 0 {
+        // Return all remaining entries
+        entries := d.entries[d.pos:]
+        d.pos = len(d.entries)
+        return entries, nil
+    }
+    // Return up to count entries, io.EOF at end
+    if d.pos >= len(d.entries) {
+        return nil, io.EOF
+    }
+    end := min(d.pos+count, len(d.entries))
+    entries := d.entries[d.pos:end]
+    d.pos = end
+    if d.pos >= len(d.entries) {
+        return entries, io.EOF
+    }
+    return entries, nil
+}
+```
+
+**Key detail**: When returning the last batch with `count > 0`, return both the entries AND `io.EOF` in the same call. Some implementations incorrectly return entries with nil error, then EOF on the next call — this works but causes an extra round-trip.
+
+## Lock System
+
+### MemLS
+
+`NewMemLS()` provides an in-memory lock system. Suitable for single-process deployments. Locks are lost on restart.
+
+Internals:
+- Stores locks in a map keyed by token (UUID URN)
+- Maintains a path→token index for Confirm lookups
+- Handles infinite-depth locks by checking path prefixes
+- Thread-safe (internal mutex)
+
+### Per-Vault Isolation
+
+This project uses one `MemLS` per vault to prevent cross-vault lock interference:
+
+```go
+var lockSystems sync.Map // vaultID → webdav.LockSystem
+
+getLockSystem := func(vaultID string) webdav.LockSystem {
+    if ls, ok := lockSystems.Load(vaultID); ok {
+        return ls.(webdav.LockSystem)
+    }
+    ls, _ := lockSystems.LoadOrStore(vaultID, webdav.NewMemLS())
+    return ls.(webdav.LockSystem)
+}
+```
+
+`LoadOrStore` handles the race where two requests for the same vault arrive simultaneously — only one `MemLS` is created and stored.
+
+### Distributed Lock Systems
+
+For multi-process deployments, implement `LockSystem` backed by a distributed store (Redis, database). Key requirements:
+- Token uniqueness (UUID URNs are sufficient)
+- Atomic Confirm (check + hold must be atomic)
+- TTL expiration for lock cleanup
+- Path-prefix matching for infinite-depth locks
+
+## WebDAV Protocol Coverage
+
+### DAV Compliance Classes
+
+The handler advertises `DAV: 1, 2` in OPTIONS responses:
+- **Class 1**: Basic WebDAV (PROPFIND, PROPPATCH, MKCOL, GET, PUT, DELETE, COPY, MOVE)
+- **Class 2**: Locking support (LOCK, UNLOCK)
+- **Class 3**: Not supported (would require `If` header extensions beyond what's implemented)
+
+### Depth Header
+
+Used by PROPFIND and COPY:
+- `Depth: 0` — target resource only
+- `Depth: 1` — target + immediate children
+- `Depth: infinity` — target + all descendants (PROPFIND only; COPY always recurses)
+
+The handler rejects `Depth: infinity` PROPFIND by default for performance. To allow it, the FileSystem must handle potentially large Readdir results.
+
+### Multi-Status Responses (207)
+
+PROPFIND, PROPPATCH, COPY, MOVE, and DELETE can return 207 Multi-Status with per-resource status. The handler generates the XML automatically from FileSystem/LockSystem return values.
+
+## Performance
+
+### Streaming vs Buffering
+
+- **GET**: The handler uses `http.ServeContent` which supports range requests and `If-Modified-Since`. It calls `Seek` on the File, so `bytes.Reader` works efficiently.
+- **PUT**: The handler reads the request body and writes to the File. For large files, consider implementing `io.ReaderFrom` on your write file to avoid double-buffering.
+- **PROPFIND Depth 1**: Calls `Readdir(-1)` to get all children, then `Stat()` on each. For directories with thousands of entries, this can be slow. Consider caching directory metadata.
+
+### PROPFIND Depth Infinity
+
+Can be expensive for deep trees. The handler walks the entire subtree calling `OpenFile` + `Readdir` at each level. Mitigation:
+- Return `403 Forbidden` for `Depth: infinity` requests on large trees
+- Limit directory depth in your FileSystem implementation
+- Use `Stat` for metadata-only queries (the handler does this for each entry)
+
+### Concurrent Access
+
+- The handler is safe for concurrent use
+- `MemLS` is internally synchronized (mutex)
+- Your `FileSystem` must handle concurrent access — the handler doesn't serialize calls
+- `Confirm` + `release` pattern means locks are held for the duration of the request
+
+### Lightweight Stat
+
+For PROPFIND, the handler calls `Stat()` on every listed resource. Use lightweight metadata queries that don't load file content. This project uses `GetDocumentMetaByPath` (returns content length + timestamps, not content) instead of `GetDocumentByPath`.
+
+## Security
+
+### Authentication
+
+**None built in.** You must implement auth in a wrapper handler or middleware. Common patterns:
+- HTTP Basic Auth (this project's approach — password = API token)
+- Digest Auth (more complex but doesn't send passwords in cleartext)
+- Cookie/session-based (unusual for WebDAV)
+
+Always set `WWW-Authenticate` header on 401 responses so clients prompt for credentials.
+
+### Path Traversal
+
+`Dir` sanitizes paths to prevent escaping the directory root. If implementing a custom `FileSystem`, ensure:
+- `path.Clean()` all input paths
+- Reject or normalize `..` components
+- Never concatenate raw user paths with filesystem paths
+
+This project normalizes all paths through `normalizeName()`:
+```go
+func normalizeName(name string) string {
+    name = path.Clean(name)
+    if name == "." || name == "" {
+        return "/"
+    }
+    if !strings.HasPrefix(name, "/") {
+        name = "/" + name
+    }
+    return name
+}
+```
+
+### TLS
+
+WebDAV over plain HTTP exposes credentials (Basic Auth) and content. Always use TLS in production. The package itself doesn't handle TLS — use `http.ListenAndServeTLS` or a reverse proxy.
+
+### PROPFIND DoS
+
+A `Depth: infinity` PROPFIND on a deep tree can consume significant server resources. Consider:
+- Rejecting `Depth: infinity` requests
+- Rate limiting PROPFIND requests
+- Setting timeouts on context
+
+### CSRF
+
+WebDAV methods (PUT, DELETE, MKCOL, etc.) bypass browser CSRF protections since they're not standard HTML form methods. However, if your WebDAV endpoint shares cookies with a web UI, consider CSRF tokens for non-WebDAV methods. This project uses Origin/Referer checking for the web UI, while WebDAV uses separate Basic Auth.
+
+## Client Quirks
+
+### macOS Finder
+
+- Sends `._*` resource fork files and `.DS_Store` on every file operation
+- Expects `DAV: 1, 2` header on OPTIONS response — without it, Finder won't recognize the server as WebDAV
+- Performs PROPFIND with Depth 0 on the root before mounting
+- May cache aggressively — set proper `ETag` and `Last-Modified` headers
+- **This project's solution**: `nopFile` accepts and silently discards `._*` and `.DS_Store` writes; reads return `os.ErrNotExist`
+
+### Windows Mini-Redirector (Explorer)
+
+- Has a 50MB file size limit by default (registry setting `FileSizeLimitInBytes`)
+- Requires the path to end with `/` for directory browsing
+- May not work with self-signed certificates
+- Sends `Translate: f` header (not standard)
+- Caches heavily — may need server restart to see changes
+
+### Linux Clients
+
+- `cadaver` and `davfs2` are well-behaved
+- GNOME Files (gvfs) works but may issue many redundant PROPFINDs
+- KDE Dolphin uses `kio-webdav`, generally compliant
+
+### curl
+
+Useful for testing:
+```bash
+# List directory
+curl -X PROPFIND -H "Depth: 1" http://localhost:8080/dav/default/ -u :token
+
+# Upload file
+curl -T file.md http://localhost:8080/dav/default/file.md -u :token
+
+# Download file
+curl http://localhost:8080/dav/default/file.md -u :token
+
+# Delete file
+curl -X DELETE http://localhost:8080/dav/default/file.md -u :token
+
+# Create directory
+curl -X MKCOL http://localhost:8080/dav/default/newdir/ -u :token
+```
+
+## Known Issues
+
+### In `golang.org/x/net/webdav`
+
+1. **No built-in Depth infinity limit** — the handler doesn't cap recursion depth for PROPFIND
+2. **Close() errors are swallowed** — when the handler closes a File after PUT, errors from Close() are logged but don't affect the HTTP response (response is already committed)
+3. **No partial PUT (Content-Range)** — the package doesn't support partial uploads
+4. **No DAV Class 3** — extended `If` header conditions aren't fully supported
+5. **Dead property storage is opt-in** — without `DeadPropsHolder`, PROPPATCH returns 403 for custom properties
+
+### General WebDAV Gotchas
+
+- Lock tokens must survive server restarts for reliable editing (MemLS doesn't)
+- COPY/MOVE may trigger multiple FileSystem calls — ensure atomicity if needed
+- Some clients send `Expect: 100-continue` — Go's `net/http` handles this automatically
+
+## Testing Patterns
+
+### Unit Testing with httptest
+
+```go
+func TestWebDAV(t *testing.T) {
+    handler := &webdav.Handler{
+        FileSystem: webdav.NewMemFS(),
+        LockSystem: webdav.NewMemLS(),
+    }
+    srv := httptest.NewServer(handler)
+    defer srv.Close()
+
+    // PUT a file
+    req, _ := http.NewRequest(http.MethodPut, srv.URL+"/test.md", strings.NewReader("# Hello"))
+    resp, _ := http.DefaultClient.Do(req)
+    if resp.StatusCode != http.StatusCreated {
+        t.Fatalf("PUT status = %d, want 201", resp.StatusCode)
+    }
+
+    // GET it back
+    resp, _ = http.Get(srv.URL + "/test.md")
+    body, _ := io.ReadAll(resp.Body)
+    if string(body) != "# Hello" {
+        t.Fatalf("GET body = %q, want %q", body, "# Hello")
+    }
+}
+```
+
+### Testing Custom FileSystem
+
+Mock the FileSystem interface:
+
+```go
+type mockFS struct {
+    webdav.FileSystem
+    openFileFn func(ctx context.Context, name string, flag int, perm os.FileMode) (webdav.File, error)
+}
+
+func (m *mockFS) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (webdav.File, error) {
+    return m.openFileFn(ctx, name, flag, perm)
+}
+```
+
+### Litmus Test Suite
+
+The [litmus WebDAV test suite](http://www.webdav.org/neon/litmus/) is the standard compliance test. Run it against your server:
+
+```bash
+litmus http://localhost:8080/dav/ username password
+```
+
+## Patterns from This Project
+
+### Per-Vault WebDAV Handler
+
+Rather than one global handler, this project creates a per-request handler with vault-scoped FileSystem and LockSystem:
+
+```go
+davFS := NewFS(vaultID, dbClient, docService, vaultSvc)
+davHandler := &webdav.Handler{
+    FileSystem: davFS,
+    LockSystem: getLockSystem(vaultID),
+    Prefix:     pathPrefix + vaultName,
+}
+davHandler.ServeHTTP(w, r)
+```
+
+This is slightly more allocation per request but gives clean vault isolation.
+
+### nopFile for OS Metadata
+
+macOS Finder sends `._*` and `.DS_Store` files. Rejecting them causes Finder to abort the entire operation. The `nopFile` pattern silently accepts writes (discarding content) and returns `io.EOF` on reads:
+
+```go
+func (f *nopFile) Write(p []byte) (int, error) { return len(p), nil }
+func (f *nopFile) Read([]byte) (int, error)    { return 0, io.EOF }
+```
+
+### Markdown-Only Restriction
+
+This project only stores markdown. Non-`.md` file writes return a custom error wrapping `os.ErrPermission`:
+
+```go
+var errNotMarkdown = fmt.Errorf("only markdown files (.md) are allowed: %w", os.ErrPermission)
+```
+
+Wrapping `os.ErrPermission` ensures the handler returns 403 (not 500).
+
+### Write Pipeline on Close
+
+When a file is saved via WebDAV PUT, the full document pipeline runs on `Close()`:
+1. Content is buffered during `Write()` calls
+2. On `Close()`, `docService.Create()` runs the pipeline: parse → embed → link → chunk
+3. A fresh `context.Background()` with timeout is used because the original request context may be cancelled
+
+### DAV Header for Client Discovery
+
+The handler sets `DAV: 1, 2` on **every** response (not just OPTIONS) so clients like macOS Finder detect WebDAV support even on initial auth probes:
+
+```go
+w.Header().Set("DAV", "1, 2")
+```
+
+### Structured Error Logging
+
+The Logger callback filters by error type — `os.ErrNotExist` and `os.ErrPermission` are debug-level (expected in normal operation), while other errors are warnings:
+
+```go
+Logger: func(r *http.Request, err error) {
+    if err == nil {
+        return
+    }
+    if errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrPermission) {
+        slog.Debug("webdav request", "method", r.Method, "path", r.URL.Path, "error", err)
+    } else {
+        slog.Warn("webdav request failed", "method", r.Method, "path", r.URL.Path, "error", err)
+    }
+},
+```

--- a/internal/db/queries_document.go
+++ b/internal/db/queries_document.go
@@ -344,7 +344,7 @@ func (c *Client) ListLabels(ctx context.Context, vaultID string) ([]string, erro
 // GetDocumentMetaByPath returns lightweight metadata for a document (no content).
 // Returns nil if the document doesn't exist.
 func (c *Client) GetDocumentMetaByPath(ctx context.Context, vaultID, path string) (*models.DocumentMeta, error) {
-	sql := `SELECT path, content_length, updated_at FROM document WHERE vault = type::record("vault", $vault_id) AND path = $path LIMIT 1`
+	sql := `SELECT path, content_length, content_hash ?? null AS content_hash, updated_at FROM document WHERE vault = type::record("vault", $vault_id) AND path = $path LIMIT 1`
 	results, err := surrealdb.Query[[]models.DocumentMeta](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
 		"path":     path,
@@ -361,7 +361,7 @@ func (c *Client) GetDocumentMetaByPath(ctx context.Context, vaultID, path string
 // ListDocumentMetas returns lightweight metadata (no content) for documents matching the filter.
 func (c *Client) ListDocumentMetas(ctx context.Context, filter ListDocumentsFilter) ([]models.DocumentMeta, error) {
 	where, vars, suffix := buildDocumentFilter(filter)
-	sql := fmt.Sprintf("SELECT path, content_length, updated_at FROM document WHERE %s %s", where, suffix)
+	sql := fmt.Sprintf("SELECT path, content_length, content_hash ?? null AS content_hash, updated_at FROM document WHERE %s %s", where, suffix)
 
 	results, err := surrealdb.Query[[]models.DocumentMeta](ctx, c.DB(), sql, vars)
 	if err != nil {

--- a/internal/integration/webdav_test.go
+++ b/internal/integration/webdav_test.go
@@ -1,0 +1,370 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/raphi011/knowhow/internal/document"
+	"github.com/raphi011/knowhow/internal/parser"
+	knowhowdav "github.com/raphi011/knowhow/internal/webdav"
+)
+
+// setupWebDAV creates a vault, document service, and httptest.Server
+// with WebDAV handler (noAuth mode). Returns the server and vault cleanup func.
+func setupWebDAV(t *testing.T, suffix string) (*httptest.Server, string) {
+	t.Helper()
+	ctx := context.Background()
+
+	vaultID, vaultSvc := setupVault(t, ctx, "webdav-"+suffix+"-"+fmt.Sprint(time.Now().UnixNano()))
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig(), document.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil)
+
+	handler := knowhowdav.NewHandler("/dav/", testDB, docSvc, vaultSvc, true, 1024*1024)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	return srv, vaultID
+}
+
+// davURL builds a full URL for a WebDAV request.
+func davURL(srv *httptest.Server, vaultName, path string) string {
+	return srv.URL + "/dav/" + vaultName + path
+}
+
+func TestWebDAV_PutGetRoundtrip(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "roundtrip")
+	vaultName := vaultNameFromID(vaultID)
+
+	content := "# Hello\n\nThis is a test document.\n"
+	url := davURL(srv, vaultName, "/test.md")
+
+	// PUT
+	req, _ := http.NewRequest(http.MethodPut, url, strings.NewReader(content))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("PUT status = %d, want 201 or 204", resp.StatusCode)
+	}
+
+	// GET
+	resp, err = http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET status = %d, want 200", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read GET body: %v", err)
+	}
+	if string(body) != content {
+		t.Errorf("GET body = %q, want %q", string(body), content)
+	}
+}
+
+func TestWebDAV_PropfindDepth1(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "propfind")
+	vaultName := vaultNameFromID(vaultID)
+
+	// PUT two files
+	for _, name := range []string{"/a.md", "/b.md"} {
+		req, _ := http.NewRequest(http.MethodPut, davURL(srv, vaultName, name), strings.NewReader("# "+name))
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("PUT %s: %v", name, err)
+		}
+		resp.Body.Close()
+	}
+
+	// PROPFIND Depth:1 on root
+	req, _ := http.NewRequest("PROPFIND", davURL(srv, vaultName, "/"), nil)
+	req.Header.Set("Depth", "1")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PROPFIND: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMultiStatus {
+		t.Fatalf("PROPFIND status = %d, want 207", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read PROPFIND body: %v", err)
+	}
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, "a.md") || !strings.Contains(bodyStr, "b.md") {
+		t.Errorf("PROPFIND response missing file entries:\n%s", bodyStr)
+	}
+}
+
+func TestWebDAV_Mkcol(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "mkcol")
+	vaultName := vaultNameFromID(vaultID)
+
+	// MKCOL
+	req, _ := http.NewRequest("MKCOL", davURL(srv, vaultName, "/notes"), nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("MKCOL: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("MKCOL status = %d, want 201", resp.StatusCode)
+	}
+
+	// PUT file inside
+	req, _ = http.NewRequest(http.MethodPut, davURL(srv, vaultName, "/notes/doc.md"), strings.NewReader("# Doc"))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+
+	// PROPFIND on folder
+	req, _ = http.NewRequest("PROPFIND", davURL(srv, vaultName, "/notes"), nil)
+	req.Header.Set("Depth", "1")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PROPFIND /notes: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read PROPFIND body: %v", err)
+	}
+	if !strings.Contains(string(body), "doc.md") {
+		t.Errorf("PROPFIND /notes missing doc.md:\n%s", string(body))
+	}
+}
+
+func TestWebDAV_Delete(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "delete")
+	vaultName := vaultNameFromID(vaultID)
+	url := davURL(srv, vaultName, "/deleteme.md")
+
+	// PUT
+	req, _ := http.NewRequest(http.MethodPut, url, strings.NewReader("# Delete me"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+
+	// DELETE
+	req, _ = http.NewRequest(http.MethodDelete, url, nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("DELETE status = %d, want 204", resp.StatusCode)
+	}
+
+	// GET should 404
+	resp, err = http.Get(url)
+	if err != nil {
+		t.Fatalf("GET after DELETE: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("GET after DELETE status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestWebDAV_Move(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "move")
+	vaultName := vaultNameFromID(vaultID)
+	oldURL := davURL(srv, vaultName, "/old.md")
+	newURL := davURL(srv, vaultName, "/new.md")
+
+	// PUT at old path
+	req, _ := http.NewRequest(http.MethodPut, oldURL, strings.NewReader("# Move me"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+
+	// MOVE
+	req, _ = http.NewRequest("MOVE", oldURL, nil)
+	req.Header.Set("Destination", newURL)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("MOVE: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("MOVE status = %d, want 201 or 204", resp.StatusCode)
+	}
+
+	// Old path should 404
+	resp, err = http.Get(oldURL)
+	if err != nil {
+		t.Fatalf("GET old: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("GET old status = %d, want 404", resp.StatusCode)
+	}
+
+	// New path should 200
+	resp, err = http.Get(newURL)
+	if err != nil {
+		t.Fatalf("GET new: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GET new status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestWebDAV_NonMarkdownRejected(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "nonmd")
+	vaultName := vaultNameFromID(vaultID)
+
+	req, _ := http.NewRequest(http.MethodPut, davURL(srv, vaultName, "/file.txt"), strings.NewReader("hello"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT .txt: %v", err)
+	}
+	resp.Body.Close()
+	// The webdav library translates os.ErrPermission from OpenFile into a 404 on PUT.
+	if resp.StatusCode < 400 {
+		t.Errorf("PUT .txt status = %d, want error status", resp.StatusCode)
+	}
+}
+
+func TestWebDAV_MacOSMetadata(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "macos")
+	vaultName := vaultNameFromID(vaultID)
+
+	// PUT ._foo (accepted but discarded)
+	req, _ := http.NewRequest(http.MethodPut, davURL(srv, vaultName, "/._foo"), strings.NewReader("\x00\x05\x16"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT ._foo: %v", err)
+	}
+	resp.Body.Close()
+	// Should succeed (silently accept)
+	if resp.StatusCode >= 400 {
+		t.Errorf("PUT ._foo status = %d, want success", resp.StatusCode)
+	}
+
+	// GET ._foo should 404 (not stored)
+	resp, err = http.Get(davURL(srv, vaultName, "/._foo"))
+	if err != nil {
+		t.Fatalf("GET ._foo: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("GET ._foo status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestWebDAV_DepthInfinityRejected(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "depth-inf")
+	vaultName := vaultNameFromID(vaultID)
+
+	req, _ := http.NewRequest("PROPFIND", davURL(srv, vaultName, "/"), nil)
+	req.Header.Set("Depth", "infinity")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PROPFIND: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("PROPFIND Depth:infinity status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestWebDAV_BodySizeLimit(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "sizelimit")
+	vaultName := vaultNameFromID(vaultID)
+
+	// setupWebDAV uses 1MB limit. Send 2MB.
+	oversized := strings.Repeat("x", 2*1024*1024)
+	req, _ := http.NewRequest(http.MethodPut, davURL(srv, vaultName, "/big.md"), strings.NewReader(oversized))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT oversized: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Errorf("PUT oversized status = %d, want 413", resp.StatusCode)
+	}
+}
+
+func TestWebDAV_LockUnlock(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "lock")
+	vaultName := vaultNameFromID(vaultID)
+	url := davURL(srv, vaultName, "/lockme.md")
+
+	// PUT first so the resource exists
+	req, _ := http.NewRequest(http.MethodPut, url, strings.NewReader("# Lock test"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+
+	// LOCK
+	lockBody := `<?xml version="1.0" encoding="utf-8"?>
+<D:lockinfo xmlns:D="DAV:">
+  <D:lockscope><D:exclusive/></D:lockscope>
+  <D:locktype><D:write/></D:locktype>
+  <D:owner><D:href>test</D:href></D:owner>
+</D:lockinfo>`
+	req, _ = http.NewRequest("LOCK", url, strings.NewReader(lockBody))
+	req.Header.Set("Content-Type", "application/xml")
+	req.Header.Set("Timeout", "Second-60")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("LOCK: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("LOCK status = %d, want 200, body: %s", resp.StatusCode, body)
+	}
+
+	// Extract lock token from Lock-Token header
+	lockToken := resp.Header.Get("Lock-Token")
+	if lockToken == "" {
+		t.Fatal("LOCK response missing Lock-Token header")
+	}
+
+	// UNLOCK
+	req, _ = http.NewRequest("UNLOCK", url, nil)
+	req.Header.Set("Lock-Token", lockToken)
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("UNLOCK: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusNoContent {
+		t.Errorf("UNLOCK status = %d, want 204", resp2.StatusCode)
+	}
+}
+
+// vaultNameFromID looks up the vault name from its record ID.
+// The WebDAV handler resolves vaults by name, so we fetch the actual name from DB.
+func vaultNameFromID(vaultID string) string {
+	ctx := context.Background()
+	v, err := testDB.GetVault(ctx, vaultID)
+	if err != nil || v == nil {
+		panic(fmt.Sprintf("vaultNameFromID: vault %s not found: %v", vaultID, err))
+	}
+	return v.Name
+}

--- a/internal/models/document.go
+++ b/internal/models/document.go
@@ -62,6 +62,7 @@ type DocumentInput struct {
 type DocumentMeta struct {
 	Path          string    `json:"path"`
 	ContentLength int       `json:"content_length"`
+	ContentHash   *string   `json:"content_hash,omitempty"`
 	UpdatedAt     time.Time `json:"updated_at"`
 }
 

--- a/internal/webdav/file.go
+++ b/internal/webdav/file.go
@@ -31,8 +31,8 @@ func newReadFile(name string, doc *models.Document) *readFile {
 	}
 }
 
-func (f *readFile) Read(p []byte) (int, error)  { return f.reader.Read(p) }
-func (f *readFile) Write([]byte) (int, error)   { return 0, os.ErrPermission }
+func (f *readFile) Read(p []byte) (int, error) { return f.reader.Read(p) }
+func (f *readFile) Write([]byte) (int, error)  { return 0, os.ErrPermission }
 func (f *readFile) Seek(offset int64, whence int) (int64, error) {
 	return f.reader.Seek(offset, whence)
 }
@@ -41,11 +41,16 @@ func (f *readFile) Readdir(count int) ([]fs.FileInfo, error) {
 	return nil, os.ErrInvalid
 }
 func (f *readFile) Stat() (fs.FileInfo, error) {
-	return &fileInfo{
-		name:    path.Base(f.name),
-		size:    int64(len(f.doc.Content)),
-		modTime: f.doc.UpdatedAt,
-	}, nil
+	fi := &fileInfo{
+		name:        path.Base(f.name),
+		size:        int64(len(f.doc.Content)),
+		modTime:     f.doc.UpdatedAt,
+		contentType: markdownContentType,
+	}
+	if f.doc.ContentHash != nil {
+		fi.etag = `"` + *f.doc.ContentHash + `"`
+	}
+	return fi, nil
 }
 
 // writeFile buffers writes and triggers the document pipeline on Close().
@@ -66,14 +71,15 @@ func newWriteFile(name, vaultID string, docService *document.Service, initial []
 		modTime:    modTime,
 	}
 	if initial != nil {
+		// bytes.Buffer.Write never returns a non-nil error; safe to ignore.
 		wf.buf.Write(initial)
 	}
 	return wf
 }
 
-func (f *writeFile) Read([]byte) (int, error)               { return 0, os.ErrPermission }
-func (f *writeFile) Readdir(int) ([]fs.FileInfo, error)      { return nil, os.ErrInvalid }
-func (f *writeFile) Seek(int64, int) (int64, error)          { return 0, os.ErrPermission }
+func (f *writeFile) Read([]byte) (int, error)           { return 0, os.ErrPermission }
+func (f *writeFile) Readdir(int) ([]fs.FileInfo, error) { return nil, os.ErrInvalid }
+func (f *writeFile) Seek(int64, int) (int64, error)     { return 0, os.ErrPermission }
 
 func (f *writeFile) Write(p []byte) (int, error) {
 	f.written = true
@@ -108,9 +114,10 @@ func (f *writeFile) Close() error {
 
 func (f *writeFile) Stat() (fs.FileInfo, error) {
 	return &fileInfo{
-		name:    path.Base(f.name),
-		size:    int64(f.buf.Len()),
-		modTime: f.modTime,
+		name:        path.Base(f.name),
+		size:        int64(f.buf.Len()),
+		modTime:     f.modTime,
+		contentType: markdownContentType,
 	}, nil
 }
 
@@ -126,10 +133,10 @@ func newDirFile(name string, modTime time.Time, entries []fs.FileInfo) *dirFile 
 	return &dirFile{name: name, modTime: modTime, entries: entries}
 }
 
-func (d *dirFile) Read([]byte) (int, error)             { return 0, os.ErrInvalid }
-func (d *dirFile) Write([]byte) (int, error)            { return 0, os.ErrPermission }
-func (d *dirFile) Seek(int64, int) (int64, error)       { return 0, os.ErrInvalid }
-func (d *dirFile) Close() error                         { return nil }
+func (d *dirFile) Read([]byte) (int, error)       { return 0, os.ErrInvalid }
+func (d *dirFile) Write([]byte) (int, error)      { return 0, os.ErrPermission }
+func (d *dirFile) Seek(int64, int) (int64, error) { return 0, os.ErrInvalid }
+func (d *dirFile) Close() error                   { return nil }
 
 func (d *dirFile) Readdir(count int) ([]fs.FileInfo, error) {
 	if count <= 0 {
@@ -173,14 +180,14 @@ type nopFile struct {
 func newNopFile(name string) *nopFile {
 	return &nopFile{name: name, modTime: time.Now()}
 }
-func (f *nopFile) Read([]byte) (int, error)                    { return 0, io.EOF }
-func (f *nopFile) Write(p []byte) (int, error)                 { return len(p), nil }
-func (f *nopFile) Seek(int64, int) (int64, error)              { return 0, nil }
+func (f *nopFile) Read([]byte) (int, error)       { return 0, io.EOF }
+func (f *nopFile) Write(p []byte) (int, error)    { return len(p), nil }
+func (f *nopFile) Seek(int64, int) (int64, error) { return 0, nil }
 func (f *nopFile) Close() error {
 	slog.Debug("webdav: discarded OS metadata file", "path", f.name)
 	return nil
 }
-func (f *nopFile) Readdir(int) ([]fs.FileInfo, error)          { return nil, os.ErrInvalid }
+func (f *nopFile) Readdir(int) ([]fs.FileInfo, error) { return nil, os.ErrInvalid }
 func (f *nopFile) Stat() (fs.FileInfo, error) {
 	return &fileInfo{name: path.Base(f.name), modTime: f.modTime}, nil
 }

--- a/internal/webdav/fs.go
+++ b/internal/webdav/fs.go
@@ -20,6 +20,8 @@ import (
 	"github.com/raphi011/knowhow/internal/vault"
 )
 
+const markdownContentType = "text/markdown; charset=utf-8"
+
 // FS implements webdav.FileSystem backed by document and vault services.
 type FS struct {
 	vaultID    string
@@ -204,12 +206,17 @@ func (f *FS) Stat(ctx context.Context, name string) (os.FileInfo, error) {
 		return nil, fmt.Errorf("stat %s: %w", name, err)
 	}
 	if meta != nil {
-		return &fileInfo{
-			name:    path.Base(name),
-			size:    int64(meta.ContentLength),
-			modTime: meta.UpdatedAt,
-			isDir:   false,
-		}, nil
+		fi := &fileInfo{
+			name:        path.Base(name),
+			size:        int64(meta.ContentLength),
+			modTime:     meta.UpdatedAt,
+			isDir:       false,
+			contentType: markdownContentType,
+		}
+		if meta.ContentHash != nil {
+			fi.etag = `"` + *meta.ContentHash + `"`
+		}
+		return fi, nil
 	}
 
 	// Try as folder
@@ -287,12 +294,17 @@ func (f *FS) listDirEntries(ctx context.Context, dirPath string) ([]os.FileInfo,
 		if strings.Contains(rel, "/") {
 			continue // nested doc, skip
 		}
-		entries = append(entries, &fileInfo{
-			name:    path.Base(meta.Path),
-			size:    int64(meta.ContentLength),
-			modTime: meta.UpdatedAt,
-			isDir:   false,
-		})
+		fi := &fileInfo{
+			name:        path.Base(meta.Path),
+			size:        int64(meta.ContentLength),
+			modTime:     meta.UpdatedAt,
+			isDir:       false,
+			contentType: markdownContentType,
+		}
+		if meta.ContentHash != nil {
+			fi.etag = `"` + *meta.ContentHash + `"`
+		}
+		entries = append(entries, fi)
 	}
 
 	return entries, nil
@@ -325,16 +337,42 @@ func normalizeName(name string) string {
 }
 
 // fileInfo implements os.FileInfo for WebDAV entries.
+// It optionally implements webdav.ContentTyper (to avoid opening files to
+// sniff MIME type) and webdav.ETager (to return content-hash-based ETags
+// instead of the default ModTime+Size heuristic).
 type fileInfo struct {
-	name    string
-	size    int64
-	modTime time.Time
-	isDir   bool
+	name        string
+	size        int64
+	modTime     time.Time
+	isDir       bool
+	contentType string
+	etag        string
 }
 
-func (fi *fileInfo) Name() string        { return fi.name }
-func (fi *fileInfo) Size() int64          { return fi.size }
-func (fi *fileInfo) Mode() fs.FileMode    { if fi.isDir { return fs.ModeDir | 0755 }; return 0644 }
-func (fi *fileInfo) ModTime() time.Time   { return fi.modTime }
-func (fi *fileInfo) IsDir() bool          { return fi.isDir }
-func (fi *fileInfo) Sys() any             { return nil }
+func (fi *fileInfo) Name() string { return fi.name }
+func (fi *fileInfo) Size() int64  { return fi.size }
+func (fi *fileInfo) Mode() fs.FileMode {
+	if fi.isDir {
+		return fs.ModeDir | 0755
+	}
+	return 0644
+}
+func (fi *fileInfo) ModTime() time.Time { return fi.modTime }
+func (fi *fileInfo) IsDir() bool        { return fi.isDir }
+func (fi *fileInfo) Sys() any           { return nil }
+
+// ContentType implements webdav.ContentTyper.
+func (fi *fileInfo) ContentType(_ context.Context) (string, error) {
+	if fi.contentType == "" {
+		return "", webdav.ErrNotImplemented
+	}
+	return fi.contentType, nil
+}
+
+// ETag implements webdav.ETager.
+func (fi *fileInfo) ETag(_ context.Context) (string, error) {
+	if fi.etag == "" {
+		return "", webdav.ErrNotImplemented
+	}
+	return fi.etag, nil
+}

--- a/internal/webdav/fs_test.go
+++ b/internal/webdav/fs_test.go
@@ -1,10 +1,13 @@
 package webdav
 
 import (
+	"context"
 	"errors"
 	"io"
 	"os"
 	"testing"
+
+	"golang.org/x/net/webdav"
 )
 
 func TestNormalizeName(t *testing.T) {
@@ -67,8 +70,8 @@ func TestIsMarkdownFile(t *testing.T) {
 		{"/notes/file.txt", false},
 		{"/notes/binary.exe", false},
 		{"/notes/noext", false},
-		{"/notes/.md", true},           // hidden file with .md extension
-		{"/notes/._readme.md", true},   // has .md extension (OS filtering is separate)
+		{"/notes/.md", true},         // hidden file with .md extension
+		{"/notes/._readme.md", true}, // has .md extension (OS filtering is separate)
 	}
 
 	for _, tt := range tests {
@@ -141,4 +144,50 @@ func TestErrNotMarkdownWrapsErrPermission(t *testing.T) {
 	if !errors.Is(errNotMarkdown, os.ErrPermission) {
 		t.Error("errNotMarkdown should wrap os.ErrPermission")
 	}
+}
+
+func TestFileInfoContentType(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns content type when set", func(t *testing.T) {
+		fi := &fileInfo{name: "test.md", contentType: "text/markdown; charset=utf-8"}
+		ct, err := fi.ContentType(ctx)
+		if err != nil {
+			t.Fatalf("ContentType() error: %v", err)
+		}
+		if ct != "text/markdown; charset=utf-8" {
+			t.Errorf("ContentType() = %q, want %q", ct, "text/markdown; charset=utf-8")
+		}
+	})
+
+	t.Run("returns ErrNotImplemented when empty", func(t *testing.T) {
+		fi := &fileInfo{name: "test.md"}
+		_, err := fi.ContentType(ctx)
+		if err != webdav.ErrNotImplemented {
+			t.Errorf("ContentType() error = %v, want ErrNotImplemented", err)
+		}
+	})
+}
+
+func TestFileInfoETag(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns etag when set", func(t *testing.T) {
+		fi := &fileInfo{name: "test.md", etag: `"abc123"`}
+		etag, err := fi.ETag(ctx)
+		if err != nil {
+			t.Fatalf("ETag() error: %v", err)
+		}
+		if etag != `"abc123"` {
+			t.Errorf("ETag() = %q, want %q", etag, `"abc123"`)
+		}
+	})
+
+	t.Run("returns ErrNotImplemented when empty", func(t *testing.T) {
+		fi := &fileInfo{name: "test.md"}
+		_, err := fi.ETag(ctx)
+		if err != webdav.ErrNotImplemented {
+			t.Errorf("ETag() error = %v, want ErrNotImplemented", err)
+		}
+	})
 }

--- a/internal/webdav/handler.go
+++ b/internal/webdav/handler.go
@@ -20,12 +20,14 @@ import (
 // NewHandler creates an http.Handler that serves WebDAV for vault documents.
 // The path prefix is stripped from incoming requests (e.g. "/dav/default/").
 // Auth uses HTTP Basic Auth where the password is a knowhow API token.
+// maxPutBytes limits the size of PUT request bodies (0 = no limit).
 func NewHandler(
 	pathPrefix string,
 	dbClient *db.Client,
 	docService *document.Service,
 	vaultSvc *vault.Service,
 	noAuth bool,
+	maxPutBytes int64,
 ) http.Handler {
 	// Per-vault lock systems to isolate WebDAV locks across vaults.
 	var lockSystems sync.Map // vaultID → webdav.LockSystem
@@ -85,6 +87,25 @@ func NewHandler(
 				http.Error(w, "read-only access", http.StatusForbidden)
 				return
 			}
+		}
+
+		// Reject PROPFIND Depth:infinity — unbounded recursion is a DoS vector (RFC 4918 §9.1).
+		if r.Method == "PROPFIND" && r.Header.Get("Depth") == "infinity" {
+			http.Error(w, "Depth: infinity not supported", http.StatusForbidden)
+			return
+		}
+
+		// Limit PUT body size to prevent memory exhaustion (write-on-close buffers in memory).
+		// The ContentLength check provides a clean 413 when the header is present.
+		// MaxBytesReader is a fallback for chunked transfers without Content-Length;
+		// in that case the x/net/webdav library surfaces a 500 because it cannot map
+		// http.MaxBytesError to a WebDAV status code.
+		if r.Method == http.MethodPut && maxPutBytes > 0 {
+			if r.ContentLength > maxPutBytes {
+				http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+			r.Body = http.MaxBytesReader(w, r.Body, maxPutBytes)
 		}
 
 		// Create per-request WebDAV handler with the resolved vault

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -37,5 +37,6 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.knowhow.ios
         MARKETING_VERSION: "1.0"
         CURRENT_PROJECT_VERSION: "1"
+        CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: ""
         CODE_SIGN_ENTITLEMENTS: Knowhow.entitlements


### PR DESCRIPTION
Harden WebDAV server with proper HTTP caching, content-type hints, and security limits for production readiness.

## Breaking Changes
- `webdav.NewHandler` now requires a `maxPutBytes int64` parameter (set to 0 to disable)

## Test Coverage
- Unit tests added: `TestFileInfoContentType`, `TestFileInfoETag` in `internal/webdav/fs_test.go`
- Integration tests added: `internal/integration/webdav_test.go` — PUT/GET roundtrip, PROPFIND, MKCOL, DELETE, MOVE, LOCK/UNLOCK, non-markdown rejection, macOS metadata handling, Depth:infinity rejection, body size limit

## Changes

- **ETag support**: `fileInfo` implements `webdav.ETager` using document `content_hash`. Added `content_hash` to `DocumentMeta` model and DB queries
- **Content-Type**: `fileInfo` implements `webdav.ContentTyper` returning `text/markdown; charset=utf-8`, avoiding file-sniffing overhead
- **Depth:infinity rejection**: PROPFIND with `Depth: infinity` returns 403 (DoS prevention per RFC 4918 §9.1)
- **PUT body size limit**: Configurable max via `maxPutBytes` param (default 10MB). Returns 413 when Content-Length exceeds limit, falls back to `MaxBytesReader` for chunked transfers
- **Docs**: Added `docs/webdav-go-package.md` technical reference
- **iOS**: Set `CODE_SIGN_STYLE: Automatic` in project.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)