### PR TITLE
feat: GoReleaser with GitHub Actions and Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Test
+        run: go test -buildvcs=false -v ./...
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify secrets
+        run: |
+          if [ -z "$TAP_GITHUB_TOKEN" ]; then
+            echo "::error::TAP_GITHUB_TOKEN secret is not set. Configure it in repository settings."
+            exit 1
+          fi
+        env:
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,84 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - mkdir -p completions
+    - sh -c "go run -buildvcs=false ./cmd/knowhow completion bash > completions/knowhow.bash"
+    - sh -c "go run -buildvcs=false ./cmd/knowhow completion zsh > completions/_knowhow"
+    - sh -c "go run -buildvcs=false ./cmd/knowhow completion fish > completions/knowhow.fish"
+    - sh -c "test -s completions/knowhow.bash && test -s completions/_knowhow && test -s completions/knowhow.fish"
+
+builds:
+  - id: knowhow
+    main: ./cmd/knowhow
+    binary: knowhow
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+  - id: knowhow-server
+    main: ./cmd/knowhow-server
+    binary: knowhow-server
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+
+archives:
+  - formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - completions/*
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  groups:
+    - title: "Features"
+      regexp: '^.*?feat(\(.+\))?\!?:.+$'
+      order: 0
+    - title: "Bug Fixes"
+      regexp: '^.*?fix(\(.+\))?\!?:.+$'
+      order: 1
+    - title: "Documentation"
+      regexp: '^.*?docs(\(.+\))?\!?:.+$'
+      order: 2
+    - title: "Other"
+      order: 999
+  filters:
+    exclude:
+      - "^test:"
+      - "^chore:"
+
+brews:
+  - repository:
+      owner: raphi011
+      name: homebrew-tap
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/raphi011/knowhow"
+    description: "Knowledge management CLI with AI-powered search"
+    license: "MIT"
+    extra_install: |
+      bash_completion.install "completions/knowhow.bash" => "knowhow"
+      zsh_completion.install "completions/_knowhow"
+      fish_completion.install "completions/knowhow.fish"

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Store any type of knowledge (people, services, concepts, documents) with flexibl
 ## Installation
 
 ```bash
-# Build from source
-go build -o knowhow ./cmd/knowhow
+# Homebrew (macOS/Linux)
+brew install raphi011/tap/knowhow
 
-# Install to path
-go install ./cmd/knowhow
+# Or build from source
+go build -o knowhow ./cmd/knowhow
 ```
 
 ### Prerequisites

--- a/cmd/knowhow-server/main.go
+++ b/cmd/knowhow-server/main.go
@@ -29,6 +29,9 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
+// Version information — set by GoReleaser ldflags at build time.
+var version = "dev"
+
 func main() {
 	// Load configuration
 	cfg := config.Load()
@@ -47,7 +50,7 @@ func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
 	slog.SetDefault(logger)
 
-	slog.Info("starting knowhow-server", "port", port)
+	slog.Info("starting knowhow-server", "version", version, "port", port)
 
 	// Bind the port early so we fail fast if another instance is still running.
 	// This prevents the race where initialization succeeds but ListenAndServe

--- a/cmd/knowhow/main.go
+++ b/cmd/knowhow/main.go
@@ -6,8 +6,16 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/spf13/cobra"
+)
+
+// Version information — set by GoReleaser ldflags at build time.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
 )
 
 var (
@@ -26,10 +34,19 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&apiToken, "token", os.Getenv("KNOWHOW_TOKEN"), "API bearer token")
 }
 
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("knowhow %s (%s, %s, %s)\n", version, commit[:min(7, len(commit))], date, runtime.Version())
+	},
+}
+
 func main() {
 	rootCmd.AddCommand(scrapeCmd)
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(devCmd)
+	rootCmd.AddCommand(versionCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/justfile
+++ b/justfile
@@ -71,6 +71,10 @@ install:
 test:
     go test -buildvcs=false -v ./...
 
+# Build snapshot release locally (requires goreleaser)
+snapshot:
+    goreleaser release --snapshot --clean
+
 # Start dev environment with live-reload
 dev: db-up
     air


### PR DESCRIPTION
Adds automated release pipeline via GoReleaser + GitHub Actions, triggered by `v*` tags.

## Breaking Changes
- None

## Test Coverage
- Unit tests added: N/A (build/CI config only)
- Integration tests added: N/A

## What's included
- `.goreleaser.yaml` — builds `knowhow` + `knowhow-server` for darwin/linux (amd64/arm64), generates shell completions, publishes Homebrew formula to `raphi011/homebrew-tap`
- `.github/workflows/release.yml` — runs tests then GoReleaser on tag push, requires `TAP_GITHUB_TOKEN` secret for Homebrew tap publishing
- Version ldflags injected into both binaries at build time
- `knowhow version` CLI command
- `just snapshot` for local release testing
- README updated with `brew install raphi011/tap/knowhow`

## Setup required
- Create `TAP_GITHUB_TOKEN` repository secret (PAT with write access to `raphi011/homebrew-tap`)
- Create `raphi011/homebrew-tap` repo with a `Formula/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)