### PR TITLE
feat: virtual read-only files in WebDAV

### DIFF
--- a/internal/db/queries_document.go
+++ b/internal/db/queries_document.go
@@ -160,18 +160,36 @@ func (c *Client) GetDocumentByID(ctx context.Context, id string) (*models.Docume
 	return &(*results)[0].Result[0], nil
 }
 
+// DocumentOrderBy defines allowed ORDER BY clauses for document queries.
+type DocumentOrderBy string
+
+const (
+	OrderByPathAsc       DocumentOrderBy = "path ASC"
+	OrderByUpdatedAtDesc DocumentOrderBy = "updated_at DESC"
+	OrderByUpdatedAtAsc  DocumentOrderBy = "updated_at ASC"
+	OrderByCreatedAtDesc DocumentOrderBy = "created_at DESC"
+)
+
+var validOrderBy = map[DocumentOrderBy]bool{
+	OrderByPathAsc:       true,
+	OrderByUpdatedAtDesc: true,
+	OrderByUpdatedAtAsc:  true,
+	OrderByCreatedAtDesc: true,
+}
+
 type ListDocumentsFilter struct {
 	VaultID string
 	Folder  *string
 	Labels  []string
 	DocType *string
+	OrderBy DocumentOrderBy // defaults to OrderByPathAsc
 	Limit   int
 	Offset  int
 }
 
 // buildDocumentFilter constructs the WHERE clause, variables, and pagination
 // suffix shared by ListDocuments and ListDocumentMetas.
-func buildDocumentFilter(filter ListDocumentsFilter) (whereClause string, vars map[string]any, suffix string) {
+func buildDocumentFilter(filter ListDocumentsFilter) (whereClause string, vars map[string]any, suffix string, err error) {
 	var conditions []string
 	vars = map[string]any{
 		"vault_id": bareID("vault", filter.VaultID),
@@ -197,13 +215,24 @@ func buildDocumentFilter(filter ListDocumentsFilter) (whereClause string, vars m
 		limit = filter.Limit
 	}
 
+	orderBy := OrderByPathAsc
+	if filter.OrderBy != "" {
+		if !validOrderBy[filter.OrderBy] {
+			return "", nil, "", fmt.Errorf("unsupported order by: %q", string(filter.OrderBy))
+		}
+		orderBy = filter.OrderBy
+	}
+
 	whereClause = strings.Join(conditions, " AND ")
-	suffix = fmt.Sprintf("ORDER BY path ASC LIMIT %d START %d", limit, filter.Offset)
+	suffix = fmt.Sprintf("ORDER BY %s LIMIT %d START %d", string(orderBy), limit, filter.Offset)
 	return
 }
 
 func (c *Client) ListDocuments(ctx context.Context, filter ListDocumentsFilter) ([]models.Document, error) {
-	where, vars, suffix := buildDocumentFilter(filter)
+	where, vars, suffix, err := buildDocumentFilter(filter)
+	if err != nil {
+		return nil, fmt.Errorf("list documents: %w", err)
+	}
 	sql := fmt.Sprintf("SELECT * FROM document WHERE %s %s", where, suffix)
 
 	results, err := surrealdb.Query[[]models.Document](ctx, c.DB(), sql, vars)
@@ -408,7 +437,10 @@ func (c *Client) GetDocumentMetaByPath(ctx context.Context, vaultID, path string
 
 // ListDocumentMetas returns lightweight metadata (no content) for documents matching the filter.
 func (c *Client) ListDocumentMetas(ctx context.Context, filter ListDocumentsFilter) ([]models.DocumentMeta, error) {
-	where, vars, suffix := buildDocumentFilter(filter)
+	where, vars, suffix, err := buildDocumentFilter(filter)
+	if err != nil {
+		return nil, fmt.Errorf("list document metas: %w", err)
+	}
 	sql := fmt.Sprintf("SELECT path, content_length, content_hash ?? null AS content_hash, updated_at FROM document WHERE %s %s", where, suffix)
 
 	results, err := surrealdb.Query[[]models.DocumentMeta](ctx, c.DB(), sql, vars)

--- a/internal/webdav/fs.go
+++ b/internal/webdav/fs.go
@@ -26,21 +26,23 @@ const markdownContentType = "text/markdown; charset=utf-8"
 
 // FS implements webdav.FileSystem backed by document, asset, and vault services.
 type FS struct {
-	vaultID    string
-	db         *db.Client
-	docService *document.Service
-	assetSvc   *asset.Service
-	vaultSvc   *vault.Service
+	vaultID      string
+	db           *db.Client
+	docService   *document.Service
+	assetSvc     *asset.Service
+	vaultSvc     *vault.Service
+	virtualFiles []VirtualFile
 }
 
 // NewFS creates a WebDAV filesystem for the given vault.
 func NewFS(vaultID string, db *db.Client, docService *document.Service, assetSvc *asset.Service, vaultSvc *vault.Service) *FS {
 	return &FS{
-		vaultID:    vaultID,
-		db:         db,
-		docService: docService,
-		assetSvc:   assetSvc,
-		vaultSvc:   vaultSvc,
+		vaultID:      vaultID,
+		db:           db,
+		docService:   docService,
+		assetSvc:     assetSvc,
+		vaultSvc:     vaultSvc,
+		virtualFiles: defaultVirtualFiles(db),
 	}
 }
 
@@ -72,6 +74,18 @@ func (f *FS) OpenFile(ctx context.Context, name string, flag int, perm os.FileMo
 			return newNopFile(name), nil
 		}
 		return nil, os.ErrNotExist
+	}
+
+	// Virtual files are read-only computed views
+	if vf := f.findVirtualFile(name); f.isVirtualFilePath(name) && vf != nil {
+		if flag&(os.O_WRONLY|os.O_RDWR|os.O_CREATE) != 0 {
+			return nil, os.ErrPermission
+		}
+		content, err := vf.Generate(ctx, f.vaultID)
+		if err != nil {
+			return nil, fmt.Errorf("open %s: %w", name, err)
+		}
+		return newVirtualReadFile(name, content), nil
 	}
 
 	// Try as document
@@ -147,6 +161,11 @@ func (f *FS) RemoveAll(ctx context.Context, name string) error {
 		return nil
 	}
 
+	// Virtual files are read-only
+	if f.isVirtualFilePath(name) {
+		return os.ErrPermission
+	}
+
 	// Try as document first
 	doc, err := f.db.GetDocumentByPath(ctx, f.vaultID, name)
 	if err != nil {
@@ -194,6 +213,11 @@ func (f *FS) Rename(ctx context.Context, oldName, newName string) error {
 	// macOS metadata files are never stored — nothing to rename
 	if isOSMetadataFile(oldName) {
 		return nil
+	}
+
+	// Virtual files are read-only
+	if f.isVirtualFilePath(oldName) || f.isVirtualFilePath(newName) {
+		return os.ErrPermission
 	}
 
 	// Try as document first
@@ -252,6 +276,16 @@ func (f *FS) Stat(ctx context.Context, name string) (os.FileInfo, error) {
 	// macOS metadata files are never stored — always report not found
 	if isOSMetadataFile(name) {
 		return nil, os.ErrNotExist
+	}
+
+	// Virtual files report size 0 in stat to avoid expensive content generation.
+	// The actual Content-Length is set when the file is opened for reading.
+	if f.isVirtualFilePath(name) {
+		return &fileInfo{
+			name:        path.Base(name),
+			modTime:     time.Now(),
+			contentType: markdownContentType,
+		}, nil
 	}
 
 	// Try as document (lightweight meta query — no content loaded)
@@ -398,6 +432,17 @@ func (f *FS) listDirEntries(ctx context.Context, dirPath string) ([]os.FileInfo,
 			contentType: am.MimeType,
 			etag:        `"` + am.ContentHash + `"`,
 		})
+	}
+
+	// Append virtual files to root directory listing
+	if dirPath == "/" {
+		for _, vf := range f.virtualFiles {
+			entries = append(entries, &fileInfo{
+				name:        vf.Name(),
+				modTime:     time.Now(),
+				contentType: markdownContentType,
+			})
+		}
 	}
 
 	return entries, nil

--- a/internal/webdav/virtual.go
+++ b/internal/webdav/virtual.go
@@ -1,0 +1,171 @@
+package webdav
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"golang.org/x/net/webdav"
+
+	"github.com/raphi011/knowhow/internal/db"
+)
+
+// VirtualFile generates dynamic markdown content from DB state.
+// Virtual files appear as read-only entries in the root directory listing.
+type VirtualFile interface {
+	Name() string                                              // e.g. ".labels.md"
+	Generate(ctx context.Context, vaultID string) (string, error) // returns markdown content
+}
+
+// findVirtualFile returns the VirtualFile matching the given root-level path, or nil.
+func (f *FS) findVirtualFile(name string) VirtualFile {
+	base := path.Base(name)
+	for _, vf := range f.virtualFiles {
+		if vf.Name() == base {
+			return vf
+		}
+	}
+	return nil
+}
+
+// isVirtualFilePath returns true if the path refers to a virtual file at the root level.
+func (f *FS) isVirtualFilePath(name string) bool {
+	return path.Dir(name) == "/" && f.findVirtualFile(name) != nil
+}
+
+// virtualReadFile provides read-only access to generated virtual content.
+type virtualReadFile struct {
+	name    string
+	content string
+	reader  *bytes.Reader
+}
+
+func newVirtualReadFile(name, content string) *virtualReadFile {
+	return &virtualReadFile{
+		name:    name,
+		content: content,
+		reader:  bytes.NewReader([]byte(content)),
+	}
+}
+
+func (f *virtualReadFile) Read(p []byte) (int, error)             { return f.reader.Read(p) }
+func (f *virtualReadFile) Write([]byte) (int, error)              { return 0, os.ErrPermission }
+func (f *virtualReadFile) Seek(offset int64, whence int) (int64, error) {
+	return f.reader.Seek(offset, whence)
+}
+func (f *virtualReadFile) Close() error                           { return nil }
+func (f *virtualReadFile) Readdir(int) ([]fs.FileInfo, error)     { return nil, os.ErrInvalid }
+func (f *virtualReadFile) Stat() (fs.FileInfo, error) {
+	return &fileInfo{
+		name:        path.Base(f.name),
+		size:        int64(len(f.content)),
+		modTime:     time.Now(),
+		contentType: markdownContentType,
+	}, nil
+}
+
+// labelsFile generates a markdown overview of all labels and their documents.
+type labelsFile struct {
+	db *db.Client
+}
+
+func (lf *labelsFile) Name() string { return ".labels.md" }
+
+func (lf *labelsFile) Generate(ctx context.Context, vaultID string) (string, error) {
+	labels, err := lf.db.ListLabels(ctx, vaultID)
+	if err != nil {
+		return "", fmt.Errorf("generate labels: %w", err)
+	}
+
+	if len(labels) == 0 {
+		return "# Labels\n\nNo labels found.\n", nil
+	}
+
+	var b strings.Builder
+	b.WriteString("# Labels\n")
+
+	for _, label := range labels {
+		docs, err := lf.db.ListDocuments(ctx, db.ListDocumentsFilter{
+			VaultID: vaultID,
+			Labels:  []string{label},
+			Limit:   1000,
+		})
+		if err != nil {
+			return "", fmt.Errorf("generate labels: list docs for %q: %w", label, err)
+		}
+
+		fmt.Fprintf(&b, "\n## %s\n\n", label)
+		if len(docs) == 0 {
+			b.WriteString("No documents.\n")
+			continue
+		}
+		for _, doc := range docs {
+			title := doc.Title
+			if title == "" {
+				title = path.Base(doc.Path)
+			}
+			fmt.Fprintf(&b, "- [%s](%s)\n", title, doc.Path)
+		}
+	}
+
+	return b.String(), nil
+}
+
+// recentFile generates a markdown table of recently updated documents.
+type recentFile struct {
+	db *db.Client
+}
+
+func (rf *recentFile) Name() string { return ".recent.md" }
+
+func (rf *recentFile) Generate(ctx context.Context, vaultID string) (string, error) {
+	docs, err := rf.db.ListDocuments(ctx, db.ListDocumentsFilter{
+		VaultID: vaultID,
+		OrderBy: db.OrderByUpdatedAtDesc,
+		Limit:   50,
+	})
+	if err != nil {
+		return "", fmt.Errorf("generate recent: %w", err)
+	}
+
+	var b strings.Builder
+	b.WriteString("# Recently Updated\n\n")
+
+	if len(docs) == 0 {
+		b.WriteString("No documents found.\n")
+		return b.String(), nil
+	}
+
+	b.WriteString("| Document | Path | Modified |\n")
+	b.WriteString("|----------|------|----------|\n")
+
+	for _, doc := range docs {
+		title := doc.Title
+		if title == "" {
+			title = path.Base(doc.Path)
+		}
+		modified := doc.UpdatedAt.Format(time.DateOnly)
+		fmt.Fprintf(&b, "| %s | %s | %s |\n", title, doc.Path, modified)
+	}
+
+	return b.String(), nil
+}
+
+// defaultVirtualFiles returns the standard set of virtual files for a vault.
+func defaultVirtualFiles(dbClient *db.Client) []VirtualFile {
+	return []VirtualFile{
+		&labelsFile{db: dbClient},
+		&recentFile{db: dbClient},
+	}
+}
+
+var (
+	_ io.ReadSeeker = (*virtualReadFile)(nil)
+	_ webdav.File   = (*virtualReadFile)(nil)
+)

--- a/internal/webdav/virtual_test.go
+++ b/internal/webdav/virtual_test.go
@@ -1,0 +1,263 @@
+package webdav
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+// stubVirtualFile is a test double for VirtualFile.
+type stubVirtualFile struct {
+	name    string
+	content string
+	err     error
+}
+
+func (s *stubVirtualFile) Name() string { return s.name }
+func (s *stubVirtualFile) Generate(_ context.Context, _ string) (string, error) {
+	return s.content, s.err
+}
+
+func TestFindVirtualFile(t *testing.T) {
+	stub := &stubVirtualFile{name: ".labels.md", content: "# Labels\n"}
+	fs := &FS{virtualFiles: []VirtualFile{stub}}
+
+	t.Run("found", func(t *testing.T) {
+		vf := fs.findVirtualFile("/.labels.md")
+		if vf == nil {
+			t.Fatal("expected virtual file, got nil")
+		}
+		if vf.Name() != ".labels.md" {
+			t.Errorf("Name() = %q, want %q", vf.Name(), ".labels.md")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		vf := fs.findVirtualFile("/readme.md")
+		if vf != nil {
+			t.Errorf("expected nil, got %v", vf)
+		}
+	})
+}
+
+func TestIsVirtualFilePath(t *testing.T) {
+	stub := &stubVirtualFile{name: ".labels.md"}
+	fs := &FS{virtualFiles: []VirtualFile{stub}}
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/.labels.md", true},
+		{"/subfolder/.labels.md", false}, // not root level
+		{"/readme.md", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := fs.isVirtualFilePath(tt.path)
+			if got != tt.want {
+				t.Errorf("isVirtualFilePath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVirtualReadFile(t *testing.T) {
+	content := "# Hello\n\nWorld\n"
+
+	t.Run("read", func(t *testing.T) {
+		f := newVirtualReadFile("/.test.md", content)
+		buf := make([]byte, 100)
+		n, err := f.Read(buf)
+		if err != nil {
+			t.Fatalf("Read() error: %v", err)
+		}
+		if string(buf[:n]) != content {
+			t.Errorf("Read() = %q, want %q", string(buf[:n]), content)
+		}
+	})
+
+	t.Run("write rejected", func(t *testing.T) {
+		f := newVirtualReadFile("/.test.md", content)
+		_, err := f.Write([]byte("nope"))
+		if err != os.ErrPermission {
+			t.Errorf("Write() error = %v, want ErrPermission", err)
+		}
+	})
+
+	t.Run("seek", func(t *testing.T) {
+		f := newVirtualReadFile("/.test.md", content)
+		pos, err := f.Seek(0, 0)
+		if err != nil {
+			t.Fatalf("Seek() error: %v", err)
+		}
+		if pos != 0 {
+			t.Errorf("Seek() = %d, want 0", pos)
+		}
+	})
+
+	t.Run("stat", func(t *testing.T) {
+		f := newVirtualReadFile("/.test.md", content)
+		fi, err := f.Stat()
+		if err != nil {
+			t.Fatalf("Stat() error: %v", err)
+		}
+		if fi.Name() != ".test.md" {
+			t.Errorf("Name() = %q, want %q", fi.Name(), ".test.md")
+		}
+		if fi.Size() != int64(len(content)) {
+			t.Errorf("Size() = %d, want %d", fi.Size(), len(content))
+		}
+		if fi.IsDir() {
+			t.Error("IsDir() = true, want false")
+		}
+	})
+
+	t.Run("readdir invalid", func(t *testing.T) {
+		f := newVirtualReadFile("/.test.md", content)
+		_, err := f.Readdir(0)
+		if err != os.ErrInvalid {
+			t.Errorf("Readdir() error = %v, want ErrInvalid", err)
+		}
+	})
+
+	t.Run("close", func(t *testing.T) {
+		f := newVirtualReadFile("/.test.md", content)
+		if err := f.Close(); err != nil {
+			t.Errorf("Close() = %v, want nil", err)
+		}
+	})
+}
+
+func TestDefaultVirtualFiles(t *testing.T) {
+	files := defaultVirtualFiles(nil)
+	if len(files) != 2 {
+		t.Fatalf("expected 2 virtual files, got %d", len(files))
+	}
+
+	names := make(map[string]bool)
+	for _, vf := range files {
+		names[vf.Name()] = true
+	}
+
+	if !names[".labels.md"] {
+		t.Error("missing .labels.md")
+	}
+	if !names[".recent.md"] {
+		t.Error("missing .recent.md")
+	}
+}
+
+func TestVirtualReadFileContentType(t *testing.T) {
+	f := newVirtualReadFile("/.test.md", "content")
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatalf("Stat() error: %v", err)
+	}
+
+	ct, err := fi.(*fileInfo).ContentType(context.Background())
+	if err != nil {
+		t.Fatalf("ContentType() error: %v", err)
+	}
+	if !strings.Contains(ct, "markdown") {
+		t.Errorf("ContentType() = %q, want markdown content type", ct)
+	}
+}
+
+// Tests for virtual file guards in FS methods.
+// These use nil service dependencies because virtual file checks
+// happen before any service calls.
+
+func TestOpenFileVirtualReadOnly(t *testing.T) {
+	stub := &stubVirtualFile{name: ".labels.md", content: "# Labels\n"}
+	fs := &FS{virtualFiles: []VirtualFile{stub}}
+
+	t.Run("read succeeds", func(t *testing.T) {
+		f, err := fs.OpenFile(context.Background(), "/.labels.md", os.O_RDONLY, 0)
+		if err != nil {
+			t.Fatalf("OpenFile() error: %v", err)
+		}
+		buf := make([]byte, 100)
+		n, err := f.Read(buf)
+		if err != nil {
+			t.Fatalf("Read() error: %v", err)
+		}
+		if string(buf[:n]) != "# Labels\n" {
+			t.Errorf("content = %q, want %q", string(buf[:n]), "# Labels\n")
+		}
+	})
+
+	t.Run("write rejected", func(t *testing.T) {
+		_, err := fs.OpenFile(context.Background(), "/.labels.md", os.O_WRONLY, 0)
+		if !errors.Is(err, os.ErrPermission) {
+			t.Errorf("OpenFile(O_WRONLY) error = %v, want ErrPermission", err)
+		}
+	})
+
+	t.Run("create rejected", func(t *testing.T) {
+		_, err := fs.OpenFile(context.Background(), "/.labels.md", os.O_CREATE, 0)
+		if !errors.Is(err, os.ErrPermission) {
+			t.Errorf("OpenFile(O_CREATE) error = %v, want ErrPermission", err)
+		}
+	})
+
+	t.Run("generate error propagated", func(t *testing.T) {
+		errStub := &stubVirtualFile{name: ".broken.md", err: errors.New("db down")}
+		fs := &FS{virtualFiles: []VirtualFile{errStub}}
+		_, err := fs.OpenFile(context.Background(), "/.broken.md", os.O_RDONLY, 0)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "db down") {
+			t.Errorf("error = %v, want to contain 'db down'", err)
+		}
+	})
+}
+
+func TestStatVirtualFile(t *testing.T) {
+	stub := &stubVirtualFile{name: ".labels.md", content: "# Labels\n"}
+	fs := &FS{virtualFiles: []VirtualFile{stub}}
+
+	fi, err := fs.Stat(context.Background(), "/.labels.md")
+	if err != nil {
+		t.Fatalf("Stat() error: %v", err)
+	}
+	if fi.Name() != ".labels.md" {
+		t.Errorf("Name() = %q, want %q", fi.Name(), ".labels.md")
+	}
+	if fi.IsDir() {
+		t.Error("IsDir() = true, want false")
+	}
+}
+
+func TestRemoveAllVirtualFile(t *testing.T) {
+	stub := &stubVirtualFile{name: ".labels.md"}
+	fs := &FS{virtualFiles: []VirtualFile{stub}}
+
+	err := fs.RemoveAll(context.Background(), "/.labels.md")
+	if !errors.Is(err, os.ErrPermission) {
+		t.Errorf("RemoveAll() error = %v, want ErrPermission", err)
+	}
+}
+
+func TestRenameVirtualFile(t *testing.T) {
+	stub := &stubVirtualFile{name: ".labels.md"}
+	fs := &FS{virtualFiles: []VirtualFile{stub}}
+
+	t.Run("rename from virtual", func(t *testing.T) {
+		err := fs.Rename(context.Background(), "/.labels.md", "/other.md")
+		if !errors.Is(err, os.ErrPermission) {
+			t.Errorf("Rename(from virtual) error = %v, want ErrPermission", err)
+		}
+	})
+
+	t.Run("rename to virtual", func(t *testing.T) {
+		err := fs.Rename(context.Background(), "/other.md", "/.labels.md")
+		if !errors.Is(err, os.ErrPermission) {
+			t.Errorf("Rename(to virtual) error = %v, want ErrPermission", err)
+		}
+	})
+}


### PR DESCRIPTION
Add virtual read-only files (`.labels.md`, `.recent.md`) to the WebDAV filesystem root, allowing users to discover vault content by label or recency directly from their editor/file manager.

Closes #39

## New Features
- `.labels.md` — lists all labels with linked documents grouped by label heading
- `.recent.md` — markdown table of the 50 most recently updated documents
- Virtual files appear in root directory listings and are fully read-only (write/delete/rename return `ErrPermission`)
- `ListDocumentsFilter.OrderBy` field for custom sort order in document queries

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)