### PR TITLE
feat: SIGHUP LLM hot-reload, no-auth local mode, auto-bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ SURREALDB_USER=root
 SURREALDB_PASS=root
 SURREALDB_AUTH_LEVEL=root
 
+# For local (launchd) SurrealDB with --unauthenticated:
+# SURREALDB_URL=ws://localhost:8000/rpc
+# SURREALDB_AUTH_LEVEL=none
+# KNOWHOW_NO_AUTH=true
+
 # =============================================================================
 # LLM Configuration (for ask, render, extract-graph)
 # =============================================================================

--- a/cmd/knowhow-server/main.go
+++ b/cmd/knowhow-server/main.go
@@ -72,6 +72,25 @@ func main() {
 		}
 	}()
 
+	// Listen for SIGHUP to reload LLM config from .env
+	sighup := make(chan os.Signal, 1)
+	signal.Notify(sighup, syscall.SIGHUP)
+	go func() {
+		for range sighup {
+			func() {
+				defer func() {
+					if p := recover(); p != nil {
+						slog.Error("ReloadLLM panicked", "error", p)
+					}
+				}()
+				slog.Info("SIGHUP received, reloading LLM config")
+				if err := resolver.ReloadLLM(); err != nil {
+					slog.Warn("LLM reload failed", "error", err)
+				}
+			}()
+		}
+	}()
+
 	// Create GraphQL server
 	srv := handler.New(graph.NewExecutableSchema(graph.Config{
 		Resolvers: resolver,

--- a/go.mod
+++ b/go.mod
@@ -111,6 +111,7 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/joho/godotenv v1.5.1
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.3 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cloudwego/eino/schema"
@@ -36,12 +37,22 @@ type StreamEvent struct {
 // Service orchestrates the agent loop: native tool calling → streaming answer.
 type Service struct {
 	db              *db.Client
-	model           *llm.Model
+	model           atomic.Pointer[llm.Model]
 	search          *search.Service
 	docService      *document.Service
 	executor        *tools.Executor
 	tavily          *tavilyClient
 	activeApprovals sync.Map // map[conversationID]*approvalSession
+}
+
+// SetModel atomically replaces the LLM model (used by SIGHUP reload).
+func (s *Service) SetModel(m *llm.Model) {
+	s.model.Store(m)
+}
+
+// getModel returns the current model via an atomic load.
+func (s *Service) getModel() *llm.Model {
+	return s.model.Load()
 }
 
 // approvalSession pairs an approval registry with vault context for access checks.
@@ -54,7 +65,6 @@ type approvalSession struct {
 func NewService(db *db.Client, model *llm.Model, search *search.Service, docService *document.Service, tavilyAPIKey string) *Service {
 	s := &Service{
 		db:         db,
-		model:      model,
 		search:     search,
 		docService: docService,
 		executor: &tools.Executor{
@@ -63,6 +73,7 @@ func NewService(db *db.Client, model *llm.Model, search *search.Service, docServ
 			DocService: docService,
 		},
 	}
+	s.model.Store(model)
 	if tavilyAPIKey != "" {
 		s.tavily = newTavilyClient(tavilyAPIKey)
 	}
@@ -71,7 +82,7 @@ func NewService(db *db.Client, model *llm.Model, search *search.Service, docServ
 
 // Available returns true if the agent has an LLM model configured.
 func (s *Service) Available() bool {
-	return s.model != nil
+	return s.getModel() != nil
 }
 
 // buildSystemPrompt constructs the system prompt, optionally appending the vault's folder tree.
@@ -301,7 +312,8 @@ type ChatRequest struct {
 
 // Chat runs the agent loop using native tool calling and emits SSE events via the callback.
 func (s *Service) Chat(ctx context.Context, req ChatRequest, emit func(StreamEvent)) error {
-	if s.model == nil {
+	model := s.getModel()
+	if model == nil {
 		emit(StreamEvent{Type: "error", Content: "agent not available: no LLM configured"})
 		return nil
 	}
@@ -393,7 +405,7 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest, emit func(StreamEve
 	tools := s.buildTools()
 
 	// 6. Call GenerateStreamWithTools
-	err = s.model.GenerateStreamWithTools(ctx, messages, tools,
+	err = model.GenerateStreamWithTools(ctx, messages, tools,
 		func(token string) error {
 			answer.WriteString(token)
 			emit(StreamEvent{Type: "text", Content: token})
@@ -692,8 +704,13 @@ func (s *Service) execWebSearch(ctx context.Context, arguments string) (string, 
 }
 
 func (s *Service) autoTitle(ctx context.Context, conversationID, firstMessage string) {
+	model := s.getModel()
+	if model == nil {
+		slog.Debug("skipping auto-title: no LLM model configured", "conversation_id", conversationID)
+		return
+	}
 	prompt := fmt.Sprintf("Generate a very short title (3-6 words, no quotes) for a conversation that starts with this message:\n\n%s", firstMessage)
-	title, err := s.model.GenerateWithSystem(ctx, "You generate short conversation titles. Respond with ONLY the title, nothing else.", prompt)
+	title, err := model.GenerateWithSystem(ctx, "You generate short conversation titles. Respond with ONLY the title, nothing else.", prompt)
 	if err != nil {
 		slog.Warn("auto-title failed", "conversation_id", conversationID, "error", err)
 		return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,11 @@ const (
 	ProviderGoogleAI  LLMProvider = "googleai"
 )
 
+// Enabled returns true if the provider is configured (not empty or "none").
+func (p LLMProvider) Enabled() bool {
+	return p != ProviderNone && p != ""
+}
+
 // Config holds all configuration values.
 type Config struct {
 	// SurrealDB connection

--- a/internal/db/client.go
+++ b/internal/db/client.go
@@ -34,7 +34,7 @@ type Config struct {
 	Database  string
 	Username  string
 	Password  string
-	AuthLevel string // "root" or "database"
+	AuthLevel string // "root", "database", "namespace", or "none" (unauthenticated)
 }
 
 // Client wraps SurrealDB connection with auto-reconnect.
@@ -115,6 +115,8 @@ func NewClient(ctx context.Context, cfg Config, log *slog.Logger, mc *metrics.Co
 	// Authenticate based on auth level
 	sdkLogger.Info("authenticating", "user", cfg.Username, "auth_level", cfg.AuthLevel)
 	switch cfg.AuthLevel {
+	case "none":
+		sdkLogger.Info("skipping authentication (unauthenticated mode)")
 	case "database":
 		_, err = db.SignIn(ctx, surrealdb.Auth{
 			Namespace: cfg.Namespace,

--- a/internal/document/service.go
+++ b/internal/document/service.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/text/cases"
@@ -28,11 +29,21 @@ type VersionConfig struct {
 // Service manages document lifecycle: parse → extract → store → link → embed.
 type Service struct {
 	db            *db.Client
-	embedder      *llm.Embedder // optional — nil disables embedding
+	embedder      atomic.Pointer[llm.Embedder] // optional — nil disables embedding
 	resolver      *LinkResolver
 	chunkConfig   parser.ChunkConfig
 	versionConfig VersionConfig
 	bus           *event.Bus // optional — nil disables change events
+}
+
+// SetEmbedder atomically replaces the embedder (used by SIGHUP reload).
+func (s *Service) SetEmbedder(e *llm.Embedder) {
+	s.embedder.Store(e)
+}
+
+// getEmbedder returns the current embedder via an atomic load.
+func (s *Service) getEmbedder() *llm.Embedder {
+	return s.embedder.Load()
 }
 
 // NewService creates a new document service.
@@ -45,14 +56,15 @@ func NewService(db *db.Client, embedder *llm.Embedder, chunkConfig parser.ChunkC
 		slog.Warn("version coalesce minutes negative, clamping to 0", "configured", versionConfig.CoalesceMinutes)
 		versionConfig.CoalesceMinutes = 0
 	}
-	return &Service{
+	s := &Service{
 		db:            db,
-		embedder:      embedder,
 		resolver:      NewLinkResolver(db),
 		chunkConfig:   chunkConfig,
 		versionConfig: versionConfig,
 		bus:           bus,
 	}
+	s.embedder.Store(embedder)
+	return s
 }
 
 func (s *Service) publishDocEvent(eventType string, vaultID string, doc *models.Document) {
@@ -229,7 +241,8 @@ func (s *Service) Create(ctx context.Context, input models.DocumentInput) (*mode
 // content before embedding, improving semantic precision without altering stored content.
 // Returns the number of chunks successfully embedded.
 func (s *Service) EmbedPendingChunks(ctx context.Context, limit int) (int, error) {
-	if s.embedder == nil {
+	embedder := s.getEmbedder()
+	if embedder == nil {
 		return 0, nil
 	}
 
@@ -256,7 +269,7 @@ func (s *Service) EmbedPendingChunks(ctx context.Context, limit int) (int, error
 		}
 		embeddingText := buildEmbeddingContext(chunk, docTitles[docID])
 
-		emb, err := s.embedder.Embed(ctx, embeddingText)
+		emb, err := embedder.Embed(ctx, embeddingText)
 		if err != nil {
 			slog.Warn("failed to embed chunk", "chunk_id", chunkID, "error", err)
 			s.rescheduleChunk(chunkID)
@@ -622,7 +635,7 @@ func (s *Service) syncChunks(ctx context.Context, docID string, parsed *parser.M
 			}
 
 			// Only schedule embedding if embedder is configured
-			if s.embedder != nil {
+			if s.getEmbedder() != nil {
 				now := time.Now().UTC()
 				input.EmbedAt = &now
 			}

--- a/internal/graph/bootstrap.go
+++ b/internal/graph/bootstrap.go
@@ -1,0 +1,87 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/raphi011/knowhow/internal/db"
+	"github.com/raphi011/knowhow/internal/models"
+)
+
+// seedIfEmpty checks each bootstrap resource (user, vault, membership)
+// independently and creates any that are missing. This allows the server to
+// self-bootstrap against an empty database (e.g. when running as a launchd
+// service) and to recover from a partial previous bootstrap.
+func seedIfEmpty(ctx context.Context, dbClient *db.Client) error {
+	// 1. Ensure admin user exists
+	user, err := dbClient.GetUser(ctx, "admin")
+	if err != nil {
+		return fmt.Errorf("check admin user: %w", err)
+	}
+	if user == nil {
+		slog.Info("auto-bootstrap: creating admin user")
+		user, err = dbClient.CreateUserWithID(ctx, "admin", models.UserInput{
+			Name: "admin",
+		})
+		if err != nil {
+			return fmt.Errorf("create admin user: %w", err)
+		}
+	}
+
+	userID, err := models.RecordIDString(user.ID)
+	if err != nil {
+		return fmt.Errorf("extract user id: %w", err)
+	}
+
+	if !user.IsSystemAdmin {
+		if err := dbClient.UpdateUserSystemAdmin(ctx, userID, true); err != nil {
+			return fmt.Errorf("set system admin: %w", err)
+		}
+	}
+
+	// 2. Ensure default vault exists
+	v, err := dbClient.GetVault(ctx, "default")
+	if err != nil {
+		return fmt.Errorf("check default vault: %w", err)
+	}
+	if v == nil {
+		slog.Info("auto-bootstrap: creating default vault")
+		desc := "Default vault"
+		v, err = dbClient.CreateVaultWithID(ctx, "default", userID, models.VaultInput{
+			Name:        "default",
+			Description: &desc,
+		})
+		if err != nil {
+			return fmt.Errorf("create default vault: %w", err)
+		}
+	}
+
+	vaultID, err := models.RecordIDString(v.ID)
+	if err != nil {
+		return fmt.Errorf("extract vault id: %w", err)
+	}
+
+	// 3. Ensure vault membership exists
+	members, err := dbClient.GetVaultMembers(ctx, vaultID)
+	if err != nil {
+		return fmt.Errorf("check vault members: %w", err)
+	}
+	hasMembership := false
+	for _, m := range members {
+		mid, midErr := models.RecordIDString(m.User)
+		if midErr == nil && mid == userID {
+			hasMembership = true
+			break
+		}
+	}
+	if !hasMembership {
+		slog.Info("auto-bootstrap: creating vault membership")
+		if _, err := dbClient.CreateVaultMember(ctx, userID, vaultID, models.RoleAdmin); err != nil {
+			return fmt.Errorf("create vault member: %w", err)
+		}
+	}
+
+	slog.Info("auto-bootstrap complete", "user", userID, "vault", vaultID)
+	return nil
+}

--- a/internal/graph/resolver.go
+++ b/internal/graph/resolver.go
@@ -4,10 +4,15 @@ package graph
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"strings"
+	"sync"
 	"time"
 
+	"github.com/joho/godotenv"
 	"github.com/raphi011/knowhow/internal/agent"
 	"github.com/raphi011/knowhow/internal/config"
 	"github.com/raphi011/knowhow/internal/db"
@@ -20,18 +25,19 @@ import (
 )
 
 // Resolver is the root resolver with all dependencies.
+// mu protects serverConfig, workerCancel, and workerDone.
 type Resolver struct {
+	mu              sync.RWMutex
 	db              *db.Client
 	vaultService    *vault.Service
 	documentService *document.Service
 	searchService   *search.Service
 	templateService *template.Service
-	model           *llm.Model
 	agentService    *agent.Service
 	bus             *event.Bus
-	workerCancel    context.CancelFunc
-	workerDone      chan struct{}
-	serverConfig    ServerConfig
+	workerCancel    context.CancelFunc // guarded by mu
+	workerDone      chan struct{}       // guarded by mu
+	serverConfig    ServerConfig       // guarded by mu
 }
 
 // NewResolver creates a new resolver with all dependencies.
@@ -57,6 +63,14 @@ func NewResolver(ctx context.Context, cfg config.Config) (*Resolver, error) {
 		return nil, err
 	}
 
+	// In no-auth mode, auto-bootstrap the default user/vault if the DB is empty.
+	// This allows the server to self-provision when running as a launchd service.
+	if cfg.NoAuth {
+		if err := seedIfEmpty(ctx, dbClient); err != nil {
+			slog.Warn("auto-bootstrap failed", "error", err)
+		}
+	}
+
 	slog.Info("LLM config",
 		"embed_provider", cfg.EmbedProvider,
 		"embed_model", cfg.EmbedModel,
@@ -67,7 +81,7 @@ func NewResolver(ctx context.Context, cfg config.Config) (*Resolver, error) {
 
 	// Embedder is optional — nil disables AI features
 	var embedder *llm.Embedder
-	if cfg.EmbedProvider != config.ProviderNone && cfg.EmbedProvider != "" {
+	if cfg.EmbedProvider.Enabled() {
 		e, err := llm.NewEmbedder(ctx, cfg, nil)
 		if err != nil {
 			slog.Warn("embedder initialization failed, AI features disabled", "error", err)
@@ -78,7 +92,7 @@ func NewResolver(ctx context.Context, cfg config.Config) (*Resolver, error) {
 
 	// LLM model is optional — nil disables agent chat
 	var model *llm.Model
-	if cfg.LLMProvider != config.ProviderNone && cfg.LLMProvider != "" {
+	if cfg.LLMProvider.Enabled() {
 		m, err := llm.NewModel(ctx, cfg, nil)
 		if err != nil {
 			slog.Warn("LLM model initialization failed, agent chat disabled", "error", err)
@@ -113,8 +127,9 @@ func NewResolver(ctx context.Context, cfg config.Config) (*Resolver, error) {
 	bus := event.New()
 	docService := document.NewService(dbClient, embedder, chunkConfig, versionConfig, bus)
 
+	// workerDone defaults to a closed channel so <-workerDone is a no-op in Close
 	workerDone := make(chan struct{})
-	close(workerDone) // safe default: <-workerDone returns immediately if no worker
+	close(workerDone)
 
 	searchSvc := search.NewService(dbClient, embedder)
 	agentSvc := agent.NewService(dbClient, model, searchSvc, docService, cfg.TavilyAPIKey)
@@ -125,7 +140,6 @@ func NewResolver(ctx context.Context, cfg config.Config) (*Resolver, error) {
 		documentService: docService,
 		searchService:   searchSvc,
 		templateService: template.NewService(dbClient),
-		model:           model,
 		agentService:    agentSvc,
 		bus:             bus,
 		workerDone:      workerDone,
@@ -147,17 +161,7 @@ func NewResolver(ctx context.Context, cfg config.Config) (*Resolver, error) {
 	}
 
 	// Start background embedding worker if embedder is available
-	if embedder != nil {
-		workerCtx, workerCancel := context.WithCancel(context.Background())
-		r.workerCancel = workerCancel
-		r.workerDone = make(chan struct{})
-		interval := time.Duration(cfg.EmbedWorkerInterval) * time.Second
-		worker := document.NewEmbeddingWorker(docService, interval, cfg.EmbedWorkerBatch)
-		go func() {
-			defer close(r.workerDone)
-			worker.Run(workerCtx)
-		}()
-	}
+	r.syncEmbeddingWorker(cfg, embedder)
 
 	return r, nil
 }
@@ -194,12 +198,162 @@ func (r *Resolver) VaultService() *vault.Service {
 
 // Close stops background workers and closes all connections.
 func (r *Resolver) Close(ctx context.Context) error {
-	if r.workerCancel != nil {
-		r.workerCancel()
-		<-r.workerDone
+	r.mu.Lock()
+	cancel := r.workerCancel
+	done := r.workerDone
+	r.workerCancel = nil
+	r.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+		<-done
 	}
 	if r.db != nil {
 		return r.db.Close(ctx)
 	}
 	return nil
+}
+
+// ReloadLLM re-reads .env, recreates LLM/embedding clients, and swaps them
+// into the running services. Called on SIGHUP. On failure, existing working
+// providers are kept — only successful initializations are swapped in.
+func (r *Resolver) ReloadLLM() error {
+	// Load .env into process environment (overwrite existing vars)
+	if err := godotenv.Overload(); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			slog.Debug("no .env file to load")
+		} else {
+			slog.Warn("failed to load .env file, using current environment", "error", err)
+		}
+	}
+
+	cfg := config.Load()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var errs []string
+
+	// Reload embedder — only swap if initialization succeeds
+	embedderWanted := cfg.EmbedProvider.Enabled()
+	var newEmbedder *llm.Embedder
+	embedderChanged := false
+
+	if embedderWanted {
+		e, err := llm.NewEmbedder(ctx, cfg, nil)
+		if err != nil {
+			slog.Error("embedder reload failed, keeping existing", "error", err)
+			errs = append(errs, fmt.Sprintf("embedder: %v", err))
+		} else {
+			newEmbedder = e
+			embedderChanged = true
+		}
+	} else {
+		// Explicitly disabled
+		embedderChanged = true
+		newEmbedder = nil
+	}
+
+	// Reload model — only swap if initialization succeeds
+	modelWanted := cfg.LLMProvider.Enabled()
+	var newModel *llm.Model
+	modelChanged := false
+
+	if modelWanted {
+		m, err := llm.NewModel(ctx, cfg, nil)
+		if err != nil {
+			slog.Error("LLM model reload failed, keeping existing", "error", err)
+			errs = append(errs, fmt.Sprintf("model: %v", err))
+		} else {
+			newModel = m
+			modelChanged = true
+		}
+	} else {
+		modelChanged = true
+		newModel = nil
+	}
+
+	// Only swap providers that were successfully (re)created
+	if embedderChanged {
+		r.documentService.SetEmbedder(newEmbedder)
+		r.searchService.SetEmbedder(newEmbedder)
+	}
+	if modelChanged {
+		r.agentService.SetModel(newModel)
+	}
+
+	// Manage embedding worker lifecycle
+	if embedderChanged {
+		r.syncEmbeddingWorker(cfg, newEmbedder)
+	}
+
+	// Update server config
+	r.mu.Lock()
+	if embedderChanged {
+		r.serverConfig.SemanticSearchEnabled = newEmbedder != nil
+		r.serverConfig.EmbedProvider = string(cfg.EmbedProvider)
+		r.serverConfig.EmbedModel = cfg.EmbedModel
+		r.serverConfig.EmbedDimension = cfg.EmbedDimension
+	}
+	if modelChanged {
+		r.serverConfig.AgentChatEnabled = newModel != nil
+		r.serverConfig.LLMProvider = string(cfg.LLMProvider)
+		r.serverConfig.LLMModel = cfg.LLMModel
+	}
+	r.serverConfig.WebSearchEnabled = cfg.TavilyAPIKey != ""
+	r.mu.Unlock()
+
+	slog.Info("LLM providers reloaded (only LLM/embedding settings are applied)",
+		"semantic_search_changed", embedderChanged,
+		"semantic_search", r.searchService.HasSemanticSearch(),
+		"agent_chat_changed", modelChanged,
+		"agent_chat", r.agentService.Available(),
+	)
+
+	if len(errs) > 0 {
+		return fmt.Errorf("partial reload failure: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// syncEmbeddingWorker starts or stops the background embedding worker based on
+// whether an embedder is available. Protects worker fields with r.mu.
+func (r *Resolver) syncEmbeddingWorker(cfg config.Config, embedder *llm.Embedder) {
+	r.mu.Lock()
+
+	if embedder == nil {
+		// Stop worker if running
+		if r.workerCancel != nil {
+			cancel := r.workerCancel
+			done := r.workerDone
+			r.workerCancel = nil
+			r.mu.Unlock()
+			cancel()
+			<-done
+			slog.Info("stopped embedding worker (embedder removed)")
+			return
+		}
+		r.mu.Unlock()
+		return
+	}
+
+	// Already running — keep it (it picks up the new embedder via getEmbedder)
+	if r.workerCancel != nil {
+		r.mu.Unlock()
+		return
+	}
+
+	// Start new worker
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	r.workerCancel = workerCancel
+	done := make(chan struct{})
+	r.workerDone = done
+	r.mu.Unlock()
+
+	interval := time.Duration(cfg.EmbedWorkerInterval) * time.Second
+	worker := document.NewEmbeddingWorker(r.documentService, interval, cfg.EmbedWorkerBatch)
+	go func() {
+		defer close(done)
+		worker.Run(workerCtx)
+	}()
 }

--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -879,7 +879,10 @@ func (r *queryResolver) SyncMetadata(ctx context.Context, vaultID string, since 
 
 // ServerConfig is the resolver for the serverConfig field.
 func (r *queryResolver) ServerConfig(ctx context.Context) (*ServerConfig, error) {
-	return &r.serverConfig, nil
+	r.mu.RLock()
+	cfg := r.serverConfig
+	r.mu.RUnlock()
+	return &cfg, nil
 }
 
 // DocumentVersion is the resolver for the documentVersion field.

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -18,12 +19,24 @@ import (
 // Base: BM25 fulltext on chunks (always). Semantic: chunk vector search (if embedder configured).
 type Service struct {
 	db       *db.Client
-	embedder *llm.Embedder // optional
+	embedder atomic.Pointer[llm.Embedder] // optional
 }
 
 // NewService creates a new search service.
 func NewService(db *db.Client, embedder *llm.Embedder) *Service {
-	return &Service{db: db, embedder: embedder}
+	s := &Service{db: db}
+	s.embedder.Store(embedder)
+	return s
+}
+
+// SetEmbedder atomically replaces the embedder (used by SIGHUP reload).
+func (s *Service) SetEmbedder(e *llm.Embedder) {
+	s.embedder.Store(e)
+}
+
+// getEmbedder returns the current embedder via an atomic load.
+func (s *Service) getEmbedder() *llm.Embedder {
+	return s.embedder.Load()
 }
 
 type SearchInput struct {
@@ -102,7 +115,8 @@ func (s *Service) Search(ctx context.Context, input SearchInput) ([]SearchResult
 	}
 
 	// If no embedder, aggregate BM25 chunks into results
-	if s.embedder == nil || input.BM25Only {
+	embedder := s.getEmbedder()
+	if embedder == nil || input.BM25Only {
 		return chunksToResults(ctx, s.db, bm25Chunks, limit, input.FullContent, false)
 	}
 
@@ -129,7 +143,7 @@ func (s *Service) Search(ctx context.Context, input SearchInput) ([]SearchResult
 		}()
 	} else {
 		// Cache miss — call embedder
-		queryEmbedding, err = s.embedder.Embed(ctx, input.Query)
+		queryEmbedding, err = embedder.Embed(ctx, input.Query)
 		if err != nil {
 			slog.Warn("failed to embed query, falling back to BM25", "error", err)
 			return chunksToResults(ctx, s.db, bm25Chunks, limit, input.FullContent, true)
@@ -165,7 +179,7 @@ func (s *Service) Search(ctx context.Context, input SearchInput) ([]SearchResult
 
 // HasSemanticSearch returns true if vector search is available.
 func (s *Service) HasSemanticSearch() bool {
-	return s.embedder != nil
+	return s.getEmbedder() != nil
 }
 
 // collectDocIDs returns deduplicated document IDs from multiple chunk slices.

--- a/justfile
+++ b/justfile
@@ -62,10 +62,10 @@ build-all: build build-server
 server *args: build-server
     "{{build_dir}}/{{server}}" "$@"
 
-# Install both binaries to GOPATH/bin
+# Install both binaries to ~/go/bin (explicit GOBIN avoids mise's GOBIN override)
 install:
-    go install -buildvcs=false ./cmd/knowhow
-    go install -buildvcs=false ./cmd/knowhow-server
+    GOBIN="$HOME/go/bin" go install -buildvcs=false ./cmd/knowhow
+    GOBIN="$HOME/go/bin" go install -buildvcs=false ./cmd/knowhow-server
 
 # Run all tests
 test:
@@ -78,6 +78,14 @@ dev: db-up
 # Start dev environment and wipe database on first start
 dev-reset: db-up
     KNOWHOW_WIPE_DB=true air
+
+# Start dev environment using local (launchd) SurrealDB — no Docker needed
+dev-local:
+    SURREALDB_URL="ws://localhost:8000/rpc" SURREALDB_AUTH_LEVEL="none" KNOWHOW_NO_AUTH="true" air
+
+# Bootstrap local (launchd) SurrealDB — no Docker needed
+bootstrap-local: build
+    SURREALDB_URL="ws://localhost:8000/rpc" SURREALDB_AUTH_LEVEL="none" KNOWHOW_NO_AUTH="true" {{build_dir}}/{{binary}} dev seed --wipe
 
 # Run CLI command (ensures correct server URL)
 run *args: build


### PR DESCRIPTION
Add SIGHUP signal handling to reload LLM/embedding providers from `.env` without restarting the server. Add no-auth mode with unauthenticated SurrealDB for local development without Docker.

## Breaking Changes
- None

## Changes

**SIGHUP hot-reload** (`cmd/knowhow-server/main.go`, `internal/graph/resolver.go`)
- `kill -HUP <pid>` reloads `.env` via godotenv, recreates LLM/embedder clients
- Partial-failure safety: only swaps providers that initialized successfully
- Manages embedding worker lifecycle (start/stop based on embedder availability)
- Panic recovery prevents a single failure from killing future reloads

**No-auth local mode** (`internal/db/client.go`, `justfile`, `.env.example`)
- `SURREALDB_AUTH_LEVEL=none` skips authentication for local `--unauthenticated` SurrealDB
- `just dev-local` / `just bootstrap-local` targets for Docker-free development

**Auto-bootstrap** (`internal/graph/bootstrap.go`)
- Seeds admin user, default vault, and membership on empty DB in no-auth mode
- Per-resource idempotency: checks each resource independently, recovers from partial bootstrap

**Thread-safe provider swapping** (`internal/agent/service.go`, `internal/document/service.go`, `internal/search/service.go`)
- `atomic.Pointer[T]` for lock-free model/embedder swaps (replaces `sync.RWMutex`)

**Code quality**
- `LLMProvider.Enabled()` method deduplicates provider checks (`internal/config/config.go`)
- Reuse `syncEmbeddingWorker` in `NewResolver` (eliminates duplicated worker startup)
- Simplified `godotenv.Overload` error check (`errors.Is` traverses chain automatically)
- Reload summary log uses actual runtime state instead of confusing boolean expressions

## Test Coverage
- Unit tests added: n/a (existing tests pass — no new testable units)
- Integration tests added: n/a (requires running SurrealDB + signal delivery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)