### PR TITLE
feat: TLS skip verify for Bedrock proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,7 @@ KNOWHOW_EMBED_DIMENSION=768
 
 # AWS Bedrock (Claude models only for LLM, see bedrock-setup.sh for Teleport setup)
 # KNOWHOW_BEDROCK_EMBED_MODEL_PROVIDER=amazon     # For embedding inference profiles
+# KNOWHOW_TLS_SKIP_VERIFY=false                   # Skip TLS verification for local Teleport proxy
 # AWS_REGION=eu-central-1
 # AWS_ACCESS_KEY_ID=...                           # Set by Teleport proxy
 # AWS_SECRET_ACCESS_KEY=...                       # Set by Teleport proxy

--- a/docs/teleport-proxy.md
+++ b/docs/teleport-proxy.md
@@ -65,9 +65,9 @@ Source: `tool/tsh/common/app_aws.go` — `GetAWSCredentialsProvider()` generates
 
 **Root cause**: eino-ext passes `Config.HTTPClient` (*http.Client) to `awsConfig.WithHTTPClient()`. When `AWS_CA_BUNDLE` is set, the AWS SDK's `resolveCustomCABundle` does a type assertion to `*awshttp.BuildableClient`, which fails on a plain `*http.Client` → panic.
 
-**Workaround**: Unset `AWS_CA_BUNDLE` before creating the eino-ext client, handle the CA cert ourselves.
+**Workaround**: Unset `AWS_CA_BUNDLE` before creating the eino-ext client. When `KNOWHOW_TLS_SKIP_VERIFY=true`, `AWS_CA_BUNDLE` is no longer set in `.env` at all, so the panic path is avoided entirely.
 
-**Status**: Fixed in `internal/llm/model.go:newBedrockChatModel()`.
+**Status**: Fixed in `internal/llm/model.go:newBedrockChatModel()`. CA bundle unset kept as defensive measure.
 
 ### Issue 2: HTTPClient Not Used for API Calls (eino-ext bug #2)
 
@@ -75,9 +75,9 @@ Source: `tool/tsh/common/app_aws.go` — `GetAWSCredentialsProvider()` generates
 
 **Root cause**: In eino-ext's Bedrock path (`claude.go:86-105`), the `HTTPClient` is only passed to `awsConfig.WithHTTPClient()` (for SigV4 signing), NOT to `option.WithHTTPClient()` (for actual API calls). The Anthropic SDK always uses `http.DefaultClient` for Bedrock requests.
 
-**Workaround**: Patch `http.DefaultTransport` with the proxy CA cert so `http.DefaultClient` trusts it.
+**Workaround**: When `KNOWHOW_TLS_SKIP_VERIFY=true`, set `InsecureSkipVerify` on `http.DefaultTransport`. Fallback: patch `http.DefaultTransport` with the proxy CA cert when skip-verify is off.
 
-**Status**: Fixed in `internal/llm/model.go:addCAToDefaultTransport()`.
+**Status**: Fixed in `internal/llm/model.go:skipVerifyDefaultTransport()` / `addCAToDefaultTransport()`.
 
 ### Issue 3: CA Cert File Overwritten by Other tsh Sessions
 
@@ -85,9 +85,9 @@ Source: `tool/tsh/common/app_aws.go` — `GetAWSCredentialsProvider()` generates
 
 **Root cause**: Multiple `tsh` sessions (e.g., `tsh proxy aws` for knowhow AND `tsh aws --exec claude` for Claude Code) all write their CA certs to the **same file** at `~/.tsh/keys/<host>/<user>-app/<cluster>/<app>-localca.pem`. Each new session overwrites the previous cert. The proxy uses the cert from when IT started, but the app reads the file later — by which point a different session may have overwritten it.
 
-**Workaround**: Snapshot the CA cert to `~/.tsh/knowhow-proxy-ca.pem` immediately after starting the proxy.
+**Resolution**: With `KNOWHOW_TLS_SKIP_VERIFY=true`, the CA cert file is no longer needed — TLS verification is skipped for the local proxy. The proxy is always on `127.0.0.1`, so MITM is not a concern. The old CA cert snapshot workaround has been removed from `bedrock-setup.fish`.
 
-**Status**: Fixed in `bedrock-setup.fish` (copies cert to stable location after proxy starts).
+**Status**: Resolved by `KNOWHOW_TLS_SKIP_VERIFY`.
 
 ### Issue 4: 400 Bad Request from Proxy — RESOLVED
 
@@ -120,7 +120,7 @@ env -u HTTPS_PROXY -u HTTP_PROXY tsh proxy aws --app $APP -p $PORT
 
 - `internal/llm/model.go` — Bedrock LLM workaround (issues 1 & 2)
 - `internal/llm/embedder.go` — Bedrock embedder (uses AWS SDK natively)
-- `bedrock-setup.fish` — Proxy startup + cert snapshot (issues 3 & 4)
+- `bedrock-setup.fish` — Proxy startup + env var setup (issues 3 & 4)
 - `.env` — Generated credentials and proxy config (not committed)
 
 ## Teleport Source References (v18.6.1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,9 @@ type Config struct {
 	// Versioning settings
 	VersionCoalesceMinutes int // minutes between version snapshots (default: 10)
 	VersionRetentionCount  int // max versions per document (default: 50)
+
+	// TLS settings
+	TLSSkipVerify bool // skip TLS verification for Bedrock proxy (KNOWHOW_TLS_SKIP_VERIFY)
 }
 
 // ChunkConfig returns the chunking configuration as a parser.ChunkConfig.
@@ -151,6 +154,9 @@ func Load() Config {
 		// Versioning
 		VersionCoalesceMinutes: getEnvInt("KNOWHOW_VERSION_COALESCE_MINUTES", 10),
 		VersionRetentionCount:  getEnvInt("KNOWHOW_VERSION_RETENTION", 50),
+
+		// TLS
+		TLSSkipVerify: getEnvBool("KNOWHOW_TLS_SKIP_VERIFY", false),
 	}
 }
 

--- a/internal/llm/embedder.go
+++ b/internal/llm/embedder.go
@@ -3,12 +3,15 @@ package llm
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 	"time"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	"github.com/cloudwego/eino/components/embedding"
 	geminiembed "github.com/cloudwego/eino-ext/components/embedding/gemini"
@@ -99,9 +102,7 @@ func NewEmbedder(ctx context.Context, cfg config.Config, mc *metrics.Collector) 
 		}
 
 	case config.ProviderBedrock:
-		// AWS SDK picks up env vars: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
-		// AWS_REGION, HTTPS_PROXY, AWS_CA_BUNDLE
-		model, err = newBedrockEmbedder(ctx, cfg.EmbedModel, cfg.BedrockEmbedModelProvider)
+		model, err = newBedrockEmbedder(ctx, cfg.EmbedModel, cfg.BedrockEmbedModelProvider, cfg.TLSSkipVerify)
 		if err != nil {
 			return nil, fmt.Errorf("create bedrock embedder: %w", err)
 		}
@@ -212,7 +213,7 @@ type bedrockEmbedder struct {
 
 // newBedrockEmbedder creates a Bedrock embedder that supports inference profile ARNs.
 // If providerHint is empty and modelID is an ARN, returns error.
-func newBedrockEmbedder(ctx context.Context, modelID, providerHint string) (*bedrockEmbedder, error) {
+func newBedrockEmbedder(ctx context.Context, modelID, providerHint string, tlsSkipVerify bool) (*bedrockEmbedder, error) {
 	// Determine provider
 	provider := providerHint
 	if provider == "" {
@@ -232,8 +233,21 @@ func newBedrockEmbedder(ctx context.Context, modelID, providerHint string) (*bed
 		return nil, fmt.Errorf("unsupported bedrock embedding provider: %s (use 'amazon' or 'cohere')", provider)
 	}
 
-	// Create AWS client
-	awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
+	// Create AWS client, optionally skipping TLS verification for local proxy.
+	// See .env.example for required AWS env vars.
+	var opts []func(*awsconfig.LoadOptions) error
+	if tlsSkipVerify {
+		slog.Warn("bedrock embedder: skipping TLS verification for local proxy")
+		opts = append(opts, awsconfig.WithHTTPClient(
+			awshttp.NewBuildableClient().WithTransportOptions(func(t *http.Transport) {
+				if t.TLSClientConfig == nil {
+					t.TLSClientConfig = &tls.Config{}
+				}
+				t.TLSClientConfig.InsecureSkipVerify = true
+			}),
+		))
+	}
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("load AWS config: %w", err)
 	}

--- a/internal/llm/model.go
+++ b/internal/llm/model.go
@@ -37,25 +37,37 @@ import (
 //     (for actual API calls). So the Anthropic SDK always uses
 //     http.DefaultClient for Bedrock requests, ignoring Config.HTTPClient.
 //
-// Workaround: temporarily unset AWS_CA_BUNDLE to prevent the panic (bug 1),
-// and inject the CA into http.DefaultTransport so the Anthropic SDK's
-// http.DefaultClient trusts the proxy certificate (bug 2).
+// Workaround: temporarily unset AWS_CA_BUNDLE to prevent the panic (bug 1).
+// For bug 2, when tlsSkipVerify is true, set InsecureSkipVerify on
+// http.DefaultTransport. Otherwise, inject the CA from AWS_CA_BUNDLE
+// into http.DefaultTransport so http.DefaultClient trusts the proxy cert.
 //
 // TODO: remove this once eino-ext fixes both bugs.
 // See: https://github.com/cloudwego/eino-ext/issues/712
 // See: docs/teleport-proxy.md (Issues 1 & 2)
-func newBedrockChatModel(ctx context.Context, model string) (*claude.ChatModel, error) {
+func newBedrockChatModel(ctx context.Context, model string, tlsSkipVerify bool) (*claude.ChatModel, error) {
+	// NOTE: This temporarily mutates the environment. NewModel and NewEmbedder
+	// must not be called concurrently when AWS_CA_BUNDLE is set.
 	caBundle := os.Getenv("AWS_CA_BUNDLE")
 	if caBundle != "" {
 		// Bug 1: unset to prevent AWS SDK panic.
 		// Errors from Unsetenv/Setenv are impossible here (key is a valid, non-empty string).
 		_ = os.Unsetenv("AWS_CA_BUNDLE")
 		defer func() { _ = os.Setenv("AWS_CA_BUNDLE", caBundle) }()
+	}
 
-		// Bug 2: patch http.DefaultTransport with the CA so the Anthropic
+	if tlsSkipVerify {
+		// Skip TLS verification takes precedence over CA bundle injection.
+		// AWS_CA_BUNDLE is still unset above to prevent the eino-ext panic (bug 1).
+		slog.Warn("skipping TLS verification on http.DefaultTransport", "reason", "eino-ext bug #2")
+		if err := skipVerifyDefaultTransport(); err != nil {
+			return nil, fmt.Errorf("skip verify default transport: %w", err)
+		}
+	} else if caBundle != "" {
+		// Fallback: patch http.DefaultTransport with the CA so the Anthropic
 		// SDK's http.DefaultClient trusts the proxy certificate.
 		if err := addCAToDefaultTransport(caBundle); err != nil {
-			return nil, fmt.Errorf("new bedrock chat model: %w", err)
+			return nil, fmt.Errorf("add CA to default transport: %w", err)
 		}
 	}
 
@@ -63,6 +75,21 @@ func newBedrockChatModel(ctx context.Context, model string) (*claude.ChatModel, 
 		ByBedrock: true,
 		Model:     model,
 	})
+}
+
+// skipVerifyDefaultTransport sets InsecureSkipVerify on http.DefaultTransport.
+// This is process-global but necessary because the Anthropic SDK uses
+// http.DefaultClient for Bedrock API calls (eino-ext bug #2).
+func skipVerifyDefaultTransport() error {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return fmt.Errorf("http.DefaultTransport is not *http.Transport")
+	}
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{}
+	}
+	transport.TLSClientConfig.InsecureSkipVerify = true
+	return nil
 }
 
 // addCAToDefaultTransport appends a PEM CA certificate to http.DefaultTransport's
@@ -204,7 +231,7 @@ func NewModel(ctx context.Context, cfg config.Config, mc *metrics.Collector) (*M
 		}
 
 	case config.ProviderBedrock:
-		chatModel, err = newBedrockChatModel(ctx, cfg.LLMModel)
+		chatModel, err = newBedrockChatModel(ctx, cfg.LLMModel, cfg.TLSSkipVerify)
 		if err != nil {
 			return nil, fmt.Errorf("create bedrock model: %w", err)
 		}


### PR DESCRIPTION
Add `KNOWHOW_TLS_SKIP_VERIFY` config option and address PR review feedback for the Teleport proxy TLS handling.

## New Features
- `KNOWHOW_TLS_SKIP_VERIFY` env var to skip TLS verification for local Teleport proxy (Bedrock embedder + chat model)
- Scoped TLS skip for embedder (`awshttp.BuildableClient`), global `http.DefaultTransport` patch for chat model (forced by eino-ext bug #2)

## PR Review Fixes
- **Doc-block** (`model.go`): rewritten to describe both skip-verify and CA-injection paths
- **Error wrapping** (`model.go:64,70`): context now describes caller's sub-operation, not callee
- **Security logging** (`model.go`, `embedder.go`): `slog.Warn` when TLS verification is disabled
- **Precedence comment** (`model.go`): clarifies skip-verify vs CA bundle interaction
- **`.env.example`**: added `KNOWHOW_TLS_SKIP_VERIFY` to Bedrock section
- **Concurrency note** (`model.go`): documents env var mutation is not concurrent-safe
- **Stale docs** (`teleport-proxy.md`): updated `bedrock-setup.fish` description, Issue 1-3 statuses
- **Env var reference** (`embedder.go`): added `.env.example` pointer for AWS env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)