### PR TITLE
feat: add image/asset support

### DIFF
--- a/cmd/knowhow/cmd_scrape.go
+++ b/cmd/knowhow/cmd_scrape.go
@@ -1,15 +1,18 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/raphi011/knowhow/internal/apiclient"
+	"github.com/raphi011/knowhow/internal/models"
 	"github.com/spf13/cobra"
 )
 
@@ -23,11 +26,12 @@ var (
 
 var scrapeCmd = &cobra.Command{
 	Use:   "scrape <directory>",
-	Short: "Ingest Markdown files into a vault via the API",
-	Long: `Walk a directory for .md files and create/update documents in a vault.
+	Short: "Ingest Markdown files and images into a vault via the API",
+	Long: `Walk a directory for .md files and images and create/update documents/assets in a vault.
 
 Unchanged files are skipped by comparing content hashes, unless --force is set.
-Each file goes through the full document pipeline (parse, embed, link, chunk).
+Markdown files go through the full document pipeline (parse, embed, link, chunk).
+Image files (PNG, JPEG, GIF, SVG, WebP) are uploaded as binary assets.
 
 Examples:
   knowhow scrape ./docs --vault <id>
@@ -65,22 +69,32 @@ func runScrape(cmd *cobra.Command, args []string) error {
 
 	client := apiclient.New(apiURL, apiToken)
 
-	// 1. Collect local markdown files
-	files, err := collectMarkdownFiles(dirPath)
+	// 1. Collect local files (markdown + images)
+	files, err := collectFiles(dirPath)
 	if err != nil {
 		return fmt.Errorf("scrape: %w", err)
 	}
 	if len(files) == 0 {
-		fmt.Println("No Markdown files found")
+		fmt.Println("No files found")
 		return nil
 	}
-	fmt.Printf("Found %d Markdown files\n", len(files))
+
+	var mdCount, imgCount int
+	for _, f := range files {
+		if models.IsImageFile(f) {
+			imgCount++
+		} else {
+			mdCount++
+		}
+	}
+	fmt.Printf("Found %d Markdown files, %d images\n", mdCount, imgCount)
 
 	// 2. Read content and compute hashes
 	type localFile struct {
 		relPath string // vault-relative path, e.g. /docs/readme.md
-		content string
+		content []byte
 		hash    string
+		isImage bool
 	}
 
 	var localFiles []localFile
@@ -95,19 +109,19 @@ func runScrape(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			rel = absPath
 		}
-		// Normalize to vault path: /relative/path.md
 		vaultPath := "/" + filepath.ToSlash(rel)
 
 		h := sha256.Sum256(content)
 		localFiles = append(localFiles, localFile{
 			relPath: vaultPath,
-			content: string(content),
+			content: content,
 			hash:    hex.EncodeToString(h[:]),
+			isImage: models.IsImageFile(absPath),
 		})
 	}
 
 	// 3. For each file, check existing hash and decide whether to ingest
-	var created, updated, skipped, errCount int
+	var created, updated, skipped, errCount, imagesUploaded int
 
 	for _, lf := range localFiles {
 		if scrapeDryRun {
@@ -116,11 +130,32 @@ func runScrape(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		// Check existing document's content hash (unless --force)
+		if lf.isImage {
+			// Check existing asset hash (unless --force)
+			if !scrapeForce {
+				existing, err := getAssetHash(client, scrapeVaultID, lf.relPath)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: hash check for %s: %v\n", lf.relPath, err)
+				} else if existing == lf.hash {
+					skipped++
+					continue
+				}
+			}
+
+			if err := uploadAsset(client, scrapeVaultID, lf.relPath, lf.content); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %s: %v\n", lf.relPath, err)
+				errCount++
+				continue
+			}
+			fmt.Printf("  + %s (image)\n", lf.relPath)
+			imagesUploaded++
+			continue
+		}
+
+		// Markdown file
 		if !scrapeForce {
 			existing, err := getDocumentHash(client, scrapeVaultID, lf.relPath)
 			if err != nil {
-				// Document might not exist — that's fine, we'll create it
 				fmt.Fprintf(os.Stderr, "Warning: hash check for %s: %v\n", lf.relPath, err)
 			} else if existing == lf.hash {
 				skipped++
@@ -128,8 +163,7 @@ func runScrape(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		// Create/update document via REST API
-		isNew, err := upsertDocument(client, scrapeVaultID, lf.relPath, lf.content, scrapeSource)
+		isNew, err := upsertDocument(client, scrapeVaultID, lf.relPath, string(lf.content), scrapeSource)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %s: %v\n", lf.relPath, err)
 			errCount++
@@ -150,7 +184,7 @@ func runScrape(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Printf("\nDone: %d created, %d updated, %d unchanged, %d errors\n", created, updated, skipped, errCount)
+	fmt.Printf("\nDone: %d created, %d updated, %d images uploaded, %d unchanged, %d errors\n", created, updated, imagesUploaded, skipped, errCount)
 	return nil
 }
 
@@ -161,7 +195,8 @@ func getDocumentHash(client *apiclient.Client, vaultID, path string) (string, er
 		ContentHash *string `json:"contentHash"`
 	}
 
-	err := client.Get(context.Background(), fmt.Sprintf("/api/documents?vault=%s&path=%s", vaultID, path), &doc)
+	q := url.Values{"vault": {vaultID}, "path": {path}}
+	err := client.Get(context.Background(), "/api/documents?"+q.Encode(), &doc)
 	if err != nil {
 		return "", fmt.Errorf("get hash: %w", err)
 	}
@@ -194,8 +229,8 @@ func upsertDocument(client *apiclient.Client, vaultID, path, content, source str
 	return resp.CreatedAt == resp.UpdatedAt, nil
 }
 
-// collectMarkdownFiles walks a directory recursively for .md/.markdown files.
-func collectMarkdownFiles(dirPath string) ([]string, error) {
+// collectFiles walks a directory recursively for .md/.markdown and image files.
+func collectFiles(dirPath string) ([]string, error) {
 	var files []string
 	err := filepath.WalkDir(dirPath, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -205,7 +240,7 @@ func collectMarkdownFiles(dirPath string) ([]string, error) {
 			return nil
 		}
 		ext := strings.ToLower(filepath.Ext(path))
-		if ext == ".md" || ext == ".markdown" {
+		if ext == ".md" || ext == ".markdown" || models.IsImageFile(path) {
 			files = append(files, path)
 		}
 		return nil
@@ -214,4 +249,36 @@ func collectMarkdownFiles(dirPath string) ([]string, error) {
 		return nil, fmt.Errorf("scan directory: %w", err)
 	}
 	return files, nil
+}
+
+// getAssetHash queries the existing asset's contentHash via REST API.
+// Returns empty string if asset doesn't exist.
+func getAssetHash(client *apiclient.Client, vaultID, path string) (string, error) {
+	var asset struct {
+		ContentHash string `json:"contentHash"`
+	}
+
+	q := url.Values{"vault": {vaultID}, "path": {path}}
+	err := client.Get(context.Background(), "/api/assets/meta?"+q.Encode(), &asset)
+	if err != nil {
+		return "", fmt.Errorf("get asset hash: %w", err)
+	}
+
+	return asset.ContentHash, nil
+}
+
+// uploadAsset uploads an image file via multipart POST to the REST API.
+func uploadAsset(client *apiclient.Client, vaultID, path string, data []byte) error {
+	return client.PostMultipart(
+		context.Background(),
+		"/api/assets",
+		map[string]string{
+			"vault": vaultID,
+			"path":  path,
+		},
+		"file",
+		filepath.Base(path),
+		bytes.NewReader(data),
+		nil,
+	)
 }

--- a/cmd/knowhow/cmd_serve.go
+++ b/cmd/knowhow/cmd_serve.go
@@ -150,6 +150,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 		"/dav/",
 		app.DBClient(),
 		app.DocumentService(),
+		app.AssetService(),
 		app.VaultService(),
 		cfg.NoAuth,
 		10*1024*1024, // 10 MB max PUT body

--- a/internal/api/assets.go
+++ b/internal/api/assets.go
@@ -1,0 +1,178 @@
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/raphi011/knowhow/internal/auth"
+	"github.com/raphi011/knowhow/internal/models"
+)
+
+func (s *Server) uploadAsset(w http.ResponseWriter, r *http.Request) {
+	// 32 MB max memory for multipart parsing
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		slog.Warn("parse multipart form", "error", err)
+		writeError(w, http.StatusBadRequest, "invalid multipart form")
+		return
+	}
+
+	vaultID := r.FormValue("vault")
+	path := r.FormValue("path")
+	if vaultID == "" || path == "" {
+		writeError(w, http.StatusBadRequest, "vault and path fields are required")
+		return
+	}
+
+	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleWrite); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	if !models.IsImageFile(path) {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("unsupported image format: %s", path))
+		return
+	}
+
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		slog.Warn("form file extraction failed", "error", err)
+		writeError(w, http.StatusBadRequest, "file field is required")
+		return
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to read file")
+		slog.Error("read upload file", "error", err)
+		return
+	}
+
+	asset, err := s.app.AssetService().Create(r.Context(), models.AssetInput{
+		VaultID: vaultID,
+		Path:    path,
+		Data:    data,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to upload asset")
+		slog.Error("upload asset", "error", err)
+		return
+	}
+
+	vID := models.BareID("vault", vaultID)
+	writeJSON(w, http.StatusCreated, AssetMeta{
+		VaultID:     vID,
+		Path:        asset.Path,
+		MimeType:    asset.MimeType,
+		Size:        asset.Size,
+		ContentHash: asset.ContentHash,
+		CreatedAt:   asset.CreatedAt,
+		UpdatedAt:   asset.UpdatedAt,
+	})
+}
+
+func (s *Server) getAsset(w http.ResponseWriter, r *http.Request) {
+	vaultID := r.URL.Query().Get("vault")
+	path := r.URL.Query().Get("path")
+
+	if vaultID == "" || path == "" {
+		writeError(w, http.StatusBadRequest, "vault and path query parameters required")
+		return
+	}
+
+	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	asset, err := s.app.AssetService().Get(r.Context(), vaultID, path)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get asset")
+		slog.Error("get asset", "error", err)
+		return
+	}
+	if asset == nil {
+		writeError(w, http.StatusNotFound, "asset not found")
+		return
+	}
+
+	w.Header().Set("Content-Type", asset.MimeType)
+	w.Header().Set("ETag", `"`+asset.ContentHash+`"`)
+	w.Header().Set("Cache-Control", "public, max-age=3600, must-revalidate")
+	http.ServeContent(w, r, asset.Path, asset.UpdatedAt, bytes.NewReader(asset.Data))
+}
+
+func (s *Server) getAssetMeta(w http.ResponseWriter, r *http.Request) {
+	vaultID := r.URL.Query().Get("vault")
+	path := r.URL.Query().Get("path")
+
+	if vaultID == "" || path == "" {
+		writeError(w, http.StatusBadRequest, "vault and path query parameters required")
+		return
+	}
+
+	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	meta, err := s.app.AssetService().GetMeta(r.Context(), vaultID, path)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get asset metadata")
+		slog.Error("get asset meta", "error", err)
+		return
+	}
+	if meta == nil {
+		writeError(w, http.StatusNotFound, "asset not found")
+		return
+	}
+
+	vID := models.BareID("vault", vaultID)
+	writeJSON(w, http.StatusOK, AssetMeta{
+		VaultID:     vID,
+		Path:        meta.Path,
+		MimeType:    meta.MimeType,
+		Size:        meta.Size,
+		ContentHash: meta.ContentHash,
+		CreatedAt:   meta.CreatedAt,
+		UpdatedAt:   meta.UpdatedAt,
+	})
+}
+
+func (s *Server) deleteAsset(w http.ResponseWriter, r *http.Request) {
+	vaultID := r.URL.Query().Get("vault")
+	path := r.URL.Query().Get("path")
+
+	if vaultID == "" || path == "" {
+		writeError(w, http.StatusBadRequest, "vault and path query parameters required")
+		return
+	}
+
+	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleWrite); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	// Check existence first so we return 404 instead of silent 204
+	meta, err := s.app.AssetService().GetMeta(r.Context(), vaultID, path)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to check asset")
+		slog.Error("delete asset: check existence", "error", err)
+		return
+	}
+	if meta == nil {
+		writeError(w, http.StatusNotFound, "asset not found")
+		return
+	}
+
+	if err := s.app.AssetService().Delete(r.Context(), vaultID, path); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete asset")
+		slog.Error("delete asset", "error", err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -34,6 +34,12 @@ func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Han
 	mux.Handle("GET /api/documents", authMw(http.HandlerFunc(s.getDocument)))
 	mux.Handle("POST /api/documents", authMw(http.HandlerFunc(s.upsertDocument)))
 
+	// Assets
+	mux.Handle("POST /api/assets", authMw(http.HandlerFunc(s.uploadAsset)))
+	mux.Handle("GET /api/assets", authMw(http.HandlerFunc(s.getAsset)))
+	mux.Handle("GET /api/assets/meta", authMw(http.HandlerFunc(s.getAssetMeta)))
+	mux.Handle("DELETE /api/assets", authMw(http.HandlerFunc(s.deleteAsset)))
+
 	// Config
 	mux.Handle("GET /api/config", authMw(http.HandlerFunc(s.getConfig)))
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -49,6 +49,17 @@ type ChatMessage struct {
 	CreatedAt  time.Time `json:"createdAt"`
 }
 
+// AssetMeta is the JSON representation of asset metadata.
+type AssetMeta struct {
+	VaultID     string    `json:"vaultId"`
+	Path        string    `json:"path"`
+	MimeType    string    `json:"mimeType"`
+	Size        int       `json:"size"`
+	ContentHash string    `json:"contentHash"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
 // ServerConfig holds the server's effective configuration.
 type ServerConfig struct {
 	LLMProvider            string `json:"llmProvider"`

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"time"
 )
@@ -48,6 +49,41 @@ func (c *Client) Delete(ctx context.Context, path string) error {
 	return c.do(ctx, http.MethodDelete, path, nil, nil)
 }
 
+// PostMultipart performs a multipart/form-data POST request.
+// fields are sent as form fields, fileData is sent as a file upload with the given fileField name and fileName.
+func (c *Client) PostMultipart(ctx context.Context, path string, fields map[string]string, fileField, fileName string, fileData io.Reader, target any) error {
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	for k, v := range fields {
+		if err := writer.WriteField(k, v); err != nil {
+			return fmt.Errorf("write field %s: %w", k, err)
+		}
+	}
+
+	part, err := writer.CreateFormFile(fileField, fileName)
+	if err != nil {
+		return fmt.Errorf("create form file: %w", err)
+	}
+	if _, err := io.Copy(part, fileData); err != nil {
+		return fmt.Errorf("copy file data: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("close multipart writer: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, &buf)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	return c.handleResponse(req, target)
+}
+
 func (c *Client) do(ctx context.Context, method, path string, body, target any) error {
 	var bodyReader io.Reader
 	if body != nil {
@@ -69,6 +105,11 @@ func (c *Client) do(ctx context.Context, method, path string, body, target any) 
 		req.Header.Set("Authorization", "Bearer "+c.token)
 	}
 
+	return c.handleResponse(req, target)
+}
+
+// handleResponse executes the request and processes the response.
+func (c *Client) handleResponse(req *http.Request, target any) error {
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return fmt.Errorf("send request: %w", err)
@@ -81,7 +122,6 @@ func (c *Client) do(ctx context.Context, method, path string, body, target any) 
 	}
 
 	if resp.StatusCode >= 400 {
-		// Try to extract error message from JSON
 		var errResp struct {
 			Error string `json:"error"`
 		}

--- a/internal/asset/service.go
+++ b/internal/asset/service.go
@@ -1,0 +1,128 @@
+package asset
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/raphi011/knowhow/internal/db"
+	"github.com/raphi011/knowhow/internal/event"
+	"github.com/raphi011/knowhow/internal/models"
+)
+
+// Service manages asset lifecycle: validate, store, serve.
+type Service struct {
+	db  *db.Client
+	bus *event.Bus
+}
+
+// NewService creates a new asset service.
+func NewService(db *db.Client, bus *event.Bus) *Service {
+	return &Service{db: db, bus: bus}
+}
+
+// Create validates and upserts an asset.
+func (s *Service) Create(ctx context.Context, input models.AssetInput) (*models.Asset, error) {
+	if len(input.Data) == 0 {
+		return nil, fmt.Errorf("empty asset data")
+	}
+
+	if input.MimeType == "" {
+		input.MimeType = models.MimeTypeFromExt(input.Path)
+	}
+	if input.MimeType == "" {
+		input.MimeType = http.DetectContentType(input.Data)
+	}
+
+	input.Path = models.NormalizePath(input.Path)
+
+	asset, err := s.db.UpsertAsset(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("create: %w", err)
+	}
+
+	if s.bus != nil {
+		vaultID := models.BareID("vault", input.VaultID)
+		s.bus.Publish(event.ChangeEvent{
+			Type:    "asset.created",
+			VaultID: vaultID,
+			Payload: event.DocumentPayload{
+				Path:        input.Path,
+				ContentHash: asset.ContentHash,
+			},
+		})
+	}
+
+	return asset, nil
+}
+
+// Get returns the full asset (including data) by vault+path.
+func (s *Service) Get(ctx context.Context, vaultID, path string) (*models.Asset, error) {
+	path = models.NormalizePath(path)
+	asset, err := s.db.GetAssetByPath(ctx, vaultID, path)
+	if err != nil {
+		return nil, fmt.Errorf("get: %w", err)
+	}
+	return asset, nil
+}
+
+// GetMeta returns lightweight asset metadata (no data).
+func (s *Service) GetMeta(ctx context.Context, vaultID, path string) (*models.AssetMeta, error) {
+	path = models.NormalizePath(path)
+	meta, err := s.db.GetAssetMetaByPath(ctx, vaultID, path)
+	if err != nil {
+		return nil, fmt.Errorf("get meta: %w", err)
+	}
+	return meta, nil
+}
+
+// Delete removes an asset by vault+path.
+func (s *Service) Delete(ctx context.Context, vaultID, path string) error {
+	path = models.NormalizePath(path)
+	if err := s.db.DeleteAsset(ctx, vaultID, path); err != nil {
+		return fmt.Errorf("delete: %w", err)
+	}
+
+	if s.bus != nil {
+		s.bus.Publish(event.ChangeEvent{
+			Type:    "asset.deleted",
+			VaultID: models.BareID("vault", vaultID),
+			Payload: event.DocumentPayload{
+				Path: path,
+			},
+		})
+	}
+
+	return nil
+}
+
+// Move renames an asset from oldPath to newPath.
+func (s *Service) Move(ctx context.Context, vaultID, oldPath, newPath string) error {
+	oldPath = models.NormalizePath(oldPath)
+	newPath = models.NormalizePath(newPath)
+	if err := s.db.MoveAsset(ctx, vaultID, oldPath, newPath); err != nil {
+		return fmt.Errorf("move: %w", err)
+	}
+
+	if s.bus != nil {
+		s.bus.Publish(event.ChangeEvent{
+			Type:    "asset.moved",
+			VaultID: models.BareID("vault", vaultID),
+			Payload: event.DocumentPayload{
+				Path:    newPath,
+				OldPath: oldPath,
+			},
+		})
+	}
+
+	return nil
+}
+
+// ListMetas returns lightweight metadata for assets in a vault, optionally filtered by folder.
+func (s *Service) ListMetas(ctx context.Context, vaultID string, folder *string) ([]models.AssetMeta, error) {
+	metas, err := s.db.ListAssetMetas(ctx, vaultID, folder)
+	if err != nil {
+		return nil, fmt.Errorf("list metas: %w", err)
+	}
+	return metas, nil
+}

--- a/internal/db/queries_asset.go
+++ b/internal/db/queries_asset.go
@@ -1,0 +1,175 @@
+package db
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/raphi011/knowhow/internal/models"
+	"github.com/surrealdb/surrealdb.go"
+)
+
+// UpsertAsset creates or updates an asset by vault+path.
+// Computes content_hash and size from the input data.
+func (c *Client) UpsertAsset(ctx context.Context, input models.AssetInput) (*models.Asset, error) {
+	h := sha256.Sum256(input.Data)
+	contentHash := hex.EncodeToString(h[:])
+	size := len(input.Data)
+
+	sql := `
+		UPSERT asset SET
+			vault = type::record("vault", $vault_id),
+			path = $path,
+			mime_type = $mime_type,
+			size = $size,
+			content_hash = $content_hash,
+			data = $data
+		WHERE vault = type::record("vault", $vault_id) AND path = $path
+		RETURN AFTER
+	`
+	results, err := surrealdb.Query[[]models.Asset](ctx, c.DB(), sql, map[string]any{
+		"vault_id":     bareID("vault", input.VaultID),
+		"path":         input.Path,
+		"mime_type":    input.MimeType,
+		"size":         size,
+		"content_hash": contentHash,
+		"data":         input.Data,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("upsert asset: %w", err)
+	}
+	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
+		return nil, fmt.Errorf("upsert asset: no result returned")
+	}
+	return &(*results)[0].Result[0], nil
+}
+
+// GetAssetByPath returns the full asset (including data) by vault+path.
+func (c *Client) GetAssetByPath(ctx context.Context, vaultID, path string) (*models.Asset, error) {
+	sql := `SELECT * FROM asset WHERE vault = type::record("vault", $vault_id) AND path = $path LIMIT 1`
+	results, err := surrealdb.Query[[]models.Asset](ctx, c.DB(), sql, map[string]any{
+		"vault_id": bareID("vault", vaultID),
+		"path":     path,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get asset by path: %w", err)
+	}
+	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
+		return nil, nil
+	}
+	return &(*results)[0].Result[0], nil
+}
+
+// GetAssetMetaByPath returns lightweight asset metadata (no data bytes).
+func (c *Client) GetAssetMetaByPath(ctx context.Context, vaultID, path string) (*models.AssetMeta, error) {
+	sql := `SELECT path, mime_type, size, content_hash, created_at, updated_at FROM asset WHERE vault = type::record("vault", $vault_id) AND path = $path LIMIT 1`
+	results, err := surrealdb.Query[[]models.AssetMeta](ctx, c.DB(), sql, map[string]any{
+		"vault_id": bareID("vault", vaultID),
+		"path":     path,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get asset meta by path: %w", err)
+	}
+	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
+		return nil, nil
+	}
+	return &(*results)[0].Result[0], nil
+}
+
+// ListAssetMetas returns lightweight metadata for assets in a vault, optionally filtered by folder prefix.
+func (c *Client) ListAssetMetas(ctx context.Context, vaultID string, folder *string) ([]models.AssetMeta, error) {
+	vars := map[string]any{
+		"vault_id": bareID("vault", vaultID),
+	}
+
+	var conditions []string
+	conditions = append(conditions, `vault = type::record("vault", $vault_id)`)
+
+	if folder != nil {
+		conditions = append(conditions, `string::starts_with(path, $folder)`)
+		vars["folder"] = *folder
+	}
+
+	where := strings.Join(conditions, " AND ")
+	sql := fmt.Sprintf("SELECT path, mime_type, size, content_hash, created_at, updated_at FROM asset WHERE %s ORDER BY path ASC LIMIT 10000", where)
+
+	results, err := surrealdb.Query[[]models.AssetMeta](ctx, c.DB(), sql, vars)
+	if err != nil {
+		return nil, fmt.Errorf("list asset metas: %w", err)
+	}
+	if results == nil || len(*results) == 0 {
+		return nil, nil
+	}
+	return (*results)[0].Result, nil
+}
+
+// DeleteAsset deletes an asset by vault+path.
+func (c *Client) DeleteAsset(ctx context.Context, vaultID, path string) error {
+	sql := `DELETE FROM asset WHERE vault = type::record("vault", $vault_id) AND path = $path`
+	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
+		"vault_id": bareID("vault", vaultID),
+		"path":     path,
+	}); err != nil {
+		return fmt.Errorf("delete asset: %w", err)
+	}
+	return nil
+}
+
+// DeleteAssetsByPrefix deletes all assets in a vault whose path starts with the given prefix.
+// Returns the number of deleted assets.
+func (c *Client) DeleteAssetsByPrefix(ctx context.Context, vaultID, pathPrefix string) (int, error) {
+	sql := `DELETE FROM asset WHERE vault = type::record("vault", $vault_id) AND string::starts_with(path, $prefix) RETURN BEFORE`
+	results, err := surrealdb.Query[[]models.Asset](ctx, c.DB(), sql, map[string]any{
+		"vault_id": bareID("vault", vaultID),
+		"prefix":   pathPrefix,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("delete assets by prefix: %w", err)
+	}
+	if results == nil || len(*results) == 0 {
+		return 0, nil
+	}
+	return len((*results)[0].Result), nil
+}
+
+// MoveAsset updates an asset's path and mime_type.
+func (c *Client) MoveAsset(ctx context.Context, vaultID, oldPath, newPath string) error {
+	newMime := models.MimeTypeFromExt(newPath)
+	sql := `UPDATE asset SET path = $new_path, mime_type = $mime_type WHERE vault = type::record("vault", $vault_id) AND path = $old_path`
+	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
+		"vault_id":  bareID("vault", vaultID),
+		"old_path":  oldPath,
+		"new_path":  newPath,
+		"mime_type": newMime,
+	}); err != nil {
+		return fmt.Errorf("move asset: %w", err)
+	}
+	return nil
+}
+
+// MoveAssetsByPrefix updates all assets whose path starts with oldPrefix to use newPrefix.
+// Returns the number of moved assets.
+func (c *Client) MoveAssetsByPrefix(ctx context.Context, vaultID, oldPrefix, newPrefix string) (int, error) {
+	sql := `
+		UPDATE asset
+		SET path = string::concat($new_prefix, string::slice(path, string::len($old_prefix))),
+		    mime_type = mime_type
+		WHERE vault = type::record("vault", $vault_id)
+		  AND string::starts_with(path, $old_prefix)
+		RETURN AFTER
+	`
+	results, err := surrealdb.Query[[]models.Asset](ctx, c.DB(), sql, map[string]any{
+		"vault_id":   bareID("vault", vaultID),
+		"old_prefix": oldPrefix,
+		"new_prefix": newPrefix,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("move assets by prefix: %w", err)
+	}
+	if results == nil || len(*results) == 0 {
+		return 0, nil
+	}
+	return len((*results)[0].Result), nil
+}

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -301,5 +301,27 @@ func SchemaSQL(dimension int) string {
             doc_id = type::string($before.id),
             path = $before.path
     };
+
+    -- ==========================================================================
+    -- ASSET TABLE (binary image storage)
+    -- ==========================================================================
+    DEFINE TABLE IF NOT EXISTS asset SCHEMAFULL;
+
+    DEFINE FIELD IF NOT EXISTS vault        ON asset TYPE record<vault>;
+    DEFINE FIELD IF NOT EXISTS path         ON asset TYPE string;
+    DEFINE FIELD IF NOT EXISTS mime_type    ON asset TYPE string;
+    DEFINE FIELD IF NOT EXISTS size         ON asset TYPE int;
+    DEFINE FIELD IF NOT EXISTS content_hash ON asset TYPE string;
+    DEFINE FIELD IF NOT EXISTS data         ON asset TYPE bytes;
+    DEFINE FIELD IF NOT EXISTS created_at   ON asset TYPE datetime DEFAULT time::now();
+    DEFINE FIELD IF NOT EXISTS updated_at   ON asset TYPE datetime VALUE time::now();
+
+    DEFINE INDEX IF NOT EXISTS idx_asset_vault_path ON asset FIELDS vault, path UNIQUE;
+
+    -- Cascade: delete assets when vault deleted
+    DEFINE EVENT IF NOT EXISTS cascade_delete_vault_assets ON vault
+    WHEN $event = "DELETE" ASYNC RETRY 3 THEN {
+        DELETE FROM asset WHERE vault = $before.id
+    };
 `, dimension)
 }

--- a/internal/integration/webdav_test.go
+++ b/internal/integration/webdav_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/raphi011/knowhow/internal/asset"
 	"github.com/raphi011/knowhow/internal/auth"
 	"github.com/raphi011/knowhow/internal/document"
 	"github.com/raphi011/knowhow/internal/models"
@@ -58,7 +60,8 @@ func setupWebDAV(t *testing.T, suffix string) (*httptest.Server, string) {
 	vaultID, vaultSvc := setupVault(t, ctx, "webdav-"+suffix+"-"+fmt.Sprint(time.Now().UnixNano()))
 	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig(), document.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil)
 
-	handler := knowhowdav.NewHandler("/dav/", testDB, docSvc, vaultSvc, true, 1024*1024)
+	assetSvc := asset.NewService(testDB, nil)
+	handler := knowhowdav.NewHandler("/dav/", testDB, docSvc, assetSvc, vaultSvc, true, 1024*1024)
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
@@ -439,7 +442,8 @@ func setupWebDAVWithAuth(t *testing.T, suffix string) (*httptest.Server, string,
 	}
 
 	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig(), document.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil)
-	handler := knowhowdav.NewHandler("/dav/", testDB, docSvc, vaultSvc, false, 1024*1024)
+	assetSvc := asset.NewService(testDB, nil)
+	handler := knowhowdav.NewHandler("/dav/", testDB, docSvc, assetSvc, vaultSvc, false, 1024*1024)
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
@@ -835,4 +839,281 @@ func TestWebDAV_MoveFolder(t *testing.T) {
 			t.Errorf("GET new %s status = %d, want 200", name, resp.StatusCode)
 		}
 	}
+}
+
+// testPNG is a minimal valid 1x1 red PNG (67 bytes).
+var testPNG = []byte{
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG signature
+	0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, // IHDR chunk
+	0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+	0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, // IDAT chunk
+	0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x03, 0x00, 0x01, 0x36, 0x28, 0xcf,
+	0x80, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, // IEND chunk
+	0x44, 0xae, 0x42, 0x60, 0x82,
+}
+
+func TestWebDAV_AssetPutGetRoundtrip(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "asset-roundtrip")
+	vaultName := vaultNameFromID(vaultID)
+	url := davURL(srv, vaultName, "/photo.png")
+
+	// PUT image
+	req := mustNewRequest(t, http.MethodPut, url, bytes.NewReader(testPNG))
+	req.Header.Set("Content-Type", "image/png")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "PUT", http.StatusCreated, http.StatusNoContent)
+
+	// GET image back
+	resp, err = http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	requireStatus(t, resp, "GET", http.StatusOK)
+
+	body := mustReadAll(t, resp.Body)
+	if !bytes.Equal(body, testPNG) {
+		t.Errorf("GET body length = %d, want %d", len(body), len(testPNG))
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if ct != "image/png" {
+		t.Errorf("Content-Type = %q, want image/png", ct)
+	}
+}
+
+func TestWebDAV_AssetDelete(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "asset-delete")
+	vaultName := vaultNameFromID(vaultID)
+	url := davURL(srv, vaultName, "/delete-me.png")
+
+	// PUT
+	req := mustNewRequest(t, http.MethodPut, url, bytes.NewReader(testPNG))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "PUT", http.StatusCreated, http.StatusNoContent)
+
+	// DELETE
+	req = mustNewRequest(t, http.MethodDelete, url, nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "DELETE", http.StatusNoContent, http.StatusOK)
+
+	// GET should 404
+	resp, err = http.Get(url)
+	if err != nil {
+		t.Fatalf("GET after delete: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("GET after delete status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestWebDAV_AssetRename(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "asset-rename")
+	vaultName := vaultNameFromID(vaultID)
+	srcURL := davURL(srv, vaultName, "/rename-src.png")
+	dstURL := davURL(srv, vaultName, "/rename-dst.jpg")
+
+	// PUT
+	req := mustNewRequest(t, http.MethodPut, srcURL, bytes.NewReader(testPNG))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "PUT", http.StatusCreated, http.StatusNoContent)
+
+	// MOVE to new image name
+	req = mustNewRequest(t, "MOVE", srcURL, nil)
+	req.Header.Set("Destination", dstURL)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("MOVE: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "MOVE", http.StatusCreated, http.StatusNoContent)
+
+	// Old path should 404
+	resp, err = http.Get(srcURL)
+	if err != nil {
+		t.Fatalf("GET old: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("GET old path status = %d, want 404", resp.StatusCode)
+	}
+
+	// New path should exist with correct content
+	resp, err = http.Get(dstURL)
+	if err != nil {
+		t.Fatalf("GET new: %v", err)
+	}
+	defer resp.Body.Close()
+	requireStatus(t, resp, "GET new", http.StatusOK)
+
+	body := mustReadAll(t, resp.Body)
+	if !bytes.Equal(body, testPNG) {
+		t.Errorf("GET new body length = %d, want %d", len(body), len(testPNG))
+	}
+}
+
+func TestWebDAV_AssetRenameToNonImageRejected(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "asset-rename-reject")
+	vaultName := vaultNameFromID(vaultID)
+	srcURL := davURL(srv, vaultName, "/img.png")
+	dstURL := davURL(srv, vaultName, "/img.txt")
+
+	// PUT
+	req := mustNewRequest(t, http.MethodPut, srcURL, bytes.NewReader(testPNG))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "PUT", http.StatusCreated, http.StatusNoContent)
+
+	// MOVE to non-image should fail
+	req = mustNewRequest(t, "MOVE", srcURL, nil)
+	req.Header.Set("Destination", dstURL)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("MOVE: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode < 400 {
+		t.Errorf("MOVE to non-image status = %d, want error", resp.StatusCode)
+	}
+
+	// Original should still exist
+	resp, err = http.Get(srcURL)
+	if err != nil {
+		t.Fatalf("GET original: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "GET original", http.StatusOK)
+}
+
+func TestWebDAV_AssetInDirListing(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "asset-listing")
+	vaultName := vaultNameFromID(vaultID)
+
+	// PUT a markdown file and an image at root
+	req := mustNewRequest(t, http.MethodPut, davURL(srv, vaultName, "/readme.md"), strings.NewReader("# Readme"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT md: %v", err)
+	}
+	resp.Body.Close()
+
+	req = mustNewRequest(t, http.MethodPut, davURL(srv, vaultName, "/logo.png"), bytes.NewReader(testPNG))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT png: %v", err)
+	}
+	resp.Body.Close()
+
+	// PROPFIND on root should list both
+	req = mustNewRequest(t, "PROPFIND", davURL(srv, vaultName, "/"), nil)
+	req.Header.Set("Depth", "1")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PROPFIND: %v", err)
+	}
+	defer resp.Body.Close()
+	requireStatus(t, resp, "PROPFIND", http.StatusMultiStatus)
+
+	body := string(mustReadAll(t, resp.Body))
+	if !strings.Contains(body, "readme.md") {
+		t.Error("PROPFIND missing readme.md")
+	}
+	if !strings.Contains(body, "logo.png") {
+		t.Error("PROPFIND missing logo.png")
+	}
+}
+
+func TestWebDAV_FolderDeleteCascadeAssets(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "folder-cascade-assets")
+	vaultName := vaultNameFromID(vaultID)
+
+	// Create folder
+	req := mustNewRequest(t, "MKCOL", davURL(srv, vaultName, "/imgs"), nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("MKCOL: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "MKCOL", http.StatusCreated)
+
+	// PUT a doc and an asset inside
+	req = mustNewRequest(t, http.MethodPut, davURL(srv, vaultName, "/imgs/note.md"), strings.NewReader("# Note"))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT md: %v", err)
+	}
+	resp.Body.Close()
+
+	req = mustNewRequest(t, http.MethodPut, davURL(srv, vaultName, "/imgs/pic.png"), bytes.NewReader(testPNG))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT png: %v", err)
+	}
+	resp.Body.Close()
+
+	// DELETE folder
+	req = mustNewRequest(t, http.MethodDelete, davURL(srv, vaultName, "/imgs/"), nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "DELETE", http.StatusNoContent, http.StatusOK)
+
+	// Both should be gone
+	for _, p := range []string{"/imgs/note.md", "/imgs/pic.png"} {
+		resp, err = http.Get(davURL(srv, vaultName, p))
+		if err != nil {
+			t.Fatalf("GET %s: %v", p, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("GET %s after folder delete status = %d, want 404", p, resp.StatusCode)
+		}
+	}
+}
+
+func TestWebDAV_NonImageNonMarkdownRejected(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "reject-nonimage")
+	vaultName := vaultNameFromID(vaultID)
+
+	// PUT a .txt file should be rejected
+	req := mustNewRequest(t, http.MethodPut, davURL(srv, vaultName, "/file.txt"), strings.NewReader("hello"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode < 400 {
+		t.Errorf("PUT .txt status = %d, want error", resp.StatusCode)
+	}
+
+	// PUT a .png file should be accepted
+	req = mustNewRequest(t, http.MethodPut, davURL(srv, vaultName, "/ok.png"), bytes.NewReader(testPNG))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "PUT .png", http.StatusCreated, http.StatusNoContent)
 }

--- a/internal/models/asset.go
+++ b/internal/models/asset.go
@@ -1,0 +1,62 @@
+package models
+
+import (
+	"path"
+	"strings"
+	"time"
+
+	surrealmodels "github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+type Asset struct {
+	ID          surrealmodels.RecordID `json:"id"`
+	Vault       surrealmodels.RecordID `json:"vault"`
+	Path        string                 `json:"path"`
+	MimeType    string                 `json:"mime_type"`
+	Size        int                    `json:"size"`
+	ContentHash string                 `json:"content_hash"`
+	Data        []byte                 `json:"data"`
+	CreatedAt   time.Time              `json:"created_at"`
+	UpdatedAt   time.Time              `json:"updated_at"`
+}
+
+// AssetMeta is a lightweight projection of an asset without binary data.
+type AssetMeta struct {
+	Path        string    `json:"path"`
+	MimeType    string    `json:"mime_type"`
+	Size        int       `json:"size"`
+	ContentHash string    `json:"content_hash"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+type AssetInput struct {
+	VaultID  string `json:"vault_id"`
+	Path     string `json:"path"`
+	MimeType string `json:"mime_type"`
+	Data     []byte `json:"data"`
+}
+
+// imageExtensions maps lowercase extensions to MIME types.
+var imageExtensions = map[string]string{
+	".png":  "image/png",
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif":  "image/gif",
+	".svg":  "image/svg+xml",
+	".webp": "image/webp",
+}
+
+// IsImageFile returns true if the file has a supported image extension.
+func IsImageFile(name string) bool {
+	ext := strings.ToLower(path.Ext(name))
+	_, ok := imageExtensions[ext]
+	return ok
+}
+
+// MimeTypeFromExt returns the MIME type for a file based on its extension.
+// Returns empty string for unsupported extensions.
+func MimeTypeFromExt(name string) string {
+	ext := strings.ToLower(path.Ext(name))
+	return imageExtensions[ext]
+}

--- a/internal/models/asset_test.go
+++ b/internal/models/asset_test.go
@@ -1,0 +1,72 @@
+package models
+
+import "testing"
+
+func TestIsImageFile(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"/docs/photo.png", true},
+		{"/docs/photo.jpg", true},
+		{"/docs/photo.jpeg", true},
+		{"/docs/photo.gif", true},
+		{"/docs/photo.svg", true},
+		{"/docs/photo.webp", true},
+		// Case insensitive
+		{"/docs/photo.PNG", true},
+		{"/docs/photo.Jpg", true},
+		{"/docs/photo.WEBP", true},
+		// Unsupported
+		{"/docs/readme.md", false},
+		{"/docs/file.txt", false},
+		{"/docs/file.pdf", false},
+		{"/docs/file.bmp", false},
+		{"/docs/file.tiff", false},
+		// Edge cases
+		{"", false},
+		{"noext", false},
+		{"/docs/image.backup.png", true},
+		{"/docs/.png", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsImageFile(tt.name)
+			if got != tt.want {
+				t.Errorf("IsImageFile(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMimeTypeFromExt(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"/photo.png", "image/png"},
+		{"/photo.jpg", "image/jpeg"},
+		{"/photo.jpeg", "image/jpeg"},
+		{"/photo.gif", "image/gif"},
+		{"/photo.svg", "image/svg+xml"},
+		{"/photo.webp", "image/webp"},
+		// Case insensitive
+		{"/photo.PNG", "image/png"},
+		{"/photo.JPG", "image/jpeg"},
+		// Unsupported returns empty
+		{"/file.txt", ""},
+		{"/file.md", ""},
+		{"", ""},
+		{"noext", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MimeTypeFromExt(tt.name)
+			if got != tt.want {
+				t.Errorf("MimeTypeFromExt(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/raphi011/knowhow/internal/agent"
+	"github.com/raphi011/knowhow/internal/asset"
 	"github.com/raphi011/knowhow/internal/config"
 	"github.com/raphi011/knowhow/internal/db"
 	"github.com/raphi011/knowhow/internal/document"
@@ -49,6 +50,7 @@ type App struct {
 	db                      *db.Client
 	vaultService            *vault.Service
 	documentService         *document.Service
+	assetService            *asset.Service
 	searchService           *search.Service
 	templateService         *template.Service
 	agentService            *agent.Service
@@ -158,9 +160,12 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	searchSvc := search.NewService(dbClient, embedder)
 	agentSvc := agent.NewService(dbClient, model, searchSvc, docService, cfg.TavilyAPIKey)
 
+	assetSvc := asset.NewService(dbClient, bus)
+
 	app := &App{
 		db:                       dbClient,
 		vaultService:             vault.NewService(dbClient),
+		assetService:             assetSvc,
 		processingWorkerInterval: time.Duration(cfg.ProcessingWorkerInterval) * time.Second,
 		processingWorkerBatch:    cfg.ProcessingWorkerBatch,
 		documentService:      docService,
@@ -229,6 +234,11 @@ func (a *App) VaultService() *vault.Service {
 // TemplateService returns the template service.
 func (a *App) TemplateService() *template.Service {
 	return a.templateService
+}
+
+// AssetService returns the asset service.
+func (a *App) AssetService() *asset.Service {
+	return a.assetService
 }
 
 // Config returns the server configuration.

--- a/internal/vault/service.go
+++ b/internal/vault/service.go
@@ -93,14 +93,20 @@ func (s *Service) CreateFolder(ctx context.Context, vaultID, folderPath string) 
 	return folder, nil
 }
 
-// DeleteFolder deletes a folder, all child folders, and all documents under the folder prefix.
+// DeleteFolder deletes a folder, all child folders, documents, and assets under the folder prefix.
 func (s *Service) DeleteFolder(ctx context.Context, vaultID, folderPath string) error {
 	folderPath = models.NormalizePath(folderPath)
 
-	// Delete child documents
 	prefix := folderPath + "/"
+
+	// Delete child documents
 	if _, err := s.db.DeleteDocumentsByPrefix(ctx, vaultID, prefix); err != nil {
 		return fmt.Errorf("delete folder documents: %w", err)
+	}
+
+	// Delete child assets
+	if _, err := s.db.DeleteAssetsByPrefix(ctx, vaultID, prefix); err != nil {
+		return fmt.Errorf("delete folder assets: %w", err)
 	}
 
 	// Delete folder records (self + children)
@@ -111,7 +117,7 @@ func (s *Service) DeleteFolder(ctx context.Context, vaultID, folderPath string) 
 	return nil
 }
 
-// MoveFolder moves a folder and all its children (folders + documents) from oldPath to newPath.
+// MoveFolder moves a folder and all its children (folders, documents, and assets) from oldPath to newPath.
 func (s *Service) MoveFolder(ctx context.Context, vaultID, oldPath, newPath string) error {
 	oldPath = models.NormalizePath(oldPath)
 	newPath = models.NormalizePath(newPath)
@@ -124,6 +130,11 @@ func (s *Service) MoveFolder(ctx context.Context, vaultID, oldPath, newPath stri
 	// Move documents
 	if _, err := s.db.MoveDocumentsByPrefix(ctx, vaultID, oldPath+"/", newPath+"/"); err != nil {
 		return fmt.Errorf("move folder documents: %w", err)
+	}
+
+	// Move assets
+	if _, err := s.db.MoveAssetsByPrefix(ctx, vaultID, oldPath+"/", newPath+"/"); err != nil {
+		return fmt.Errorf("move folder assets: %w", err)
 	}
 
 	// Ensure destination ancestor folders exist

--- a/internal/webdav/file.go
+++ b/internal/webdav/file.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/raphi011/knowhow/internal/asset"
 	"github.com/raphi011/knowhow/internal/document"
 	"github.com/raphi011/knowhow/internal/models"
 )
@@ -187,4 +188,91 @@ func (f *nopFile) Close() error {
 func (f *nopFile) Readdir(int) ([]fs.FileInfo, error) { return nil, os.ErrInvalid }
 func (f *nopFile) Stat() (fs.FileInfo, error) {
 	return &fileInfo{name: path.Base(f.name), modTime: f.modTime}, nil
+}
+
+// assetReadFile provides read-only access to an asset's binary data.
+type assetReadFile struct {
+	name   string
+	asset  *models.Asset
+	reader *bytes.Reader
+}
+
+func newAssetReadFile(name string, a *models.Asset) *assetReadFile {
+	return &assetReadFile{
+		name:   name,
+		asset:  a,
+		reader: bytes.NewReader(a.Data),
+	}
+}
+
+func (f *assetReadFile) Read(p []byte) (int, error) { return f.reader.Read(p) }
+func (f *assetReadFile) Write([]byte) (int, error)  { return 0, os.ErrPermission }
+func (f *assetReadFile) Seek(offset int64, whence int) (int64, error) {
+	return f.reader.Seek(offset, whence)
+}
+func (f *assetReadFile) Close() error                           { return nil }
+func (f *assetReadFile) Readdir(int) ([]fs.FileInfo, error) { return nil, os.ErrInvalid }
+func (f *assetReadFile) Stat() (fs.FileInfo, error) {
+	return &fileInfo{
+		name:        path.Base(f.name),
+		size:        int64(f.asset.Size),
+		modTime:     f.asset.UpdatedAt,
+		contentType: f.asset.MimeType,
+		etag:        `"` + f.asset.ContentHash + `"`,
+	}, nil
+}
+
+// assetWriteFile buffers writes and stores the asset on Close().
+type assetWriteFile struct {
+	name     string
+	vaultID  string
+	assetSvc *asset.Service
+	buf      bytes.Buffer
+	modTime  time.Time
+}
+
+func newAssetWriteFile(name, vaultID string, assetSvc *asset.Service, modTime time.Time) *assetWriteFile {
+	return &assetWriteFile{
+		name:     name,
+		vaultID:  vaultID,
+		assetSvc: assetSvc,
+		modTime:  modTime,
+	}
+}
+
+func (f *assetWriteFile) Read([]byte) (int, error)           { return 0, os.ErrPermission }
+func (f *assetWriteFile) Readdir(int) ([]fs.FileInfo, error) { return nil, os.ErrInvalid }
+func (f *assetWriteFile) Seek(int64, int) (int64, error)     { return 0, os.ErrPermission }
+
+func (f *assetWriteFile) Write(p []byte) (int, error) {
+	return f.buf.Write(p)
+}
+
+func (f *assetWriteFile) Close() error {
+	data := f.buf.Bytes()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := f.assetSvc.Create(ctx, models.AssetInput{
+		VaultID: f.vaultID,
+		Path:    f.name,
+		Data:    data,
+	})
+	if err != nil {
+		slog.Error("webdav: failed to save asset on close",
+			"path", f.name, "vault", f.vaultID, "error", err)
+		return fmt.Errorf("close %s: %w", f.name, err)
+	}
+
+	slog.Info("webdav: asset saved", "path", f.name, "vault", f.vaultID, "size", len(data))
+	return nil
+}
+
+func (f *assetWriteFile) Stat() (fs.FileInfo, error) {
+	return &fileInfo{
+		name:        path.Base(f.name),
+		size:        int64(f.buf.Len()),
+		modTime:     f.modTime,
+		contentType: models.MimeTypeFromExt(f.name),
+	}, nil
 }

--- a/internal/webdav/fs.go
+++ b/internal/webdav/fs.go
@@ -15,27 +15,31 @@ import (
 
 	"golang.org/x/net/webdav"
 
+	"github.com/raphi011/knowhow/internal/asset"
 	"github.com/raphi011/knowhow/internal/db"
 	"github.com/raphi011/knowhow/internal/document"
+	"github.com/raphi011/knowhow/internal/models"
 	"github.com/raphi011/knowhow/internal/vault"
 )
 
 const markdownContentType = "text/markdown; charset=utf-8"
 
-// FS implements webdav.FileSystem backed by document and vault services.
+// FS implements webdav.FileSystem backed by document, asset, and vault services.
 type FS struct {
 	vaultID    string
 	db         *db.Client
 	docService *document.Service
+	assetSvc   *asset.Service
 	vaultSvc   *vault.Service
 }
 
 // NewFS creates a WebDAV filesystem for the given vault.
-func NewFS(vaultID string, db *db.Client, docService *document.Service, vaultSvc *vault.Service) *FS {
+func NewFS(vaultID string, db *db.Client, docService *document.Service, assetSvc *asset.Service, vaultSvc *vault.Service) *FS {
 	return &FS{
 		vaultID:    vaultID,
 		db:         db,
 		docService: docService,
+		assetSvc:   assetSvc,
 		vaultSvc:   vaultSvc,
 	}
 }
@@ -88,6 +92,26 @@ func (f *FS) OpenFile(ctx context.Context, name string, flag int, perm os.FileMo
 		return newReadFile(name, doc), nil
 	}
 
+	// Try as asset
+	if flag&(os.O_WRONLY|os.O_RDWR) != 0 {
+		// For write mode, only need metadata (avoid loading full binary data)
+		assetMeta, err := f.assetSvc.GetMeta(ctx, f.vaultID, name)
+		if err != nil {
+			return nil, fmt.Errorf("open %s: %w", name, err)
+		}
+		if assetMeta != nil {
+			return newAssetWriteFile(name, f.vaultID, f.assetSvc, assetMeta.UpdatedAt), nil
+		}
+	} else {
+		assetObj, err := f.assetSvc.Get(ctx, f.vaultID, name)
+		if err != nil {
+			return nil, fmt.Errorf("open %s: %w", name, err)
+		}
+		if assetObj != nil {
+			return newAssetReadFile(name, assetObj), nil
+		}
+	}
+
 	// Try as folder
 	folder, err := f.db.GetFolderByPath(ctx, f.vaultID, name)
 	if err != nil {
@@ -99,6 +123,9 @@ func (f *FS) OpenFile(ctx context.Context, name string, flag int, perm os.FileMo
 
 	// Not found — if creating, open for write
 	if flag&os.O_CREATE != 0 {
+		if models.IsImageFile(name) {
+			return newAssetWriteFile(name, f.vaultID, f.assetSvc, time.Now()), nil
+		}
 		if !isMarkdownFile(name) {
 			return nil, errNotMarkdown
 		}
@@ -128,6 +155,18 @@ func (f *FS) RemoveAll(ctx context.Context, name string) error {
 	if doc != nil {
 		if err := f.docService.Delete(ctx, f.vaultID, name); err != nil {
 			return fmt.Errorf("remove document %s: %w", name, err)
+		}
+		return nil
+	}
+
+	// Try as asset
+	assetMeta, err := f.assetSvc.GetMeta(ctx, f.vaultID, name)
+	if err != nil {
+		return fmt.Errorf("remove %s: %w", name, err)
+	}
+	if assetMeta != nil {
+		if err := f.assetSvc.Delete(ctx, f.vaultID, name); err != nil {
+			return fmt.Errorf("remove asset %s: %w", name, err)
 		}
 		return nil
 	}
@@ -168,6 +207,21 @@ func (f *FS) Rename(ctx context.Context, oldName, newName string) error {
 		}
 		if _, err := f.docService.Move(ctx, f.vaultID, oldName, newName); err != nil {
 			return fmt.Errorf("rename %s to %s: %w", oldName, newName, err)
+		}
+		return nil
+	}
+
+	// Try as asset
+	assetMeta, err := f.assetSvc.GetMeta(ctx, f.vaultID, oldName)
+	if err != nil {
+		return fmt.Errorf("rename %s: %w", oldName, err)
+	}
+	if assetMeta != nil {
+		if !models.IsImageFile(newName) {
+			return fmt.Errorf("cannot rename asset to non-image file: %w", os.ErrPermission)
+		}
+		if err := f.assetSvc.Move(ctx, f.vaultID, oldName, newName); err != nil {
+			return fmt.Errorf("rename asset %s to %s: %w", oldName, newName, err)
 		}
 		return nil
 	}
@@ -217,6 +271,22 @@ func (f *FS) Stat(ctx context.Context, name string) (os.FileInfo, error) {
 			fi.etag = `"` + *meta.ContentHash + `"`
 		}
 		return fi, nil
+	}
+
+	// Try as asset
+	assetMeta, err := f.assetSvc.GetMeta(ctx, f.vaultID, name)
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", name, err)
+	}
+	if assetMeta != nil {
+		return &fileInfo{
+			name:        path.Base(name),
+			size:        int64(assetMeta.Size),
+			modTime:     assetMeta.UpdatedAt,
+			isDir:       false,
+			contentType: assetMeta.MimeType,
+			etag:        `"` + assetMeta.ContentHash + `"`,
+		}, nil
 	}
 
 	// Try as folder
@@ -307,6 +377,29 @@ func (f *FS) listDirEntries(ctx context.Context, dirPath string) ([]os.FileInfo,
 		entries = append(entries, fi)
 	}
 
+	// List immediate child assets
+	assetMetas, err := f.assetSvc.ListMetas(ctx, f.vaultID, &folderFilter)
+	if err != nil {
+		return nil, fmt.Errorf("list assets in %s: %w", dirPath, err)
+	}
+	for _, am := range assetMetas {
+		rel := strings.TrimPrefix(am.Path, folderFilter)
+		if dirPath == "/" {
+			rel = strings.TrimPrefix(am.Path, "/")
+		}
+		if strings.Contains(rel, "/") {
+			continue // nested asset, skip
+		}
+		entries = append(entries, &fileInfo{
+			name:        path.Base(am.Path),
+			size:        int64(am.Size),
+			modTime:     am.UpdatedAt,
+			isDir:       false,
+			contentType: am.MimeType,
+			etag:        `"` + am.ContentHash + `"`,
+		})
+	}
+
 	return entries, nil
 }
 
@@ -321,8 +414,8 @@ func isOSMetadataFile(name string) bool {
 	return strings.HasPrefix(base, "._") || base == ".DS_Store"
 }
 
-// errNotMarkdown is returned when a non-markdown file is created or renamed to.
-var errNotMarkdown = fmt.Errorf("only markdown files (.md) are allowed: %w", os.ErrPermission)
+// errNotMarkdown is returned when a non-markdown, non-image file is created or renamed to.
+var errNotMarkdown = fmt.Errorf("only markdown (.md) and image files are allowed: %w", os.ErrPermission)
 
 // normalizeName cleans up a WebDAV path to match our internal path format.
 func normalizeName(name string) string {

--- a/internal/webdav/handler.go
+++ b/internal/webdav/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"golang.org/x/net/webdav"
 
+	"github.com/raphi011/knowhow/internal/asset"
 	"github.com/raphi011/knowhow/internal/auth"
 	"github.com/raphi011/knowhow/internal/db"
 	"github.com/raphi011/knowhow/internal/document"
@@ -26,6 +27,7 @@ func NewHandler(
 	pathPrefix string,
 	dbClient *db.Client,
 	docService *document.Service,
+	assetSvc *asset.Service,
 	vaultSvc *vault.Service,
 	noAuth bool,
 	maxPutBytes int64,
@@ -137,7 +139,7 @@ func NewHandler(
 		}
 
 		// Create per-request WebDAV handler with the resolved vault
-		davFS := NewFS(vaultID, dbClient, docService, vaultSvc)
+		davFS := NewFS(vaultID, dbClient, docService, assetSvc, vaultSvc)
 		davHandler := &webdav.Handler{
 			FileSystem: davFS,
 			LockSystem: getLockSystem(vaultID),

--- a/internal/webdav/handler_test.go
+++ b/internal/webdav/handler_test.go
@@ -9,7 +9,7 @@ import (
 func TestHandler_OSMetadataFastPath(t *testing.T) {
 	// Handler with nil dependencies — if the fast path works,
 	// these are never touched and we don't panic.
-	handler := NewHandler("/dav/", nil, nil, nil, true, 0)
+	handler := NewHandler("/dav/", nil, nil, nil, nil, true, 0)
 
 	tests := []struct {
 		method string
@@ -48,7 +48,7 @@ func TestHandler_OSMetadataFastPath(t *testing.T) {
 func TestHandler_RealFilesNotShortCircuited(t *testing.T) {
 	// A request for a real .md file with nil deps should panic,
 	// proving the fast path did NOT intercept it.
-	handler := NewHandler("/dav/", nil, nil, nil, true, 0)
+	handler := NewHandler("/dav/", nil, nil, nil, nil, true, 0)
 	req := httptest.NewRequest("PROPFIND", "/dav/somevault/readme.md", nil)
 	rec := httptest.NewRecorder()
 


### PR DESCRIPTION
Add binary image asset storage alongside existing markdown documents. Assets are stored in SurrealDB with content-hash-based deduplication and served via both REST API and WebDAV.

## New Features
- **Asset table** in SurrealDB with vault+path unique index, cascade delete on vault removal
- **REST API**: `POST /api/assets` (multipart upload), `GET /api/assets` (binary serving with range requests), `GET /api/assets/meta`, `DELETE /api/assets`
- **WebDAV**: full read/write/rename/delete/stat/list support for image files (PNG, JPEG, GIF, SVG, WebP)
- **CLI scrape**: `knowhow scrape` now ingests images alongside markdown, with hash-based skip for unchanged files
- **Asset service** with CRUD, move, path normalization, MIME auto-detection (extension + content sniffing), event bus integration
- Folder delete/move cascades to child assets (not just documents)
- Uses SurrealDB `UPSERT` for race-free asset creation
- `http.ServeContent` for conditional responses and range request support

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)