### PR TITLE
feat: add labels CLI command and agent system prompt labels

### DIFF
--- a/cmd/knowhow/cmd_labels.go
+++ b/cmd/knowhow/cmd_labels.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/raphi011/knowhow/internal/apiclient"
+	"github.com/spf13/cobra"
+)
+
+var (
+	labelsVaultID string
+	labelsCounts  bool
+)
+
+var labelsCmd = &cobra.Command{
+	Use:   "labels",
+	Short: "List labels in a vault",
+	Long: `List all labels used by documents in a vault.
+
+Examples:
+  knowhow labels --vault default
+  knowhow labels --vault default --count`,
+	RunE: runLabels,
+}
+
+func init() {
+	labelsCmd.Flags().StringVar(&labelsVaultID, "vault", "", "vault name (required)")
+	labelsCmd.Flags().BoolVar(&labelsCounts, "count", false, "show document count per label")
+	if err := labelsCmd.MarkFlagRequired("vault"); err != nil {
+		panic(fmt.Sprintf("mark vault flag required: %v", err))
+	}
+}
+
+func runLabels(_ *cobra.Command, _ []string) error {
+	if err := requireToken(); err != nil {
+		return fmt.Errorf("labels: %w", err)
+	}
+
+	client := apiclient.New(apiURL, apiToken)
+	ctx := context.Background()
+
+	if labelsCounts {
+		counts, err := client.ListLabelsWithCounts(ctx, labelsVaultID)
+		if err != nil {
+			return fmt.Errorf("labels: %w", err)
+		}
+		for _, lc := range counts {
+			fmt.Printf("%s (%d)\n", lc.Label, lc.Count)
+		}
+		return nil
+	}
+
+	labels, err := client.ListLabels(ctx, labelsVaultID)
+	if err != nil {
+		return fmt.Errorf("labels: %w", err)
+	}
+	sort.Strings(labels)
+	for _, l := range labels {
+		fmt.Println(l)
+	}
+	return nil
+}

--- a/cmd/knowhow/cmd_ui.go
+++ b/cmd/knowhow/cmd_ui.go
@@ -24,13 +24,13 @@ environment variables or flags:
 
 Examples:
   knowhow ui
-  knowhow ui --vault vault:default
+  knowhow ui --vault default
   knowhow ui --server-url http://localhost:4001 --token kh_...`,
 	RunE: runUI,
 }
 
 func init() {
-	uiCmd.Flags().StringVar(&uiVaultID, "vault", envOrDefault("KNOWHOW_VAULT", "vault:default"), "vault ID to use")
+	uiCmd.Flags().StringVar(&uiVaultID, "vault", envOrDefault("KNOWHOW_VAULT", "default"), "vault name to use")
 }
 
 func runUI(_ *cobra.Command, _ []string) error {

--- a/cmd/knowhow/main.go
+++ b/cmd/knowhow/main.go
@@ -51,6 +51,7 @@ func main() {
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(uiCmd)
 	rootCmd.AddCommand(serveCmd)
+	rootCmd.AddCommand(labelsCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/docs/surrealdb.md
+++ b/docs/surrealdb.md
@@ -365,6 +365,21 @@ RETURN array::distinct(array::flatten(...))
 
 Bracket-based negative indexing (`[-1]`) is unreliable — returns NONE. Use `array::last()` or `array::at()` instead.
 
+### `SPLIT` and `GROUP BY` Are Mutually Exclusive
+
+In v3.0, `SPLIT` and `GROUP BY` cannot appear in the same query — they have opposing semantics (SPLIT multiplies rows, GROUP collapses them). This was allowed in v2.
+
+```sql
+-- FAILS: "SPLIT and GROUP are mutually exclusive"
+SELECT labels, count() AS count FROM document SPLIT labels GROUP BY labels
+
+-- WORKS: subquery — SPLIT first, then GROUP in the outer query
+SELECT label, count() AS count
+FROM (SELECT labels AS label FROM document SPLIT labels)
+GROUP BY label
+ORDER BY count DESC
+```
+
 ### `STARTS WITH` vs `string::starts_with()`
 
 The `STARTS WITH` operator can fail in compound WHERE clauses. Use `string::starts_with()` function instead.

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -85,7 +85,7 @@ func (s *Service) Available() bool {
 	return s.getModel() != nil
 }
 
-// buildSystemPrompt constructs the system prompt, optionally appending the vault's folder tree.
+// buildSystemPrompt constructs the system prompt, appending the vault's folder tree and label summary when available.
 func (s *Service) buildSystemPrompt(ctx context.Context, vaultID string) string {
 	base := `You are a helpful knowledge assistant for the Knowhow knowledge base. You help users find and understand information stored in their documents.
 
@@ -99,27 +99,35 @@ func (s *Service) buildSystemPrompt(ctx context.Context, vaultID string) string 
 - Always cite document paths when referencing information from the knowledge base
 - Do not include a sources section at the end of your response — sources are shown separately in the UI`
 
+	var sb strings.Builder
+	sb.WriteString(base)
+
 	folders, err := s.db.ListFolders(ctx, vaultID)
 	if err != nil {
 		slog.Warn("failed to list folders for system prompt", "vault_id", vaultID, "error", err)
-		return base
-	}
-	if len(folders) == 0 {
-		return base
+	} else if len(folders) > 0 {
+		sb.WriteString("\n\nVault folder structure:\n```\n/\n")
+		for _, f := range folders {
+			depth := strings.Count(strings.Trim(f.Path, "/"), "/")
+			indent := strings.Repeat("  ", depth)
+			sb.WriteString(indent)
+			sb.WriteString("├── ")
+			sb.WriteString(f.Name)
+			sb.WriteString("/\n")
+		}
+		sb.WriteString("```")
 	}
 
-	var sb strings.Builder
-	sb.WriteString(base)
-	sb.WriteString("\n\nVault folder structure:\n```\n/\n")
-	for _, f := range folders {
-		depth := strings.Count(strings.Trim(f.Path, "/"), "/")
-		indent := strings.Repeat("  ", depth)
-		sb.WriteString(indent)
-		sb.WriteString("├── ")
-		sb.WriteString(f.Name)
-		sb.WriteString("/\n")
+	labelCounts, err := s.db.ListLabelsWithCounts(ctx, vaultID)
+	if err != nil {
+		slog.Warn("failed to list labels for system prompt", "vault_id", vaultID, "error", err)
+	} else if len(labelCounts) > 0 {
+		sb.WriteString("\n\nVault labels:\n")
+		for _, lc := range labelCounts {
+			fmt.Fprintf(&sb, "- %s (%d)\n", lc.Label, lc.Count)
+		}
 	}
-	sb.WriteString("```")
+
 	return sb.String()
 }
 

--- a/internal/api/labels.go
+++ b/internal/api/labels.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/raphi011/knowhow/internal/auth"
+	"github.com/raphi011/knowhow/internal/models"
+)
+
+func (s *Server) listLabels(w http.ResponseWriter, r *http.Request) {
+	vaultID := r.URL.Query().Get("vault")
+	if vaultID == "" {
+		writeError(w, http.StatusBadRequest, "vault query parameter required")
+		return
+	}
+
+	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	if r.URL.Query().Get("counts") == "true" {
+		counts, err := s.app.DBClient().ListLabelsWithCounts(r.Context(), vaultID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to list labels")
+			slog.Error("list labels with counts", "vault_id", vaultID, "error", err)
+			return
+		}
+		writeJSON(w, http.StatusOK, counts)
+		return
+	}
+
+	labels, err := s.app.DBClient().ListLabels(r.Context(), vaultID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list labels")
+		slog.Error("list labels", "vault_id", vaultID, "error", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, labels)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -40,6 +40,9 @@ func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Han
 	mux.Handle("GET /api/assets/meta", authMw(http.HandlerFunc(s.getAssetMeta)))
 	mux.Handle("DELETE /api/assets", authMw(http.HandlerFunc(s.deleteAsset)))
 
+	// Labels
+	mux.Handle("GET /api/labels", authMw(http.HandlerFunc(s.listLabels)))
+
 	// Config
 	mux.Handle("GET /api/config", authMw(http.HandlerFunc(s.getConfig)))
 }

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -9,7 +9,10 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"time"
+
+	"github.com/raphi011/knowhow/internal/models"
 )
 
 // Client is a REST API client for the Knowhow server.
@@ -106,6 +109,24 @@ func (c *Client) do(ctx context.Context, method, path string, body, target any) 
 	}
 
 	return c.handleResponse(req, target)
+}
+
+// ListLabels returns all distinct labels in the given vault.
+func (c *Client) ListLabels(ctx context.Context, vaultID string) ([]string, error) {
+	var labels []string
+	if err := c.Get(ctx, "/api/labels?vault="+url.QueryEscape(vaultID), &labels); err != nil {
+		return nil, fmt.Errorf("list labels: %w", err)
+	}
+	return labels, nil
+}
+
+// ListLabelsWithCounts returns labels with their document counts for the given vault.
+func (c *Client) ListLabelsWithCounts(ctx context.Context, vaultID string) ([]models.LabelCount, error) {
+	var counts []models.LabelCount
+	if err := c.Get(ctx, "/api/labels?vault="+url.QueryEscape(vaultID)+"&counts=true", &counts); err != nil {
+		return nil, fmt.Errorf("list labels with counts: %w", err)
+	}
+	return counts, nil
 }
 
 // handleResponse executes the request and processes the response.

--- a/internal/db/queries_document.go
+++ b/internal/db/queries_document.go
@@ -370,6 +370,25 @@ func (c *Client) ListLabels(ctx context.Context, vaultID string) ([]string, erro
 	return labels, nil
 }
 
+// ListLabelsWithCounts returns labels with their document counts for the given vault.
+func (c *Client) ListLabelsWithCounts(ctx context.Context, vaultID string) ([]models.LabelCount, error) {
+	sql := `SELECT label, count() AS count FROM (SELECT labels AS label FROM document WHERE vault = type::record("vault", $vault_id) SPLIT labels) GROUP BY label ORDER BY count DESC`
+	results, err := surrealdb.Query[[]models.LabelCount](ctx, c.DB(), sql, map[string]any{
+		"vault_id": bareID("vault", vaultID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list labels with counts: %w", err)
+	}
+	if results == nil || len(*results) == 0 {
+		return []models.LabelCount{}, nil
+	}
+	counts := (*results)[0].Result
+	if counts == nil {
+		return []models.LabelCount{}, nil
+	}
+	return counts, nil
+}
+
 // GetDocumentMetaByPath returns lightweight metadata for a document (no content).
 // Returns nil if the document doesn't exist.
 func (c *Client) GetDocumentMetaByPath(ctx context.Context, vaultID, path string) (*models.DocumentMeta, error) {

--- a/internal/db/queries_document_test.go
+++ b/internal/db/queries_document_test.go
@@ -459,6 +459,69 @@ func TestListLabels(t *testing.T) {
 	}
 }
 
+func TestListLabelsWithCounts(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	// Empty vault should return empty slice
+	emptyCounts, err := testDB.ListLabelsWithCounts(ctx, vaultID)
+	if err != nil {
+		t.Fatalf("ListLabelsWithCounts on empty vault failed: %v", err)
+	}
+	if len(emptyCounts) != 0 {
+		t.Errorf("expected 0 label counts on empty vault, got %d", len(emptyCounts))
+	}
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	for _, doc := range []struct {
+		path   string
+		labels []string
+	}{
+		{"/lc-" + suffix + "/a.md", []string{"go", "project"}},
+		{"/lc-" + suffix + "/b.md", []string{"go", "tutorial"}},
+		{"/lc-" + suffix + "/c.md", []string{"rust"}},
+	} {
+		_, err := testDB.CreateDocument(ctx, models.DocumentInput{
+			VaultID:     vaultID,
+			Path:        doc.path,
+			Title:       "Doc " + doc.path,
+			Content:     "content",
+			ContentBody: "content",
+			Source:      models.SourceManual,
+			Labels:      doc.labels,
+		})
+		if err != nil {
+			t.Fatalf("CreateDocument %s failed: %v", doc.path, err)
+		}
+	}
+
+	counts, err := testDB.ListLabelsWithCounts(ctx, vaultID)
+	if err != nil {
+		t.Fatalf("ListLabelsWithCounts failed: %v", err)
+	}
+
+	// Should be sorted by count desc: go(2), then project/tutorial/rust(1 each)
+	if len(counts) != 4 {
+		t.Fatalf("expected 4 label counts, got %d", len(counts))
+	}
+	if counts[0].Label != "go" || counts[0].Count != 2 {
+		t.Errorf("expected first label to be go(2), got %s(%d)", counts[0].Label, counts[0].Count)
+	}
+
+	countMap := map[string]int{}
+	for _, lc := range counts {
+		countMap[lc.Label] = lc.Count
+	}
+	for _, label := range []string{"project", "tutorial", "rust"} {
+		if countMap[label] != 1 {
+			t.Errorf("expected label %q count 1, got %d", label, countMap[label])
+		}
+	}
+}
+
 func TestUpsertDocument(t *testing.T) {
 	ctx := context.Background()
 	user := createTestUser(t, ctx)

--- a/internal/models/document.go
+++ b/internal/models/document.go
@@ -67,6 +67,12 @@ type DocumentMeta struct {
 	UpdatedAt     time.Time `json:"updated_at"`
 }
 
+// LabelCount holds a label and its document count.
+type LabelCount struct {
+	Label string `json:"label"`
+	Count int    `json:"count"`
+}
+
 // Folder is a first-class folder record backed by the folder table.
 type Folder struct {
 	ID        surrealmodels.RecordID `json:"id"`


### PR DESCRIPTION
Add CLI command to list labels in a vault and include label counts in the agent system prompt, giving the LLM awareness of available categories.

## New Features
- `knowhow labels --vault <name>` — list all labels alphabetically
- `knowhow labels --vault <name> --count` — list labels with document counts, sorted by count descending
- `GET /api/labels?vault=<name>[&counts=true]` REST endpoint
- Agent system prompt now includes vault labels with counts (alongside existing folder structure)
- Clean up `ui` command vault default from `vault:default` to `default`

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)