### PR TITLE
Default vault + remove CLI auth checks + ls command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ The server exposes a REST API at `/api/` for CLI and TUI communication:
 - `POST /api/conversations` — create conversation
 - `DELETE /api/conversations/{id}` — delete conversation
 - `PATCH /api/conversations/{id}` — rename conversation
+- `GET /api/ls?vault={id}&path={path}&recursive=true` — list files and folders
 - `GET /api/documents?vault={id}&path={path}` — get document by vault+path
 - `POST /api/documents` — create/update document
 - `GET /api/config` — server configuration

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ knowhow delete "old-notes" --force
 ### List & Explore
 
 ```bash
+# List files and folders in a vault
+knowhow ls
+knowhow ls /docs
+knowhow ls /docs -R
+knowhow ls --vault my-vault /notes
+
 # List all entities
 knowhow list
 

--- a/cmd/knowhow/cmd_backup.go
+++ b/cmd/knowhow/cmd_backup.go
@@ -21,17 +21,14 @@ var backupCmd = &cobra.Command{
 preserving the path structure.
 
 Examples:
-  knowhow backup --vault vault:default
-  knowhow backup --vault vault:default -o my-backup.tar.gz`,
+  knowhow backup --vault default
+  knowhow backup --vault default -o my-backup.tar.gz`,
 	RunE: runBackup,
 }
 
 func init() {
-	backupCmd.Flags().StringVar(&backupVaultID, "vault", "", "vault ID (required)")
+	backupCmd.Flags().StringVar(&backupVaultID, "vault", envOrDefault("KNOWHOW_VAULT", "default"), "vault name (env: KNOWHOW_VAULT)")
 	backupCmd.Flags().StringVarP(&backupOutput, "output", "o", "", "output file path (default: knowhow-backup-{vault}.tar.gz)")
-	if err := backupCmd.MarkFlagRequired("vault"); err != nil {
-		panic(fmt.Sprintf("mark vault flag required: %v", err))
-	}
 }
 
 func runBackup(cmd *cobra.Command, args []string) error {

--- a/cmd/knowhow/cmd_config.go
+++ b/cmd/knowhow/cmd_config.go
@@ -39,10 +39,6 @@ type serverConfig struct {
 }
 
 func runConfig(_ *cobra.Command, _ []string) error {
-	if err := requireToken(); err != nil {
-		return err
-	}
-
 	client := apiclient.New(apiURL, apiToken)
 
 	var cfg serverConfig

--- a/cmd/knowhow/cmd_labels.go
+++ b/cmd/knowhow/cmd_labels.go
@@ -29,18 +29,11 @@ Examples:
 }
 
 func init() {
-	labelsCmd.Flags().StringVar(&labelsVaultID, "vault", envOrDefault("KNOWHOW_VAULT", ""), "vault name (env: KNOWHOW_VAULT)")
+	labelsCmd.Flags().StringVar(&labelsVaultID, "vault", envOrDefault("KNOWHOW_VAULT", "default"), "vault name (env: KNOWHOW_VAULT)")
 	labelsCmd.Flags().BoolVar(&labelsCounts, "count", false, "show document count per label")
 }
 
 func runLabels(_ *cobra.Command, _ []string) error {
-	if labelsVaultID == "" {
-		return fmt.Errorf("labels: vault is required (set KNOWHOW_VAULT or use --vault)")
-	}
-	if err := requireToken(); err != nil {
-		return fmt.Errorf("labels: %w", err)
-	}
-
 	client := apiclient.New(apiURL, apiToken)
 	ctx := context.Background()
 

--- a/cmd/knowhow/cmd_ls.go
+++ b/cmd/knowhow/cmd_ls.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/raphi011/knowhow/internal/apiclient"
+	"github.com/spf13/cobra"
+)
+
+var (
+	lsVaultID   string
+	lsRecursive bool
+)
+
+var lsCmd = &cobra.Command{
+	Use:   "ls [path]",
+	Short: "List files and folders in a vault",
+	Long: `List files and folders in a vault path, similar to the Unix ls command.
+
+By default only shows direct children of the given path. Use -R for recursive listing.
+
+Environment variables:
+  KNOWHOW_VAULT    vault name (alternative to --vault flag)
+
+Examples:
+  knowhow ls
+  knowhow ls /docs
+  knowhow ls /docs -R
+  knowhow ls --vault my-vault /notes`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runLs,
+}
+
+func init() {
+	lsCmd.Flags().StringVar(&lsVaultID, "vault", envOrDefault("KNOWHOW_VAULT", "default"), "vault name (env: KNOWHOW_VAULT)")
+	lsCmd.Flags().BoolVarP(&lsRecursive, "recursive", "R", false, "list files recursively")
+}
+
+func runLs(_ *cobra.Command, args []string) error {
+	path := "/"
+	if len(args) > 0 {
+		path = args[0]
+	}
+
+	client := apiclient.New(apiURL, apiToken)
+	entries, err := client.ListFiles(context.Background(), lsVaultID, path, lsRecursive)
+	if err != nil {
+		return fmt.Errorf("ls: %w", err)
+	}
+
+	for _, e := range entries {
+		name := e.Name
+		if lsRecursive {
+			name = e.Path
+		}
+		if e.IsDir {
+			name += "/"
+		}
+		fmt.Println(name)
+	}
+
+	return nil
+}

--- a/cmd/knowhow/cmd_scrape.go
+++ b/cmd/knowhow/cmd_scrape.go
@@ -46,7 +46,7 @@ Examples:
 }
 
 func init() {
-	scrapeCmd.Flags().StringVar(&scrapeVaultID, "vault", envOrDefault("KNOWHOW_VAULT", ""), "vault name (env: KNOWHOW_VAULT)")
+	scrapeCmd.Flags().StringVar(&scrapeVaultID, "vault", envOrDefault("KNOWHOW_VAULT", "default"), "vault name (env: KNOWHOW_VAULT)")
 	scrapeCmd.Flags().StringSliceVarP(&scrapeLabels, "labels", "l", nil, "labels to include in document path metadata")
 	scrapeCmd.Flags().BoolVar(&scrapeDryRun, "dry-run", false, "show what would be ingested without changes")
 	scrapeCmd.Flags().BoolVar(&scrapeForce, "force", false, "re-ingest all files (ignore content hash)")
@@ -54,13 +54,6 @@ func init() {
 }
 
 func runScrape(cmd *cobra.Command, args []string) error {
-	if scrapeVaultID == "" {
-		return fmt.Errorf("scrape: vault is required (set KNOWHOW_VAULT or use --vault)")
-	}
-	if err := requireToken(); err != nil {
-		return fmt.Errorf("scrape: %w", err)
-	}
-
 	dirPath := args[0]
 	info, err := os.Stat(dirPath)
 	if err != nil {

--- a/cmd/knowhow/cmd_ui.go
+++ b/cmd/knowhow/cmd_ui.go
@@ -34,10 +34,6 @@ func init() {
 }
 
 func runUI(_ *cobra.Command, _ []string) error {
-	if err := requireToken(); err != nil {
-		return fmt.Errorf("ui: %w", err)
-	}
-
 	client := tui.NewClient(apiURL, apiToken)
 	model := tui.NewModel(client, uiVaultID)
 

--- a/cmd/knowhow/main.go
+++ b/cmd/knowhow/main.go
@@ -54,6 +54,7 @@ func main() {
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(labelsCmd)
 	rootCmd.AddCommand(backupCmd)
+	rootCmd.AddCommand(lsCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -89,11 +90,4 @@ func envOrDefaultBool(key string, def bool) bool {
 		return b
 	}
 	return def
-}
-
-func requireToken() error {
-	if apiToken == "" {
-		return fmt.Errorf("api token required: set KNOWHOW_TOKEN or use --token")
-	}
-	return nil
 }

--- a/internal/api/ls.go
+++ b/internal/api/ls.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/raphi011/knowhow/internal/auth"
+	"github.com/raphi011/knowhow/internal/db"
+	"github.com/raphi011/knowhow/internal/models"
+)
+
+func (s *Server) ls(w http.ResponseWriter, r *http.Request) {
+	vaultID := r.URL.Query().Get("vault")
+	if vaultID == "" {
+		writeError(w, http.StatusBadRequest, "vault query parameter required")
+		return
+	}
+
+	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	folder := r.URL.Query().Get("path")
+	if folder == "" {
+		folder = "/"
+	}
+	folder = models.NormalizePath(folder)
+
+	recursive := r.URL.Query().Get("recursive") == "true"
+
+	// Build prefix with trailing slash for filtering (root "/" stays as "/").
+	prefix := folder
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	// Pass prefix (with trailing slash) to the DB so that "/docs" doesn't match "/docs-other".
+	// For root ("/"), starts_with(path, "/") correctly matches all documents.
+	docs, err := s.app.DBClient().ListDocumentMetas(r.Context(), db.ListDocumentsFilter{
+		VaultID: vaultID,
+		Folder:  &prefix,
+		Limit:   10000,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list documents")
+		slog.Error("ls documents", "vault_id", vaultID, "path", folder, "error", err)
+		return
+	}
+
+	var entries []models.FileEntry
+
+	if recursive {
+		// Recursive: return all folders and documents under this path.
+		// ListFolders(nil) returns all vault folders; filter to those under the prefix.
+		allFolders, err := s.app.VaultService().ListFolders(r.Context(), vaultID, nil)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to list folders")
+			slog.Error("ls folders", "vault_id", vaultID, "path", folder, "error", err)
+			return
+		}
+		for _, f := range allFolders {
+			if strings.HasPrefix(f.Path, prefix) {
+				entries = append(entries, models.FileEntry{
+					Name:  f.Name,
+					Path:  f.Path,
+					IsDir: true,
+				})
+			}
+		}
+		for _, d := range docs {
+			entries = append(entries, models.FileEntry{
+				Name: path.Base(d.Path),
+				Path: d.Path,
+				Size: d.ContentLength,
+			})
+		}
+	} else {
+		// Non-recursive: only direct children
+		childFolders, err := s.app.DBClient().ListChildFolders(r.Context(), vaultID, folder)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to list folders")
+			slog.Error("ls child folders", "vault_id", vaultID, "path", folder, "error", err)
+			return
+		}
+		for _, f := range childFolders {
+			entries = append(entries, models.FileEntry{
+				Name:  f.Name,
+				Path:  f.Path,
+				IsDir: true,
+			})
+		}
+
+		// Direct child documents (path after prefix has no further "/")
+		for _, d := range docs {
+			rel := strings.TrimPrefix(d.Path, prefix)
+			if rel != d.Path && !strings.Contains(rel, "/") {
+				entries = append(entries, models.FileEntry{
+					Name: path.Base(d.Path),
+					Path: d.Path,
+					Size: d.ContentLength,
+				})
+			}
+		}
+	}
+
+	if entries == nil {
+		entries = []models.FileEntry{}
+	}
+
+	writeJSON(w, http.StatusOK, entries)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -31,6 +31,7 @@ func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Han
 	mux.Handle("GET /api/vaults", authMw(http.HandlerFunc(s.listVaults)))
 
 	// Documents
+	mux.Handle("GET /api/ls", authMw(http.HandlerFunc(s.ls)))
 	mux.Handle("GET /api/documents", authMw(http.HandlerFunc(s.getDocument)))
 	mux.Handle("POST /api/documents", authMw(http.HandlerFunc(s.upsertDocument)))
 

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -186,6 +187,19 @@ func (c *Client) do(ctx context.Context, method, path string, body, target any) 
 	return c.handleResponse(req, target)
 }
 
+// ListFiles lists files and folders at the given path in a vault.
+func (c *Client) ListFiles(ctx context.Context, vaultID, path string, recursive bool) ([]models.FileEntry, error) {
+	q := url.Values{"vault": {vaultID}, "path": {path}}
+	if recursive {
+		q.Set("recursive", "true")
+	}
+	var entries []models.FileEntry
+	if err := c.Get(ctx, "/api/ls?"+q.Encode(), &entries); err != nil {
+		return nil, fmt.Errorf("list files: %w", err)
+	}
+	return entries, nil
+}
+
 // ListLabels returns all distinct labels in the given vault.
 func (c *Client) ListLabels(ctx context.Context, vaultID string) ([]string, error) {
 	var labels []string
@@ -248,7 +262,9 @@ func (c *Client) DownloadBackup(ctx context.Context, vaultID, outputPath string)
 		copyErr = closeErr
 	}
 	if copyErr != nil {
-		os.Remove(outputPath)
+		if removeErr := os.Remove(outputPath); removeErr != nil {
+			slog.Warn("failed to clean up partial backup file", "path", outputPath, "error", removeErr)
+		}
 		return 0, fmt.Errorf("write output file: %w", copyErr)
 	}
 

--- a/internal/integration/ls_test.go
+++ b/internal/integration/ls_test.go
@@ -1,0 +1,212 @@
+package integration
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/raphi011/knowhow/internal/models"
+)
+
+func TestLs_NonRecursiveRoot(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "ls-root")
+
+	bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/readme.md":          []byte("# Readme"),
+		"/docs/guide.md":     []byte("# Guide"),
+		"/docs/sub/deep.md":  []byte("# Deep"),
+		"/notes/todo.md":     []byte("# Todo"),
+	})
+
+	entries := lsRequest(t, srv, vaultID, "/", false)
+
+	// Should list direct children only: readme.md + folders docs/ and notes/
+	names := entryNames(entries)
+	sort.Strings(names)
+
+	wantNames := []string{"docs", "notes", "readme.md"}
+	if len(names) != len(wantNames) {
+		t.Fatalf("expected %d entries, got %d: %v", len(wantNames), len(names), names)
+	}
+	for i, want := range wantNames {
+		if names[i] != want {
+			t.Errorf("entry[%d]: got %q, want %q", i, names[i], want)
+		}
+	}
+
+	// Verify isDir flags
+	dirMap := make(map[string]bool)
+	for _, e := range entries {
+		dirMap[e.Name] = e.IsDir
+	}
+	if !dirMap["docs"] {
+		t.Error("docs should be a directory")
+	}
+	if !dirMap["notes"] {
+		t.Error("notes should be a directory")
+	}
+	if dirMap["readme.md"] {
+		t.Error("readme.md should not be a directory")
+	}
+}
+
+func TestLs_NonRecursiveSubfolder(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "ls-subfolder")
+
+	bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/docs/guide.md":    []byte("# Guide"),
+		"/docs/setup.md":    []byte("# Setup"),
+		"/docs/sub/deep.md": []byte("# Deep"),
+	})
+
+	entries := lsRequest(t, srv, vaultID, "/docs", false)
+
+	names := entryNames(entries)
+	sort.Strings(names)
+
+	// Should list guide.md, setup.md, and sub/ folder — NOT deep.md
+	wantNames := []string{"guide.md", "setup.md", "sub"}
+	if len(names) != len(wantNames) {
+		t.Fatalf("expected %d entries, got %d: %v", len(wantNames), len(names), names)
+	}
+	for i, want := range wantNames {
+		if names[i] != want {
+			t.Errorf("entry[%d]: got %q, want %q", i, names[i], want)
+		}
+	}
+}
+
+func TestLs_Recursive(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "ls-recursive")
+
+	bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/docs/guide.md":    []byte("# Guide"),
+		"/docs/sub/deep.md": []byte("# Deep"),
+	})
+
+	entries := lsRequest(t, srv, vaultID, "/docs", true)
+
+	paths := entryPaths(entries)
+	sort.Strings(paths)
+
+	// Should include the sub folder and both documents
+	wantPaths := []string{"/docs/guide.md", "/docs/sub", "/docs/sub/deep.md"}
+	if len(paths) != len(wantPaths) {
+		t.Fatalf("expected %d entries, got %d: %v", len(wantPaths), len(paths), paths)
+	}
+	for i, want := range wantPaths {
+		if paths[i] != want {
+			t.Errorf("entry[%d]: got %q, want %q", i, paths[i], want)
+		}
+	}
+}
+
+func TestLs_PrefixIsolation(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "ls-prefix")
+
+	// Create docs under /docs and /docs-other — they share the "/docs" prefix
+	bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/docs/a.md":       []byte("# A"),
+		"/docs-other/b.md": []byte("# B"),
+	})
+
+	// Non-recursive ls of /docs should NOT include /docs-other/b.md
+	entries := lsRequest(t, srv, vaultID, "/docs", false)
+	for _, e := range entries {
+		if e.Name == "b.md" || e.Path == "/docs-other/b.md" {
+			t.Errorf("ls /docs should not include /docs-other entries: got %+v", e)
+		}
+	}
+	if len(entries) != 1 || entries[0].Name != "a.md" {
+		t.Errorf("expected [a.md], got %v", entryNames(entries))
+	}
+
+	// Recursive ls of /docs should also not include /docs-other
+	entries = lsRequest(t, srv, vaultID, "/docs", true)
+	for _, e := range entries {
+		if e.Name == "b.md" || e.Path == "/docs-other/b.md" {
+			t.Errorf("recursive ls /docs should not include /docs-other entries: got %+v", e)
+		}
+	}
+}
+
+func TestLs_EmptyVault(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "ls-empty")
+
+	entries := lsRequest(t, srv, vaultID, "/", false)
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries for empty vault, got %d", len(entries))
+	}
+}
+
+func TestLs_MissingVaultParam(t *testing.T) {
+	srv, _ := setupBulkServer(t, "ls-no-vault")
+
+	resp, err := http.Get(srv.URL + "/api/ls")
+	if err != nil {
+		t.Fatalf("GET ls: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+// lsRequest performs a GET /api/ls and returns the parsed entries.
+func lsRequest(t *testing.T, srv *httptest.Server, vaultID, path string, recursive bool) []models.FileEntry {
+	t.Helper()
+
+	u := srv.URL + "/api/ls?vault=" + vaultID + "&path=" + path
+	if recursive {
+		u += "&recursive=true"
+	}
+
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET ls: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	var entries []models.FileEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return entries
+}
+
+func entryNames(entries []models.FileEntry) []string {
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.Name
+	}
+	return names
+}
+
+func entryPaths(entries []models.FileEntry) []string {
+	paths := make([]string, len(entries))
+	for i, e := range entries {
+		paths[i] = e.Path
+	}
+	return paths
+}

--- a/internal/models/document.go
+++ b/internal/models/document.go
@@ -74,6 +74,14 @@ type LabelCount struct {
 	Count int    `json:"count"`
 }
 
+// FileEntry is a lightweight entry for directory listings (ls endpoint).
+type FileEntry struct {
+	Name  string `json:"name"`
+	Path  string `json:"path"`
+	IsDir bool   `json:"isDir"`
+	Size  int    `json:"size,omitempty"`
+}
+
 // Folder is a first-class folder record backed by the folder table.
 type Folder struct {
 	ID        surrealmodels.RecordID `json:"id"`


### PR DESCRIPTION
Remove CLI-side `requireToken()` checks so `--no-auth` server mode works end-to-end. Default `--vault` to `"default"` on all CLI commands. Add `knowhow ls` command for listing vault contents.

## New Features
- `knowhow ls [path]` — list files and folders in a vault (like Unix `ls`)
- `knowhow ls -R` — recursive listing
- `GET /api/ls?vault=X&path=/Y&recursive=true` API endpoint
- All CLI commands default `--vault` to `"default"` (overridable via `KNOWHOW_VAULT` env var)
- Shared `models.FileEntry` type for ls API/client
- Integration tests for ls endpoint (prefix isolation, recursive, empty vault, etc.)

## Breaking Changes
- `requireToken()` removed: CLI no longer pre-validates tokens; the server handles auth. Commands now work without a token when the server runs in `--no-auth` mode
- `knowhow backup --vault` is no longer required (defaults to `"default"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)