### PR TITLE
feat: add backup CLI command and API endpoint

### DIFF
--- a/cmd/knowhow/cmd_backup.go
+++ b/cmd/knowhow/cmd_backup.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/raphi011/knowhow/internal/apiclient"
+	"github.com/raphi011/knowhow/internal/models"
+	"github.com/spf13/cobra"
+)
+
+var (
+	backupVaultID string
+	backupOutput  string
+)
+
+var backupCmd = &cobra.Command{
+	Use:   "backup",
+	Short: "Download a backup archive of all documents and assets in a vault",
+	Long: `Creates a .tar.gz archive containing all documents and assets from a vault,
+preserving the path structure.
+
+Examples:
+  knowhow backup --vault vault:default
+  knowhow backup --vault vault:default -o my-backup.tar.gz`,
+	RunE: runBackup,
+}
+
+func init() {
+	backupCmd.Flags().StringVar(&backupVaultID, "vault", "", "vault ID (required)")
+	backupCmd.Flags().StringVarP(&backupOutput, "output", "o", "", "output file path (default: knowhow-backup-{vault}.tar.gz)")
+	if err := backupCmd.MarkFlagRequired("vault"); err != nil {
+		panic(fmt.Sprintf("mark vault flag required: %v", err))
+	}
+}
+
+func runBackup(cmd *cobra.Command, args []string) error {
+	if backupOutput == "" {
+		bareVault := strings.ReplaceAll(models.BareID("vault", backupVaultID), "/", "_")
+		backupOutput = fmt.Sprintf("knowhow-backup-%s.tar.gz", bareVault)
+	}
+
+	client := apiclient.New(apiURL, apiToken)
+
+	n, err := client.DownloadBackup(cmd.Context(), backupVaultID, backupOutput)
+	if err != nil {
+		return fmt.Errorf("backup: %w", err)
+	}
+
+	fmt.Printf("Backup saved to %s (%s)\n", backupOutput, formatBytes(n))
+	return nil
+}
+
+func formatBytes(b int64) string {
+	switch {
+	case b >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(b)/float64(1<<20))
+	case b >= 1<<10:
+		return fmt.Sprintf("%.1f KB", float64(b)/float64(1<<10))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/cmd/knowhow/cmd_backup_test.go
+++ b/cmd/knowhow/cmd_backup_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048575, "1024.0 KB"},
+		{1048576, "1.0 MB"},
+		{10485760, "10.0 MB"},
+	}
+	for _, tt := range tests {
+		got := formatBytes(tt.input)
+		if got != tt.want {
+			t.Errorf("formatBytes(%d) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/cmd/knowhow/main.go
+++ b/cmd/knowhow/main.go
@@ -52,6 +52,7 @@ func main() {
 	rootCmd.AddCommand(uiCmd)
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(labelsCmd)
+	rootCmd.AddCommand(backupCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/raphi011/knowhow/internal/auth"
+	"github.com/raphi011/knowhow/internal/db"
+	"github.com/raphi011/knowhow/internal/models"
+)
+
+func (s *Server) backup(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	vaultID := r.URL.Query().Get("vault")
+	if vaultID == "" {
+		writeError(w, http.StatusBadRequest, "vault query parameter is required")
+		return
+	}
+
+	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleRead); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
+
+	dbClient := s.app.DBClient()
+
+	// Phase 1: Build manifest — collect all paths without content.
+	const pageSize = 1000
+
+	var docMetas []models.DocumentMeta
+	for offset := 0; ; offset += pageSize {
+		batch, err := dbClient.ListDocumentMetas(ctx, db.ListDocumentsFilter{
+			VaultID: vaultID,
+			OrderBy: db.OrderByPathAsc,
+			Limit:   pageSize,
+			Offset:  offset,
+		})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("list documents: %v", err))
+			return
+		}
+		docMetas = append(docMetas, batch...)
+		if len(batch) < pageSize {
+			break
+		}
+	}
+
+	assetMetas, err := dbClient.ListAssetMetas(ctx, vaultID, nil)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("list assets: %v", err))
+		return
+	}
+
+	// Phase 2: Write tar.gz to temp file.
+	tmp, err := os.CreateTemp("", "knowhow-backup-*.tar.gz")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("create temp file: %v", err))
+		return
+	}
+	defer os.Remove(tmp.Name())
+	defer tmp.Close()
+
+	gzw := gzip.NewWriter(tmp)
+	tw := tar.NewWriter(gzw)
+
+	for _, meta := range docMetas {
+		doc, err := dbClient.GetDocumentByPath(ctx, vaultID, meta.Path)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("get document %s: %v", meta.Path, err))
+			return
+		}
+		if doc == nil {
+			slog.Warn("document deleted since manifest", "path", meta.Path)
+			continue
+		}
+		if err := writeTarEntry(tw, doc.Path, []byte(doc.Content), doc.UpdatedAt); err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("write document %s: %v", meta.Path, err))
+			return
+		}
+	}
+
+	for _, meta := range assetMetas {
+		asset, err := dbClient.GetAssetByPath(ctx, vaultID, meta.Path)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("get asset %s: %v", meta.Path, err))
+			return
+		}
+		if asset == nil {
+			slog.Warn("asset deleted since manifest", "path", meta.Path)
+			continue
+		}
+		if err := writeTarEntry(tw, asset.Path, asset.Data, asset.UpdatedAt); err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("write asset %s: %v", meta.Path, err))
+			return
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("close tar writer: %v", err))
+		return
+	}
+	if err := gzw.Close(); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("close gzip writer: %v", err))
+		return
+	}
+
+	// Phase 3: Serve completed file.
+	if _, err := tmp.Seek(0, 0); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("seek temp file: %v", err))
+		return
+	}
+
+	bareVault := models.BareID("vault", vaultID)
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="knowhow-backup-%s.tar.gz"`, bareVault))
+	http.ServeContent(w, r, "", time.Time{}, tmp)
+}
+
+func writeTarEntry(tw *tar.Writer, path string, data []byte, modTime time.Time) error {
+	if err := tw.WriteHeader(&tar.Header{
+		Name:    strings.TrimPrefix(path, "/"),
+		Size:    int64(len(data)),
+		Mode:    0644,
+		ModTime: modTime,
+	}); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		return fmt.Errorf("write content: %w", err)
+	}
+	return nil
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -46,6 +46,9 @@ func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Han
 	// Labels
 	mux.Handle("GET /api/labels", authMw(http.HandlerFunc(s.listLabels)))
 
+	// Backup
+	mux.Handle("GET /api/backup", authMw(http.HandlerFunc(s.backup)))
+
 	// Config
 	mux.Handle("GET /api/config", authMw(http.HandlerFunc(s.getConfig)))
 }

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -10,6 +10,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/raphi011/knowhow/internal/models"
@@ -201,6 +202,57 @@ func (c *Client) ListLabelsWithCounts(ctx context.Context, vaultID string) ([]mo
 		return nil, fmt.Errorf("list labels with counts: %w", err)
 	}
 	return counts, nil
+}
+
+// DownloadBackup downloads a vault backup archive to the given output path.
+// Returns the number of bytes written.
+func (c *Client) DownloadBackup(ctx context.Context, vaultID, outputPath string) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/backup?vault="+url.QueryEscape(vaultID), nil)
+	if err != nil {
+		return 0, fmt.Errorf("create request: %w", err)
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	// Use a client with no timeout — large vaults may take a while.
+	// Context controls cancellation instead.
+	noTimeoutClient := &http.Client{}
+	resp, err := noTimeoutClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		if readErr != nil {
+			return 0, fmt.Errorf("HTTP %d (failed to read error body: %w)", resp.StatusCode, readErr)
+		}
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
+			return 0, fmt.Errorf("HTTP %d: %s", resp.StatusCode, errResp.Error)
+		}
+		return 0, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return 0, fmt.Errorf("create output file: %w", err)
+	}
+
+	n, copyErr := io.Copy(f, resp.Body)
+	if closeErr := f.Close(); closeErr != nil && copyErr == nil {
+		copyErr = closeErr
+	}
+	if copyErr != nil {
+		os.Remove(outputPath)
+		return 0, fmt.Errorf("write output file: %w", copyErr)
+	}
+
+	return n, nil
 }
 
 // handleResponse executes the request and processes the response.

--- a/internal/integration/backup_test.go
+++ b/internal/integration/backup_test.go
@@ -1,0 +1,162 @@
+package integration
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestBackup_DocumentsAndAssets(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "backup")
+
+	// Seed documents and an asset via bulk upload.
+	bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/docs/readme.md":  []byte("# Hello\n\nWorld"),
+		"/docs/nested/a.md": []byte("# Nested"),
+		"/images/logo.png": {0x89, 0x50, 0x4E, 0x47},
+	})
+
+	resp, err := http.Get(srv.URL + "/api/backup?vault=" + vaultID)
+	if err != nil {
+		t.Fatalf("GET backup: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	if ct := resp.Header.Get("Content-Type"); ct != "application/gzip" {
+		t.Errorf("Content-Type = %q, want application/gzip", ct)
+	}
+
+	// Extract tar.gz and verify entries.
+	gr, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+	entries := make(map[string][]byte)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar next: %v", err)
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatalf("read tar entry %s: %v", hdr.Name, err)
+		}
+		entries[hdr.Name] = data
+	}
+
+	// Verify documents (paths should have leading slash stripped).
+	wantDocs := map[string]string{
+		"docs/readme.md":   "# Hello\n\nWorld",
+		"docs/nested/a.md": "# Nested",
+	}
+	for path, wantContent := range wantDocs {
+		got, ok := entries[path]
+		if !ok {
+			t.Errorf("missing tar entry %q", path)
+			continue
+		}
+		if string(got) != wantContent {
+			t.Errorf("entry %q: got %q, want %q", path, string(got), wantContent)
+		}
+	}
+
+	// Verify asset.
+	assetData, ok := entries["images/logo.png"]
+	if !ok {
+		t.Fatal("missing tar entry images/logo.png")
+	}
+	if len(assetData) != 4 || assetData[0] != 0x89 {
+		t.Errorf("asset data mismatch: got %v", assetData)
+	}
+
+	// Should have exactly 3 entries.
+	if len(entries) != 3 {
+		t.Errorf("expected 3 tar entries, got %d: %v", len(entries), keys(entries))
+	}
+}
+
+func TestBackup_EmptyVault(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "backup-empty")
+
+	resp, err := http.Get(srv.URL + "/api/backup?vault=" + vaultID)
+	if err != nil {
+		t.Fatalf("GET backup: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	gr, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+	count := 0
+	for {
+		_, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar next: %v", err)
+		}
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0 tar entries for empty vault, got %d", count)
+	}
+}
+
+func TestBackup_MissingVaultParam(t *testing.T) {
+	srv, _ := setupBulkServer(t, "backup-no-vault")
+
+	resp, err := http.Get(srv.URL + "/api/backup")
+	if err != nil {
+		t.Fatalf("GET backup: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if errResp.Error == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func keys[V any](m map[string]V) []string {
+	result := make([]string, 0, len(m))
+	for k := range m {
+		result = append(result, k)
+	}
+	return result
+}


### PR DESCRIPTION
Add a backup/export mechanism so vault data survives SurrealDB failures. The server builds a `.tar.gz` archive of all documents and assets in a vault (preserving path structure via a temp file), then serves the completed file. The CLI streams it to disk.

## New Features
- `GET /api/backup?vault={id}` — server-side tar.gz archive generation with three-phase approach (manifest → archive → serve)
- `knowhow backup --vault <id> [-o output.tar.gz]` — CLI command to download the archive
- `apiclient.DownloadBackup()` — client method with no-timeout HTTP client for large vaults

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)