### PR TITLE
fix: support macOS Finder two-phase WebDAV asset upload

### DIFF
--- a/docs/surrealdb.md
+++ b/docs/surrealdb.md
@@ -149,6 +149,29 @@ if existing == nil {
 }
 ```
 
+### `UPSERT ... WHERE` Does Not Create New Records
+
+In SurrealDB v3, `UPSERT ... WHERE` only updates existing rows — it **never creates** new records when the WHERE clause matches nothing. This silently does nothing and returns an empty result set.
+
+```sql
+-- BAD: silently does nothing if no asset matches this vault+path
+UPSERT asset SET data = $data WHERE vault = $v AND path = $p RETURN AFTER
+
+-- GOOD: check-then-create/update pattern
+-- 1. SELECT to check existence (use a lightweight projection to avoid loading blobs)
+-- 2. If not found: CREATE asset SET ...
+-- 3. If found: UPDATE asset SET ... WHERE ...
+-- 4. On unique constraint violation during CREATE: retry as UPDATE (race condition)
+```
+
+This is the same pattern used by `UpsertDocument` and `UpsertAsset` in this codebase.
+
+### `bytes` Fields Reject NULL
+
+SurrealDB's `bytes` type does not accept NULL — even for empty/nil data. Passing a Go `nil` slice results in `Couldn't coerce value for field: Expected 'bytes' but found 'NULL'`.
+
+**Fix**: Normalize `nil` to `[]byte{}` before passing to the query.
+
 ## v3.0 Breaking Changes
 
 ### KNN Operator

--- a/internal/asset/service.go
+++ b/internal/asset/service.go
@@ -22,16 +22,17 @@ func NewService(db *db.Client, bus *event.Bus) *Service {
 }
 
 // Create validates and upserts an asset.
+// Accepts empty data to support macOS Finder's two-phase PUT protocol
+// (empty PUT to claim, then PUT with real data).
 func (s *Service) Create(ctx context.Context, input models.AssetInput) (*models.Asset, error) {
-	if len(input.Data) == 0 {
-		return nil, fmt.Errorf("empty asset data")
-	}
-
 	if input.MimeType == "" {
 		input.MimeType = models.MimeTypeFromExt(input.Path)
 	}
-	if input.MimeType == "" {
+	if input.MimeType == "" && len(input.Data) > 0 {
 		input.MimeType = http.DetectContentType(input.Data)
+	}
+	if input.MimeType == "" {
+		input.MimeType = "application/octet-stream"
 	}
 
 	input.Path = models.NormalizePath(input.Path)
@@ -41,7 +42,9 @@ func (s *Service) Create(ctx context.Context, input models.AssetInput) (*models.
 		return nil, fmt.Errorf("create: %w", err)
 	}
 
-	if s.bus != nil {
+	// Only publish event when there's actual data — empty claim PUTs
+	// from macOS Finder's two-phase protocol are not meaningful changes.
+	if s.bus != nil && len(input.Data) > 0 {
 		vaultID := models.BareID("vault", input.VaultID)
 		s.bus.Publish(event.ChangeEvent{
 			Type:    "asset.created",

--- a/internal/db/queries_asset.go
+++ b/internal/db/queries_asset.go
@@ -13,15 +13,77 @@ import (
 
 // UpsertAsset creates or updates an asset by vault+path.
 // Computes content_hash and size from the input data.
+// Uses check-then-create/update to work around SurrealDB v3's UPSERT ... WHERE
+// not creating new records when no match exists.
 func (c *Client) UpsertAsset(ctx context.Context, input models.AssetInput) (*models.Asset, error) {
+	// Normalize nil to empty slice — SurrealDB rejects NULL for bytes fields.
+	if input.Data == nil {
+		input.Data = []byte{}
+	}
 	h := sha256.Sum256(input.Data)
 	contentHash := hex.EncodeToString(h[:])
 	size := len(input.Data)
 
+	const maxRetries = 3
+
+	for attempt := range maxRetries {
+		existing, err := c.GetAssetMetaByPath(ctx, input.VaultID, input.Path)
+		if err != nil {
+			return nil, fmt.Errorf("upsert asset: check existing: %w", err)
+		}
+
+		if existing == nil {
+			asset, err := c.createAsset(ctx, input, contentHash, size)
+			if err != nil {
+				if isUniqueViolation(err) && attempt < maxRetries-1 {
+					continue
+				}
+				return nil, fmt.Errorf("upsert asset: %w", err)
+			}
+			return asset, nil
+		}
+
+		asset, err := c.updateAsset(ctx, input, contentHash, size)
+		if err != nil {
+			return nil, fmt.Errorf("upsert asset: %w", err)
+		}
+		return asset, nil
+	}
+
+	return nil, fmt.Errorf("upsert asset: exhausted %d retries due to concurrent writes", maxRetries)
+}
+
+func (c *Client) createAsset(ctx context.Context, input models.AssetInput, contentHash string, size int) (*models.Asset, error) {
 	sql := `
-		UPSERT asset SET
+		CREATE asset SET
 			vault = type::record("vault", $vault_id),
 			path = $path,
+			mime_type = $mime_type,
+			size = $size,
+			content_hash = $content_hash,
+			data = $data
+		RETURN AFTER
+	`
+	results, err := surrealdb.Query[[]models.Asset](ctx, c.DB(), sql, map[string]any{
+		"vault_id":     bareID("vault", input.VaultID),
+		"path":         input.Path,
+		"mime_type":    input.MimeType,
+		"size":         size,
+		"content_hash": contentHash,
+		"data":         input.Data,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create asset: %w", err)
+	}
+	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
+		return nil, fmt.Errorf("create asset: no result returned")
+	}
+	return &(*results)[0].Result[0], nil
+}
+
+func (c *Client) updateAsset(ctx context.Context, input models.AssetInput, contentHash string, size int) (*models.Asset, error) {
+	sql := `
+		UPDATE asset SET
 			mime_type = $mime_type,
 			size = $size,
 			content_hash = $content_hash,
@@ -38,10 +100,10 @@ func (c *Client) UpsertAsset(ctx context.Context, input models.AssetInput) (*mod
 		"data":         input.Data,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("upsert asset: %w", err)
+		return nil, fmt.Errorf("update asset: %w", err)
 	}
 	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("upsert asset: no result returned")
+		return nil, fmt.Errorf("update asset: no result returned")
 	}
 	return &(*results)[0].Result[0], nil
 }

--- a/internal/integration/webdav_test.go
+++ b/internal/integration/webdav_test.go
@@ -1093,6 +1093,61 @@ func TestWebDAV_FolderDeleteCascadeAssets(t *testing.T) {
 	}
 }
 
+func TestWebDAV_AssetFinderTwoPhasePut(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "finder-2phase")
+	vaultName := vaultNameFromID(vaultID)
+	url := davURL(srv, vaultName, "/finder-upload.png")
+
+	// Phase 1: PUT with empty body (macOS Finder "claim" request)
+	req := mustNewRequest(t, http.MethodPut, url, bytes.NewReader(nil))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT empty: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "PUT empty", http.StatusCreated, http.StatusNoContent)
+
+	// Phase 2: PROPFIND Depth:0 to verify file exists (Finder does this before uploading data)
+	req = mustNewRequest(t, "PROPFIND", url, nil)
+	req.Header.Set("Depth", "0")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PROPFIND: %v", err)
+	}
+	defer resp.Body.Close()
+	requireStatus(t, resp, "PROPFIND", http.StatusMultiStatus)
+	propBody := string(mustReadAll(t, resp.Body))
+	if !strings.Contains(propBody, "finder-upload.png") {
+		t.Errorf("PROPFIND response missing filename:\n%s", propBody)
+	}
+
+	// Phase 3: PUT with real PNG data
+	req = mustNewRequest(t, http.MethodPut, url, bytes.NewReader(testPNG))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT real data: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "PUT real data", http.StatusCreated, http.StatusNoContent)
+
+	// Verify: GET returns the real data with correct Content-Type
+	resp, err = http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	requireStatus(t, resp, "GET", http.StatusOK)
+
+	body := mustReadAll(t, resp.Body)
+	if !bytes.Equal(body, testPNG) {
+		t.Errorf("GET body length = %d, want %d", len(body), len(testPNG))
+	}
+	ct := resp.Header.Get("Content-Type")
+	if ct != "image/png" {
+		t.Errorf("Content-Type = %q, want image/png", ct)
+	}
+}
+
 func TestWebDAV_NonImageNonMarkdownRejected(t *testing.T) {
 	srv, vaultID := setupWebDAV(t, "reject-nonimage")
 	vaultName := vaultNameFromID(vaultID)


### PR DESCRIPTION
macOS Finder uploads files via WebDAV using a two-phase protocol (PUT empty → PROPFIND → PUT real data). Two SurrealDB v3 bugs prevented this from working for assets.

## New Features

- WebDAV asset uploads from macOS Finder now work correctly

## Breaking Changes

- None

### What changed

- **`internal/db/queries_asset.go`** — Replace broken `UPSERT...WHERE` with check-then-create/update pattern (same as `UpsertDocument`). Normalize nil bytes to `[]byte{}` for SurrealDB's `bytes` type.
- **`internal/asset/service.go`** — Only publish `asset.created` events when data is non-empty (skip Finder's empty claim PUTs).
- **`internal/integration/webdav_test.go`** — Add `TestWebDAV_AssetFinderTwoPhasePut` covering the full Finder protocol.
- **`docs/surrealdb.md`** — Document `UPSERT...WHERE` and `bytes` NULL gotchas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)