### PR TITLE
feat: add bulk upload endpoint

### DIFF
--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -1,0 +1,210 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"net/http"
+
+	"github.com/raphi011/knowhow/internal/auth"
+	"github.com/raphi011/knowhow/internal/models"
+)
+
+// bulkMeta is the JSON metadata sent as the first multipart part ("meta").
+type bulkMeta struct {
+	VaultID string `json:"vaultId"`
+	Source  string `json:"source"`
+	Force   bool   `json:"force"`
+	DryRun  bool   `json:"dryRun"`
+}
+
+// bulkFileResult is the per-file result in the response.
+type bulkFileResult struct {
+	Path   string `json:"path"`
+	Status string `json:"status"`           // "created", "updated", "skipped", "error"
+	Reason string `json:"reason,omitempty"`  // e.g. "hash_match", "exists"
+	Error  string `json:"error,omitempty"`
+}
+
+// bulkResponse is the response body for POST /api/bulk.
+type bulkResponse struct {
+	Results []bulkFileResult `json:"results"`
+	Error   string           `json:"error,omitempty"`
+}
+
+func (s *Server) bulkUpload(w http.ResponseWriter, r *http.Request) {
+	// Use streaming multipart reader to avoid buffering the entire request in memory.
+	reader, err := r.MultipartReader()
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "expected multipart/form-data request")
+		return
+	}
+
+	// First part must be "meta" with JSON metadata.
+	metaPart, err := reader.NextPart()
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "missing meta part")
+		return
+	}
+	if metaPart.FormName() != "meta" {
+		writeError(w, http.StatusBadRequest, "first part must be named 'meta'")
+		return
+	}
+
+	var meta bulkMeta
+	if err := json.NewDecoder(metaPart).Decode(&meta); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid meta JSON: %v", err))
+		return
+	}
+	if meta.VaultID == "" {
+		writeError(w, http.StatusBadRequest, "vaultId is required in meta")
+		return
+	}
+
+	if err := auth.RequireVaultRole(r.Context(), meta.VaultID, models.RoleWrite); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	src := models.SourceCP
+	if meta.Source != "" {
+		src = models.DocumentSource(meta.Source)
+		if !src.Valid() {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid source: %q", meta.Source))
+			return
+		}
+	}
+
+	var results []bulkFileResult
+
+	// Process remaining parts — each is a file.
+	var loopErr error
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			slog.Error("bulk upload: read part", "vault", meta.VaultID, "error", err)
+			loopErr = err
+			break
+		}
+
+		result := s.processBulkPart(r, part, meta, src)
+		results = append(results, result)
+	}
+
+	if results == nil {
+		results = []bulkFileResult{}
+	}
+
+	resp := bulkResponse{Results: results}
+	if loopErr != nil {
+		resp.Error = "upload interrupted: not all files were processed"
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) processBulkPart(r *http.Request, part *multipart.Part, meta bulkMeta, src models.DocumentSource) bulkFileResult {
+	path := part.FormName()
+	if path == "" {
+		return bulkFileResult{Path: "(unknown)", Status: "error", Error: "missing path in form name"}
+	}
+
+	data, err := io.ReadAll(part)
+	if err != nil {
+		return bulkFileResult{Path: path, Status: "error", Error: fmt.Sprintf("read file: %v", err)}
+	}
+
+	isImage := models.IsImageFile(path)
+
+	if isImage {
+		return s.processBulkAsset(r, path, data, meta)
+	}
+	return s.processBulkDocument(r, path, string(data), meta, src)
+}
+
+func (s *Server) processBulkDocument(r *http.Request, path, content string, meta bulkMeta, src models.DocumentSource) bulkFileResult {
+	hash := models.ContentHash(content)
+
+	existing, err := s.app.DBClient().GetDocumentByPath(r.Context(), meta.VaultID, path)
+	if err != nil {
+		slog.Error("bulk: check existing document", "vault", meta.VaultID, "path", path, "error", err)
+		return bulkFileResult{Path: path, Status: "error", Error: fmt.Sprintf("check existing document: %v", err)}
+	}
+
+	if existing != nil {
+		if existing.ContentHash != nil && *existing.ContentHash == hash {
+			return bulkFileResult{Path: path, Status: "skipped", Reason: "hash_match"}
+		}
+		if !meta.Force {
+			return bulkFileResult{Path: path, Status: "skipped", Reason: "exists"}
+		}
+	}
+
+	if meta.DryRun {
+		if existing != nil {
+			return bulkFileResult{Path: path, Status: "updated"}
+		}
+		return bulkFileResult{Path: path, Status: "created"}
+	}
+
+	_, err = s.app.DocumentService().Create(r.Context(), models.DocumentInput{
+		VaultID: meta.VaultID,
+		Path:    path,
+		Content: content,
+		Source:  src,
+	})
+	if err != nil {
+		slog.Error("bulk: upsert document", "vault", meta.VaultID, "path", path, "error", err)
+		return bulkFileResult{Path: path, Status: "error", Error: fmt.Sprintf("create/update document: %v", err)}
+	}
+
+	if existing != nil {
+		return bulkFileResult{Path: path, Status: "updated"}
+	}
+	return bulkFileResult{Path: path, Status: "created"}
+}
+
+func (s *Server) processBulkAsset(r *http.Request, path string, data []byte, meta bulkMeta) bulkFileResult {
+	hash := models.ContentHash(string(data))
+
+	existing, err := s.app.DBClient().GetAssetMetaByPath(r.Context(), meta.VaultID, path)
+	if err != nil {
+		slog.Error("bulk: check existing asset", "vault", meta.VaultID, "path", path, "error", err)
+		return bulkFileResult{Path: path, Status: "error", Error: fmt.Sprintf("check existing asset: %v", err)}
+	}
+
+	if existing != nil {
+		if existing.ContentHash == hash {
+			return bulkFileResult{Path: path, Status: "skipped", Reason: "hash_match"}
+		}
+		if !meta.Force {
+			return bulkFileResult{Path: path, Status: "skipped", Reason: "exists"}
+		}
+	}
+
+	if meta.DryRun {
+		if existing != nil {
+			return bulkFileResult{Path: path, Status: "updated"}
+		}
+		return bulkFileResult{Path: path, Status: "created"}
+	}
+
+	_, err = s.app.AssetService().Create(r.Context(), models.AssetInput{
+		VaultID: meta.VaultID,
+		Path:    path,
+		Data:    data,
+	})
+	if err != nil {
+		slog.Error("bulk: upload asset", "vault", meta.VaultID, "path", path, "error", err)
+		return bulkFileResult{Path: path, Status: "error", Error: fmt.Sprintf("upload asset: %v", err)}
+	}
+
+	if existing != nil {
+		return bulkFileResult{Path: path, Status: "updated"}
+	}
+	return bulkFileResult{Path: path, Status: "created"}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -40,6 +40,9 @@ func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Han
 	mux.Handle("GET /api/assets/meta", authMw(http.HandlerFunc(s.getAssetMeta)))
 	mux.Handle("DELETE /api/assets", authMw(http.HandlerFunc(s.deleteAsset)))
 
+	// Bulk upload
+	mux.Handle("POST /api/bulk", authMw(http.HandlerFunc(s.bulkUpload)))
+
 	// Labels
 	mux.Handle("GET /api/labels", authMw(http.HandlerFunc(s.listLabels)))
 

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -87,6 +87,80 @@ func (c *Client) PostMultipart(ctx context.Context, path string, fields map[stri
 	return c.handleResponse(req, target)
 }
 
+// BulkFile represents a single file to upload via the bulk endpoint.
+type BulkFile struct {
+	Path string    // vault path (used as the multipart form name)
+	Data io.Reader // file content
+}
+
+// BulkMeta holds shared metadata for a bulk upload request.
+type BulkMeta struct {
+	VaultID string `json:"vaultId"`
+	Source  string `json:"source"`
+	Force   bool   `json:"force"`
+	DryRun  bool   `json:"dryRun"`
+}
+
+// BulkResult is a per-file result from the bulk upload endpoint.
+type BulkResult struct {
+	Path   string `json:"path"`
+	Status string `json:"status"`
+	Reason string `json:"reason,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+// BulkUpload sends multiple files (documents and assets) to the bulk upload endpoint.
+// The meta part is sent first as JSON, then each file as a separate multipart part
+// where the form name is the vault path.
+//
+// A nil error means the HTTP request succeeded, but individual files may still have
+// failed — callers must check each BulkResult.Status for "error" entries.
+func (c *Client) BulkUpload(ctx context.Context, meta BulkMeta, files []BulkFile) ([]BulkResult, error) {
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	// Write meta part as JSON
+	metaPart, err := writer.CreateFormField("meta")
+	if err != nil {
+		return nil, fmt.Errorf("create meta part: %w", err)
+	}
+	if err := json.NewEncoder(metaPart).Encode(meta); err != nil {
+		return nil, fmt.Errorf("encode meta: %w", err)
+	}
+
+	// Write each file as a part with the vault path as form name
+	for _, f := range files {
+		part, err := writer.CreateFormFile(f.Path, f.Path)
+		if err != nil {
+			return nil, fmt.Errorf("create file part %s: %w", f.Path, err)
+		}
+		if _, err := io.Copy(part, f.Data); err != nil {
+			return nil, fmt.Errorf("copy file data %s: %w", f.Path, err)
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("close multipart writer: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/bulk", &buf)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	var resp struct {
+		Results []BulkResult `json:"results"`
+	}
+	if err := c.handleResponse(req, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Results, nil
+}
+
 func (c *Client) do(ctx context.Context, method, path string, body, target any) error {
 	var bodyReader io.Reader
 	if body != nil {

--- a/internal/integration/bulk_test.go
+++ b/internal/integration/bulk_test.go
@@ -1,0 +1,471 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/raphi011/knowhow/internal/api"
+	"github.com/raphi011/knowhow/internal/asset"
+	"github.com/raphi011/knowhow/internal/auth"
+	"github.com/raphi011/knowhow/internal/document"
+	"github.com/raphi011/knowhow/internal/parser"
+	"github.com/raphi011/knowhow/internal/server"
+)
+
+// bulkResponse mirrors the server response structure.
+type bulkResponse struct {
+	Results []bulkResult `json:"results"`
+	Error   string       `json:"error,omitempty"`
+}
+
+type bulkResult struct {
+	Path   string `json:"path"`
+	Status string `json:"status"`
+	Reason string `json:"reason,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+// setupBulkServer creates a vault and httptest.Server with the bulk upload endpoint.
+func setupBulkServer(t *testing.T, suffix string) (*httptest.Server, string) {
+	t.Helper()
+	ctx := context.Background()
+
+	vaultID, vaultSvc := setupVault(t, ctx, "bulk-"+suffix+"-"+fmt.Sprint(time.Now().UnixNano()))
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig(), document.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
+	assetSvc := asset.NewService(testDB, nil)
+
+	app := server.NewForTest(testDB, docSvc, assetSvc, vaultSvc)
+	apiSrv := api.NewServer(app)
+
+	mux := http.NewServeMux()
+	apiSrv.Register(mux, auth.NoAuthMiddleware)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv, vaultID
+}
+
+// bulkUploadRequest builds and sends a multipart bulk upload request.
+func bulkUploadRequest(t *testing.T, srv *httptest.Server, meta map[string]any, files map[string][]byte) bulkResponse {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	// Write meta part
+	metaPart, err := writer.CreateFormField("meta")
+	if err != nil {
+		t.Fatalf("create meta part: %v", err)
+	}
+	if err := json.NewEncoder(metaPart).Encode(meta); err != nil {
+		t.Fatalf("encode meta: %v", err)
+	}
+
+	// Write file parts
+	for path, data := range files {
+		part, err := writer.CreateFormFile(path, path)
+		if err != nil {
+			t.Fatalf("create file part %s: %v", path, err)
+		}
+		if _, err := io.Copy(part, bytes.NewReader(data)); err != nil {
+			t.Fatalf("copy file data %s: %v", path, err)
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/bulk", &buf)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result bulkResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return result
+}
+
+func findResult(results []bulkResult, path string) *bulkResult {
+	for _, r := range results {
+		if r.Path == path {
+			return &r
+		}
+	}
+	return nil
+}
+
+func TestBulkUpload_CreateDocuments(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "create")
+
+	resp := bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/docs/a.md": []byte("# Doc A\n\nContent A"),
+		"/docs/b.md": []byte("# Doc B\n\nContent B"),
+	})
+
+	if len(resp.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(resp.Results))
+	}
+
+	for _, r := range resp.Results {
+		if r.Status != "created" {
+			t.Errorf("file %s: expected status 'created', got %q", r.Path, r.Status)
+		}
+	}
+
+	// Verify documents exist in DB
+	ctx := context.Background()
+	for _, path := range []string{"/docs/a.md", "/docs/b.md"} {
+		doc, err := testDB.GetDocumentByPath(ctx, vaultID, path)
+		if err != nil {
+			t.Fatalf("get doc %s: %v", path, err)
+		}
+		if doc == nil {
+			t.Errorf("doc %s should exist after bulk upload", path)
+		}
+	}
+}
+
+func TestBulkUpload_HashSkip(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "hash-skip")
+	content := []byte("# Same Content\n\nThis won't change.")
+
+	// First upload — creates the document
+	resp := bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/docs/stable.md": content,
+	})
+
+	if resp.Results[0].Status != "created" {
+		t.Fatalf("first upload: expected 'created', got %q", resp.Results[0].Status)
+	}
+
+	// Second upload with same content — should skip with hash_match
+	resp = bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/docs/stable.md": content,
+	})
+
+	r := resp.Results[0]
+	if r.Status != "skipped" || r.Reason != "hash_match" {
+		t.Errorf("second upload: expected skipped/hash_match, got %s/%s", r.Status, r.Reason)
+	}
+}
+
+func TestBulkUpload_ForceUpdate(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "force-update")
+
+	// Create initial document
+	bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/docs/changing.md": []byte("# Version 1"),
+	})
+
+	// Upload with different content and force=true — should update
+	resp := bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/docs/changing.md": []byte("# Version 2"),
+	})
+
+	r := resp.Results[0]
+	if r.Status != "updated" {
+		t.Errorf("force update: expected 'updated', got %q (reason: %s)", r.Status, r.Reason)
+	}
+}
+
+func TestBulkUpload_NoForceSkipsExisting(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "no-force")
+
+	// Create initial document
+	bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/docs/existing.md": []byte("# Original"),
+	})
+
+	// Upload with different content but force=false — should skip with "exists"
+	resp := bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   false,
+	}, map[string][]byte{
+		"/docs/existing.md": []byte("# Changed"),
+	})
+
+	r := resp.Results[0]
+	if r.Status != "skipped" || r.Reason != "exists" {
+		t.Errorf("no-force: expected skipped/exists, got %s/%s", r.Status, r.Reason)
+	}
+
+	// But hash_match should still work with force=false
+	resp = bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   false,
+	}, map[string][]byte{
+		"/docs/existing.md": []byte("# Original"),
+	})
+
+	r = resp.Results[0]
+	if r.Status != "skipped" || r.Reason != "hash_match" {
+		t.Errorf("no-force same hash: expected skipped/hash_match, got %s/%s", r.Status, r.Reason)
+	}
+}
+
+func TestBulkUpload_DryRun(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "dryrun")
+
+	// Dry run on new documents — should report "created" without writing
+	resp := bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+		"dryRun":  true,
+	}, map[string][]byte{
+		"/docs/new.md": []byte("# New Doc"),
+	})
+
+	if resp.Results[0].Status != "created" {
+		t.Fatalf("dry run new: expected 'created', got %q", resp.Results[0].Status)
+	}
+
+	// Verify document was NOT actually created
+	ctx := context.Background()
+	doc, err := testDB.GetDocumentByPath(ctx, vaultID, "/docs/new.md")
+	if err != nil {
+		t.Fatalf("get doc: %v", err)
+	}
+	if doc != nil {
+		t.Error("dry run should not create documents")
+	}
+
+	// Create a real document, then dry run with different content and force=true
+	bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/docs/exists.md": []byte("# Existing"),
+	})
+
+	resp = bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+		"dryRun":  true,
+	}, map[string][]byte{
+		"/docs/exists.md": []byte("# Changed"),
+	})
+
+	if resp.Results[0].Status != "updated" {
+		t.Errorf("dry run existing: expected 'updated', got %q", resp.Results[0].Status)
+	}
+}
+
+func TestBulkUpload_MixedDocumentsAndAssets(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "mixed")
+
+	// Upload a markdown document and a PNG asset in the same request
+	pngData := []byte{0x89, 0x50, 0x4E, 0x47} // minimal PNG magic bytes
+	resp := bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/docs/readme.md":    []byte("# Readme"),
+		"/images/logo.png":   pngData,
+	})
+
+	if len(resp.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(resp.Results))
+	}
+
+	docResult := findResult(resp.Results, "/docs/readme.md")
+	assetResult := findResult(resp.Results, "/images/logo.png")
+
+	if docResult == nil {
+		t.Fatal("missing result for /docs/readme.md")
+	}
+	if assetResult == nil {
+		t.Fatal("missing result for /images/logo.png")
+	}
+
+	if docResult.Status != "created" {
+		t.Errorf("document: expected 'created', got %q", docResult.Status)
+	}
+	if assetResult.Status != "created" {
+		t.Errorf("asset: expected 'created', got %q", assetResult.Status)
+	}
+
+	// Verify both exist
+	ctx := context.Background()
+	doc, err := testDB.GetDocumentByPath(ctx, vaultID, "/docs/readme.md")
+	if err != nil {
+		t.Fatalf("get doc: %v", err)
+	}
+	if doc == nil {
+		t.Error("document should exist")
+	}
+
+	assetMeta, err := testDB.GetAssetMetaByPath(ctx, vaultID, "/images/logo.png")
+	if err != nil {
+		t.Fatalf("get asset: %v", err)
+	}
+	if assetMeta == nil {
+		t.Error("asset should exist")
+	}
+}
+
+func TestBulkUpload_EmptyRequest(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "empty")
+
+	resp := bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+	}, map[string][]byte{})
+
+	if len(resp.Results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(resp.Results))
+	}
+}
+
+func TestBulkUpload_InvalidSource(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "invalid-source")
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	metaPart, err := writer.CreateFormField("meta")
+	if err != nil {
+		t.Fatalf("create meta part: %v", err)
+	}
+	if err := json.NewEncoder(metaPart).Encode(map[string]any{
+		"vaultId": vaultID,
+		"source":  "invalid_source",
+	}); err != nil {
+		t.Fatalf("encode meta: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/bulk", &buf)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestBulkUpload_MissingVaultID(t *testing.T) {
+	srv, _ := setupBulkServer(t, "no-vault")
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	metaPart, err := writer.CreateFormField("meta")
+	if err != nil {
+		t.Fatalf("create meta part: %v", err)
+	}
+	if err := json.NewEncoder(metaPart).Encode(map[string]any{}); err != nil {
+		t.Fatalf("encode meta: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/bulk", &buf)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestBulkUpload_AssetHashSkip(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "asset-hash")
+	pngData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+
+	// First upload — creates
+	resp := bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/images/icon.png": pngData,
+	})
+
+	if resp.Results[0].Status != "created" {
+		t.Fatalf("first upload: expected 'created', got %q", resp.Results[0].Status)
+	}
+
+	// Same content — should skip with hash_match
+	resp = bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/images/icon.png": pngData,
+	})
+
+	r := resp.Results[0]
+	if r.Status != "skipped" || r.Reason != "hash_match" {
+		t.Errorf("asset re-upload: expected skipped/hash_match, got %s/%s", r.Status, r.Reason)
+	}
+
+	// Different content with force — should update
+	resp = bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/images/icon.png": []byte{0x89, 0x50, 0x4E, 0x47, 0xFF, 0xFF},
+	})
+
+	r = resp.Results[0]
+	if r.Status != "updated" {
+		t.Errorf("asset force update: expected 'updated', got %q", r.Status)
+	}
+}

--- a/internal/models/document.go
+++ b/internal/models/document.go
@@ -11,6 +11,7 @@ type DocumentSource string
 const (
 	SourceManual      DocumentSource = "manual"
 	SourceScrape      DocumentSource = "scrape"
+	SourceCP          DocumentSource = "cp"
 	SourceMCP         DocumentSource = "mcp"
 	SourceAIGenerated DocumentSource = "ai_generated"
 	SourceRollback    DocumentSource = "rollback"
@@ -19,7 +20,7 @@ const (
 // Valid returns true if the DocumentSource is a known value.
 func (s DocumentSource) Valid() bool {
 	switch s {
-	case SourceManual, SourceScrape, SourceMCP, SourceAIGenerated, SourceRollback:
+	case SourceManual, SourceScrape, SourceCP, SourceMCP, SourceAIGenerated, SourceRollback:
 		return true
 	}
 	return false

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -241,6 +241,17 @@ func (a *App) AssetService() *asset.Service {
 	return a.assetService
 }
 
+// NewForTest creates a minimal App for integration tests — no background workers,
+// no embedder, no LLM. Only the services needed for handler tests are wired up.
+func NewForTest(dbClient *db.Client, docSvc *document.Service, assetSvc *asset.Service, vaultSvc *vault.Service) *App {
+	return &App{
+		db:              dbClient,
+		documentService: docSvc,
+		assetService:    assetSvc,
+		vaultService:    vaultSvc,
+	}
+}
+
 // Config returns the server configuration.
 func (a *App) Config() ServerConfig {
 	return a.serverConfig


### PR DESCRIPTION
## Summary
- Add `POST /api/bulk` multipart endpoint that accepts mixed documents and assets in a single request
- Server-side hash checking eliminates N round-trips for content comparison (was: one GET per file to check hash)
- Streams multipart parts via `MultipartReader()` for low memory usage
- Add `SourceCP` document source for the upcoming `cp` CLI command
- Add `BulkUpload` apiclient method with `BulkMeta`, `BulkFile`, `BulkResult` types

## Protocol

```
POST /api/bulk (multipart/form-data)

Part 1: "meta" → JSON { vaultId, source, force, dryRun }
Part N: form name = vault path, body = file content
```

Response: `{ results: [{ path, status, reason?, error? }] }`

Status values: `created`, `updated`, `skipped`, `error`

## Test plan
- [ ] `just build` compiles
- [ ] `just test` passes (verified)
- [ ] Manual: bulk upload docs + images, verify created
- [ ] Manual: re-upload without `--force` → all skipped (exists)
- [ ] Manual: re-upload with `--force` → all skipped (hash_match)
- [ ] Manual: modify file + re-upload with `--force` → updated
- [ ] Manual: `dryRun: true` → no side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)