### PR TITLE
feat: label graph, wiki-link unresolve, raw_target updates on move

### DIFF
--- a/internal/db/queries_label.go
+++ b/internal/db/queries_label.go
@@ -1,0 +1,134 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/raphi011/knowhow/internal/models"
+	"github.com/surrealdb/surrealdb.go"
+)
+
+// EnsureLabel gets or creates a label record for the given vault and name, returning its ID.
+// Uses check-then-create/update to work around SurrealDB v3's UPSERT ... WHERE
+// not creating new records when no match exists.
+func (c *Client) EnsureLabel(ctx context.Context, vaultID, name string) (string, error) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return "", fmt.Errorf("ensure label: name must not be empty")
+	}
+
+	const maxRetries = 3
+
+	for attempt := range maxRetries {
+		// Check if label already exists
+		selectSQL := `SELECT * FROM label WHERE vault = type::record("vault", $vault_id) AND name = $name LIMIT 1`
+		existing, err := surrealdb.Query[[]models.Label](ctx, c.DB(), selectSQL, map[string]any{
+			"vault_id": bareID("vault", vaultID),
+			"name":     name,
+		})
+		if err != nil {
+			return "", fmt.Errorf("ensure label: check existing: %w", err)
+		}
+
+		if existing != nil && len(*existing) > 0 && len((*existing)[0].Result) > 0 {
+			id, err := models.RecordIDString((*existing)[0].Result[0].ID)
+			if err != nil {
+				return "", fmt.Errorf("ensure label: extract id: %w", err)
+			}
+			return id, nil
+		}
+
+		// Create new label
+		createSQL := `CREATE label SET name = $name, vault = type::record("vault", $vault_id) RETURN AFTER`
+		created, err := surrealdb.Query[[]models.Label](ctx, c.DB(), createSQL, map[string]any{
+			"vault_id": bareID("vault", vaultID),
+			"name":     name,
+		})
+		if err != nil {
+			if isUniqueViolation(err) && attempt < maxRetries-1 {
+				continue
+			}
+			return "", fmt.Errorf("ensure label: create: %w", err)
+		}
+		if created == nil || len(*created) == 0 || len((*created)[0].Result) == 0 {
+			return "", fmt.Errorf("ensure label: no result returned from create")
+		}
+		id, err := models.RecordIDString((*created)[0].Result[0].ID)
+		if err != nil {
+			return "", fmt.Errorf("ensure label: extract id: %w", err)
+		}
+		return id, nil
+	}
+
+	return "", fmt.Errorf("ensure label: exhausted %d retries due to concurrent writes", maxRetries)
+}
+
+// SyncDocumentLabels replaces all has_label edges for a document with edges
+// to the given labels. Labels are upserted as needed.
+func (c *Client) SyncDocumentLabels(ctx context.Context, docID, vaultID string, labels []string) error {
+	// Delete existing edges from this document
+	sql := `DELETE FROM has_label WHERE in = type::record("document", $doc_id)`
+	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
+		"doc_id": bareID("document", docID),
+	}); err != nil {
+		return fmt.Errorf("sync document labels: delete old edges: %w", err)
+	}
+
+	for _, name := range labels {
+		labelID, err := c.EnsureLabel(ctx, vaultID, name)
+		if err != nil {
+			return fmt.Errorf("sync document labels: %w", err)
+		}
+
+		relateSql := `
+			LET $doc = type::record("document", $doc_id);
+			LET $lbl = type::record("label", $label_id);
+			RELATE $doc->has_label->$lbl RETURN NONE
+		`
+		if _, err := surrealdb.Query[any](ctx, c.DB(), relateSql, map[string]any{
+			"doc_id":   bareID("document", docID),
+			"label_id": bareID("label", labelID),
+		}); err != nil {
+			return fmt.Errorf("sync document labels: create edge for %q: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+// GetDocumentsByLabel returns all documents in a vault that have a specific label,
+// using graph traversal through has_label edges.
+func (c *Client) GetDocumentsByLabel(ctx context.Context, vaultID, labelName string) ([]models.Document, error) {
+	sql := `
+		SELECT * FROM document WHERE
+			vault = type::record("vault", $vault_id)
+			AND count(->has_label->label[WHERE name = $label_name]) > 0
+	`
+	results, err := surrealdb.Query[[]models.Document](ctx, c.DB(), sql, map[string]any{
+		"vault_id":   bareID("vault", vaultID),
+		"label_name": labelName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get documents by label: %w", err)
+	}
+	if results == nil || len(*results) == 0 {
+		return nil, nil
+	}
+	return (*results)[0].Result, nil
+}
+
+// GetLabelsForDocument returns all label names for a document using graph traversal.
+func (c *Client) GetLabelsForDocument(ctx context.Context, docID string) ([]string, error) {
+	sql := `SELECT VALUE ->has_label->label.name FROM type::record("document", $doc_id)`
+	results, err := surrealdb.Query[[][]string](ctx, c.DB(), sql, map[string]any{
+		"doc_id": bareID("document", docID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get labels for document: %w", err)
+	}
+	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
+		return nil, nil
+	}
+	return (*results)[0].Result[0], nil
+}

--- a/internal/db/queries_label_test.go
+++ b/internal/db/queries_label_test.go
@@ -1,0 +1,162 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/raphi011/knowhow/internal/models"
+)
+
+func TestEnsureLabel(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	// First call creates
+	id1, err := testDB.EnsureLabel(ctx, vaultID, "go")
+	if err != nil {
+		t.Fatalf("EnsureLabel failed: %v", err)
+	}
+	if id1 == "" {
+		t.Fatal("Expected non-empty label ID")
+	}
+
+	// Second call returns same ID (upsert)
+	id2, err := testDB.EnsureLabel(ctx, vaultID, "go")
+	if err != nil {
+		t.Fatalf("EnsureLabel second call failed: %v", err)
+	}
+	if id1 != id2 {
+		t.Errorf("Expected same label ID on upsert: got %q and %q", id1, id2)
+	}
+
+	// Different name creates different label
+	id3, err := testDB.EnsureLabel(ctx, vaultID, "rust")
+	if err != nil {
+		t.Fatalf("EnsureLabel different name failed: %v", err)
+	}
+	if id3 == id1 {
+		t.Error("Different label name should produce different ID")
+	}
+}
+
+func TestSyncDocumentLabels(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/label-sync.md", Title: "Label Sync",
+		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	// Sync with initial labels
+	if err := testDB.SyncDocumentLabels(ctx, docID, vaultID, []string{"go", "backend"}); err != nil {
+		t.Fatalf("SyncDocumentLabels failed: %v", err)
+	}
+
+	labels, err := testDB.GetLabelsForDocument(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetLabelsForDocument failed: %v", err)
+	}
+	if len(labels) != 2 {
+		t.Errorf("Expected 2 labels, got %d: %v", len(labels), labels)
+	}
+
+	// Sync with different labels — old edges should be removed
+	if err := testDB.SyncDocumentLabels(ctx, docID, vaultID, []string{"rust"}); err != nil {
+		t.Fatalf("SyncDocumentLabels second call failed: %v", err)
+	}
+
+	labels, err = testDB.GetLabelsForDocument(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetLabelsForDocument after resync failed: %v", err)
+	}
+	if len(labels) != 1 {
+		t.Errorf("Expected 1 label after resync, got %d: %v", len(labels), labels)
+	}
+	if len(labels) > 0 && labels[0] != "rust" {
+		t.Errorf("Expected label 'rust', got %q", labels[0])
+	}
+
+	// Sync with empty labels — all edges should be removed
+	if err := testDB.SyncDocumentLabels(ctx, docID, vaultID, nil); err != nil {
+		t.Fatalf("SyncDocumentLabels empty failed: %v", err)
+	}
+
+	labels, err = testDB.GetLabelsForDocument(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetLabelsForDocument after empty sync failed: %v", err)
+	}
+	if len(labels) != 0 {
+		t.Errorf("Expected 0 labels after empty sync, got %d: %v", len(labels), labels)
+	}
+}
+
+func TestGetDocumentsByLabel(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	doc1, err := testDB.CreateDocument(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/label-query-1.md", Title: "Label Query 1",
+		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument 1 failed: %v", err)
+	}
+	doc2, err := testDB.CreateDocument(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/label-query-2.md", Title: "Label Query 2",
+		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument 2 failed: %v", err)
+	}
+	doc1ID := models.MustRecordIDString(doc1.ID)
+	doc2ID := models.MustRecordIDString(doc2.ID)
+
+	// Both docs get "shared" label, only doc1 gets "unique"
+	if err := testDB.SyncDocumentLabels(ctx, doc1ID, vaultID, []string{"shared", "unique"}); err != nil {
+		t.Fatalf("SyncDocumentLabels doc1 failed: %v", err)
+	}
+	if err := testDB.SyncDocumentLabels(ctx, doc2ID, vaultID, []string{"shared"}); err != nil {
+		t.Fatalf("SyncDocumentLabels doc2 failed: %v", err)
+	}
+
+	// Query by "shared" — should return both docs
+	docs, err := testDB.GetDocumentsByLabel(ctx, vaultID, "shared")
+	if err != nil {
+		t.Fatalf("GetDocumentsByLabel failed: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Errorf("Expected 2 docs with 'shared' label, got %d", len(docs))
+	}
+
+	// Query by "unique" — should return only doc1
+	docs, err = testDB.GetDocumentsByLabel(ctx, vaultID, "unique")
+	if err != nil {
+		t.Fatalf("GetDocumentsByLabel unique failed: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Errorf("Expected 1 doc with 'unique' label, got %d", len(docs))
+	}
+
+	// Query by nonexistent label — should return empty
+	docs, err = testDB.GetDocumentsByLabel(ctx, vaultID, "nonexistent")
+	if err != nil {
+		t.Fatalf("GetDocumentsByLabel nonexistent failed: %v", err)
+	}
+	if len(docs) != 0 {
+		t.Errorf("Expected 0 docs with 'nonexistent' label, got %d", len(docs))
+	}
+}

--- a/internal/db/queries_relation.go
+++ b/internal/db/queries_relation.go
@@ -61,6 +61,19 @@ func (c *Client) GetRelationByID(ctx context.Context, id string) (*models.DocRel
 	return &(*results)[0].Result[0], nil
 }
 
+// DeleteRelationsBySource removes all doc_relations originating from a document with the given source.
+// Used to implement delete-then-recreate for frontmatter-derived relations.
+func (c *Client) DeleteRelationsBySource(ctx context.Context, docID, source string) error {
+	sql := `DELETE FROM doc_relation WHERE in = type::record("document", $doc_id) AND source = $source`
+	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
+		"doc_id": bareID("document", docID),
+		"source": source,
+	}); err != nil {
+		return fmt.Errorf("delete relations by source: %w", err)
+	}
+	return nil
+}
+
 func (c *Client) DeleteRelation(ctx context.Context, id string) error {
 	sql := `DELETE type::record("doc_relation", $id)`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"id": id}); err != nil {

--- a/internal/db/queries_relation_test.go
+++ b/internal/db/queries_relation_test.go
@@ -161,6 +161,72 @@ func TestGetRelationByID(t *testing.T) {
 	}
 }
 
+func TestDeleteRelationsBySource(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	docA, err := testDB.CreateDocument(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/delsrc-a-" + suffix + ".md", Title: "DelSrc A",
+		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument A failed: %v", err)
+	}
+	docB, err := testDB.CreateDocument(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/delsrc-b-" + suffix + ".md", Title: "DelSrc B",
+		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument B failed: %v", err)
+	}
+	docC, err := testDB.CreateDocument(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/delsrc-c-" + suffix + ".md", Title: "DelSrc C",
+		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument C failed: %v", err)
+	}
+	docAID := models.MustRecordIDString(docA.ID)
+	docBID := models.MustRecordIDString(docB.ID)
+	docCID := models.MustRecordIDString(docC.ID)
+
+	// Create one frontmatter relation and one API relation from A
+	_, err = testDB.CreateRelation(ctx, models.DocRelationInput{
+		FromDocID: docAID, ToDocID: docBID, RelType: "relates_to", Source: "frontmatter",
+	})
+	if err != nil {
+		t.Fatalf("CreateRelation A->B failed: %v", err)
+	}
+	_, err = testDB.CreateRelation(ctx, models.DocRelationInput{
+		FromDocID: docAID, ToDocID: docCID, RelType: "relates_to", Source: "api",
+	})
+	if err != nil {
+		t.Fatalf("CreateRelation A->C failed: %v", err)
+	}
+
+	// Delete only frontmatter relations
+	err = testDB.DeleteRelationsBySource(ctx, docAID, "frontmatter")
+	if err != nil {
+		t.Fatalf("DeleteRelationsBySource failed: %v", err)
+	}
+
+	// Should have 1 remaining relation (the API one)
+	rels, err := testDB.GetRelations(ctx, docAID)
+	if err != nil {
+		t.Fatalf("GetRelations after delete failed: %v", err)
+	}
+	if len(rels) != 1 {
+		t.Errorf("Expected 1 remaining relation, got %d", len(rels))
+	}
+	if len(rels) > 0 && rels[0].Source != "api" {
+		t.Errorf("Expected remaining relation to have source 'api', got %q", rels[0].Source)
+	}
+}
+
 func TestDeleteRelation(t *testing.T) {
 	ctx := context.Background()
 	user := createTestUser(t, ctx)

--- a/internal/db/queries_wikilink.go
+++ b/internal/db/queries_wikilink.go
@@ -90,6 +90,59 @@ func (c *Client) DeleteWikiLinks(ctx context.Context, fromDocID string) error {
 	return nil
 }
 
+// UnresolveWikiLinksToDoc sets to_doc = NONE on all wiki_links pointing to the given document,
+// making them dangling. Used during document deletion to preserve backlink references.
+func (c *Client) UnresolveWikiLinksToDoc(ctx context.Context, docID string) (int, error) {
+	sql := `UPDATE wiki_link SET to_doc = NONE WHERE to_doc = type::record("document", $doc_id)`
+	results, err := surrealdb.Query[[]models.WikiLink](ctx, c.DB(), sql, map[string]any{
+		"doc_id": bareID("document", docID),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("unresolve wiki links to doc: %w", err)
+	}
+	if results == nil || len(*results) == 0 {
+		return 0, nil
+	}
+	return len((*results)[0].Result), nil
+}
+
+// UpdateWikiLinkRawTargets updates raw_target for all wiki_links in a vault matching oldTarget.
+// Used when a document is moved to keep raw_targets consistent with the new path/title.
+func (c *Client) UpdateWikiLinkRawTargets(ctx context.Context, vaultID, oldTarget, newTarget string) (int, error) {
+	sql := `UPDATE wiki_link SET raw_target = $new_target WHERE vault = type::record("vault", $vault_id) AND raw_target = $old_target`
+	results, err := surrealdb.Query[[]models.WikiLink](ctx, c.DB(), sql, map[string]any{
+		"vault_id":   bareID("vault", vaultID),
+		"old_target": oldTarget,
+		"new_target": newTarget,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("update wiki link raw targets: %w", err)
+	}
+	if results == nil || len(*results) == 0 {
+		return 0, nil
+	}
+	return len((*results)[0].Result), nil
+}
+
+// UpdateWikiLinkRawTargetsByPrefix updates raw_target for all wiki_links in a vault
+// where raw_target starts with oldPrefix, replacing the prefix with newPrefix.
+// Used when documents are moved by prefix (folder rename).
+func (c *Client) UpdateWikiLinkRawTargetsByPrefix(ctx context.Context, vaultID, oldPrefix, newPrefix string) (int, error) {
+	sql := `UPDATE wiki_link SET raw_target = string::concat($new_prefix, string::slice(raw_target, string::len($old_prefix))) WHERE vault = type::record("vault", $vault_id) AND string::starts_with(raw_target, $old_prefix)`
+	results, err := surrealdb.Query[[]models.WikiLink](ctx, c.DB(), sql, map[string]any{
+		"vault_id":   bareID("vault", vaultID),
+		"old_prefix": oldPrefix,
+		"new_prefix": newPrefix,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("update wiki link raw targets by prefix: %w", err)
+	}
+	if results == nil || len(*results) == 0 {
+		return 0, nil
+	}
+	return len((*results)[0].Result), nil
+}
+
 // ResolveDanglingLinks finds dangling wiki-links in a vault matching a target
 // and resolves them to point to the given document.
 func (c *Client) ResolveDanglingLinks(ctx context.Context, vaultID, rawTarget, toDocID string) (int, error) {

--- a/internal/db/queries_wikilink_test.go
+++ b/internal/db/queries_wikilink_test.go
@@ -141,6 +141,171 @@ func TestResolveDanglingLinks(t *testing.T) {
 	}
 }
 
+func TestUnresolveWikiLinksToDoc(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	docA, err := testDB.CreateDocument(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/unresolve-a.md", Title: "Unresolve A",
+		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument A failed: %v", err)
+	}
+	docB, err := testDB.CreateDocument(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/unresolve-b.md", Title: "Unresolve B",
+		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument B failed: %v", err)
+	}
+	docAID := models.MustRecordIDString(docA.ID)
+	docBID := models.MustRecordIDString(docB.ID)
+
+	// Create a resolved link from A -> B
+	if err := testDB.CreateWikiLinks(ctx, docAID, vaultID, []WikiLinkInput{
+		{RawTarget: "Unresolve B", ToDocID: &docBID},
+	}); err != nil {
+		t.Fatalf("CreateWikiLinks failed: %v", err)
+	}
+
+	// Verify link is resolved
+	links, err := testDB.GetWikiLinks(ctx, docAID)
+	if err != nil {
+		t.Fatalf("GetWikiLinks failed: %v", err)
+	}
+	if len(links) != 1 || links[0].ToDoc == nil {
+		t.Fatal("Link should be resolved initially")
+	}
+
+	// Unresolve links pointing to B
+	count, err := testDB.UnresolveWikiLinksToDoc(ctx, docBID)
+	if err != nil {
+		t.Fatalf("UnresolveWikiLinksToDoc failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("Expected 1 unresolved link, got %d", count)
+	}
+
+	// Verify link is now dangling but still exists
+	links, err = testDB.GetWikiLinks(ctx, docAID)
+	if err != nil {
+		t.Fatalf("GetWikiLinks after unresolve failed: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("Expected 1 link (preserved), got %d", len(links))
+	}
+	if links[0].ToDoc != nil {
+		t.Error("Link should be dangling after unresolve")
+	}
+	if links[0].RawTarget != "Unresolve B" {
+		t.Errorf("RawTarget should be preserved, got %q", links[0].RawTarget)
+	}
+}
+
+func TestUpdateWikiLinkRawTargets(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/raw-target-src.md", Title: "Raw Target Source",
+		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	if err := testDB.CreateWikiLinks(ctx, docID, vaultID, []WikiLinkInput{
+		{RawTarget: "/old/path.md"},
+		{RawTarget: "Unrelated Target"},
+	}); err != nil {
+		t.Fatalf("CreateWikiLinks failed: %v", err)
+	}
+
+	count, err := testDB.UpdateWikiLinkRawTargets(ctx, vaultID, "/old/path.md", "/new/path.md")
+	if err != nil {
+		t.Fatalf("UpdateWikiLinkRawTargets failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("Expected 1 updated, got %d", count)
+	}
+
+	links, err := testDB.GetWikiLinks(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetWikiLinks failed: %v", err)
+	}
+	found := false
+	for _, l := range links {
+		if l.RawTarget == "/new/path.md" {
+			found = true
+		}
+		if l.RawTarget == "/old/path.md" {
+			t.Error("Old raw_target should not exist after update")
+		}
+	}
+	if !found {
+		t.Error("Expected to find link with new raw_target /new/path.md")
+	}
+}
+
+func TestUpdateWikiLinkRawTargetsByPrefix(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/prefix-src.md", Title: "Prefix Source",
+		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	if err := testDB.CreateWikiLinks(ctx, docID, vaultID, []WikiLinkInput{
+		{RawTarget: "/old-folder/a.md"},
+		{RawTarget: "/old-folder/sub/b.md"},
+		{RawTarget: "/other/c.md"},
+	}); err != nil {
+		t.Fatalf("CreateWikiLinks failed: %v", err)
+	}
+
+	count, err := testDB.UpdateWikiLinkRawTargetsByPrefix(ctx, vaultID, "/old-folder/", "/new-folder/")
+	if err != nil {
+		t.Fatalf("UpdateWikiLinkRawTargetsByPrefix failed: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("Expected 2 updated, got %d", count)
+	}
+
+	links, err := testDB.GetWikiLinks(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetWikiLinks failed: %v", err)
+	}
+	targets := make(map[string]bool)
+	for _, l := range links {
+		targets[l.RawTarget] = true
+	}
+	if !targets["/new-folder/a.md"] {
+		t.Error("Expected /new-folder/a.md")
+	}
+	if !targets["/new-folder/sub/b.md"] {
+		t.Error("Expected /new-folder/sub/b.md")
+	}
+	if !targets["/other/c.md"] {
+		t.Error("Expected /other/c.md to be unchanged")
+	}
+}
+
 func TestDeleteWikiLinks(t *testing.T) {
 	ctx := context.Background()
 	user := createTestUser(t, ctx)

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -78,7 +78,10 @@ func SchemaSQL(dimension int) string {
 
     DEFINE EVENT IF NOT EXISTS cascade_delete_document_wiki_links ON document
     WHEN $event = "DELETE" ASYNC RETRY 3 THEN {
-        DELETE FROM wiki_link WHERE from_doc = $before.id OR to_doc = $before.id
+        -- Outgoing links: delete (the doc's own links)
+        DELETE FROM wiki_link WHERE from_doc = $before.id;
+        -- Incoming links: unresolve (preserve the dangling reference)
+        UPDATE wiki_link SET to_doc = NONE WHERE to_doc = $before.id
     };
 
     DEFINE EVENT IF NOT EXISTS cascade_delete_doc_relations ON document
@@ -147,6 +150,7 @@ func SchemaSQL(dimension int) string {
     DEFINE FIELD IF NOT EXISTS vault      ON wiki_link TYPE record<vault>;
 
     DEFINE INDEX IF NOT EXISTS idx_wiki_link_from_doc         ON wiki_link FIELDS from_doc;
+    DEFINE INDEX IF NOT EXISTS idx_wiki_link_to_doc           ON wiki_link FIELDS to_doc;
     DEFINE INDEX IF NOT EXISTS idx_wiki_link_vault            ON wiki_link FIELDS vault;
     DEFINE INDEX IF NOT EXISTS idx_wiki_link_vault_raw_target ON wiki_link FIELDS vault, raw_target;
 
@@ -160,6 +164,37 @@ func SchemaSQL(dimension int) string {
     DEFINE FIELD IF NOT EXISTS created_at ON doc_relation TYPE datetime DEFAULT time::now();
 
     DEFINE INDEX IF NOT EXISTS idx_doc_relation_unique ON doc_relation FIELDS in, out, rel_type UNIQUE;
+
+    -- ==========================================================================
+    -- LABEL TABLE
+    -- ==========================================================================
+    DEFINE TABLE IF NOT EXISTS label SCHEMAFULL;
+
+    DEFINE FIELD IF NOT EXISTS name       ON label TYPE string ASSERT string::len($value) > 0;
+    DEFINE FIELD IF NOT EXISTS vault      ON label TYPE record<vault>;
+    DEFINE FIELD IF NOT EXISTS created_at ON label TYPE datetime DEFAULT time::now();
+
+    DEFINE INDEX IF NOT EXISTS idx_label_vault_name ON label FIELDS vault, name UNIQUE;
+
+    -- ==========================================================================
+    -- HAS_LABEL RELATION (document -> label)
+    -- ==========================================================================
+    DEFINE TABLE IF NOT EXISTS has_label SCHEMAFULL TYPE RELATION FROM document TO label;
+
+    DEFINE FIELD IF NOT EXISTS created_at ON has_label TYPE datetime DEFAULT time::now();
+
+    DEFINE INDEX IF NOT EXISTS idx_has_label_unique ON has_label FIELDS in, out UNIQUE;
+
+    -- Cascade: clean up edges when label or document deleted
+    DEFINE EVENT IF NOT EXISTS cascade_delete_label_edges ON label
+    WHEN $event = "DELETE" ASYNC RETRY 3 THEN {
+        DELETE FROM has_label WHERE out = $before.id
+    };
+
+    DEFINE EVENT IF NOT EXISTS cascade_delete_document_label_edges ON document
+    WHEN $event = "DELETE" ASYNC RETRY 3 THEN {
+        DELETE FROM has_label WHERE in = $before.id
+    };
 
     -- ==========================================================================
     -- TEMPLATE TABLE
@@ -223,6 +258,12 @@ func SchemaSQL(dimension int) string {
     DEFINE FIELD IF NOT EXISTS created_at ON share_link TYPE datetime DEFAULT time::now();
 
     DEFINE INDEX IF NOT EXISTS idx_share_link_hash ON share_link FIELDS token_hash UNIQUE;
+
+    -- Cascade: delete labels when vault deleted
+    DEFINE EVENT IF NOT EXISTS cascade_delete_vault_labels ON vault
+    WHEN $event = "DELETE" ASYNC RETRY 3 THEN {
+        DELETE FROM label WHERE vault = $before.id
+    };
 
     -- Cascade: delete share_links when vault deleted
     DEFINE EVENT IF NOT EXISTS cascade_delete_vault_share_links ON vault

--- a/internal/document/service.go
+++ b/internal/document/service.go
@@ -267,12 +267,17 @@ func (s *Service) ProcessDocument(ctx context.Context, doc *models.Document) err
 		return fmt.Errorf("process relates_to for %s: %w", doc.Path, err)
 	}
 
-	// 5. Mark as processed
+	// 5. Sync label graph (has_label edges)
+	if err := s.db.SyncDocumentLabels(ctx, docID, vaultID, doc.Labels); err != nil {
+		return fmt.Errorf("sync labels for %s: %w", doc.Path, err)
+	}
+
+	// 6. Mark as processed
 	if err := s.db.MarkDocumentProcessed(ctx, docID); err != nil {
 		return fmt.Errorf("mark processed: %w", err)
 	}
 
-	// 6. Publish processed event
+	// 7. Publish processed event
 	s.publishDocEvent("document.processed", vaultID, doc)
 
 	return nil
@@ -499,14 +504,20 @@ func (s *Service) Delete(ctx context.Context, vaultID, path string) error {
 
 	// Synchronous cleanup — async cascade events are a safety net, not primary.
 	if err := s.db.DeleteWikiLinks(ctx, docID); err != nil {
-		return fmt.Errorf("delete: %w", err)
+		return fmt.Errorf("delete wiki links: %w", err)
+	}
+	if _, err := s.db.UnresolveWikiLinksToDoc(ctx, docID); err != nil {
+		return fmt.Errorf("unresolve incoming wiki links: %w", err)
+	}
+	if err := s.db.SyncDocumentLabels(ctx, docID, vaultID, nil); err != nil {
+		return fmt.Errorf("delete label edges: %w", err)
 	}
 	if err := s.db.DeleteChunks(ctx, docID); err != nil {
-		return fmt.Errorf("delete: %w", err)
+		return fmt.Errorf("delete chunks: %w", err)
 	}
 
 	if err := s.db.DeleteDocument(ctx, docID); err != nil {
-		return fmt.Errorf("delete: %w", err)
+		return fmt.Errorf("delete document: %w", err)
 	}
 
 	s.publishDocDeleteEvent(vaultID, docID, path, contentHash)
@@ -545,7 +556,8 @@ func (s *Service) DeleteByPrefix(ctx context.Context, vaultID, pathPrefix string
 // replacing oldPrefix with newPrefix. Returns the number of moved documents.
 // Both prefixes are normalized and ensured to end with "/" to avoid partial matches.
 //
-// Does not update wiki-links or relations referencing the old paths.
+// Updates wiki-link raw_targets referencing paths under the old prefix.
+// Does not update doc_relations referencing the old paths.
 func (s *Service) MoveByPrefix(ctx context.Context, vaultID, oldPrefix, newPrefix string) (int, error) {
 	oldNorm := models.NormalizePath(oldPrefix)
 	if !strings.HasSuffix(oldNorm, "/") {
@@ -564,6 +576,11 @@ func (s *Service) MoveByPrefix(ctx context.Context, vaultID, oldPrefix, newPrefi
 	count, err := s.db.MoveDocumentsByPrefix(ctx, vaultID, oldNorm, newNorm)
 	if err != nil {
 		return 0, fmt.Errorf("move by prefix: %w", err)
+	}
+
+	// Update raw_targets in wiki_links referencing paths under the old prefix
+	if _, err := s.db.UpdateWikiLinkRawTargetsByPrefix(ctx, vaultID, oldNorm, newNorm); err != nil {
+		return count, fmt.Errorf("update wiki link raw targets by prefix: %w", err)
 	}
 
 	// Move folder records to match
@@ -598,6 +615,19 @@ func (s *Service) Move(ctx context.Context, vaultID, oldPath, newPath string) (*
 	doc, err = s.db.MoveDocument(ctx, docID, normalizedNew)
 	if err != nil {
 		return nil, fmt.Errorf("move document: %w", err)
+	}
+
+	// Update raw_targets in wiki_links referencing the old path
+	if _, err := s.db.UpdateWikiLinkRawTargets(ctx, vaultID, oldPath, normalizedNew); err != nil {
+		return nil, fmt.Errorf("update wiki link raw targets for path: %w", err)
+	}
+	// Update raw_targets referencing the old title (if filename-derived title changed)
+	oldTitle := filenameTitle(oldPath)
+	newTitle := filenameTitle(normalizedNew)
+	if oldTitle != newTitle {
+		if _, err := s.db.UpdateWikiLinkRawTargets(ctx, vaultID, oldTitle, newTitle); err != nil {
+			return nil, fmt.Errorf("update wiki link raw targets for title: %w", err)
+		}
 	}
 
 	// Ensure destination folders exist
@@ -764,6 +794,11 @@ func (s *Service) syncChunks(ctx context.Context, docID string, parsed *parser.M
 }
 
 func (s *Service) processRelatesTo(ctx context.Context, docID, vaultID string, frontmatter map[string]any) error {
+	// Delete existing frontmatter-derived relations before recreating
+	if err := s.db.DeleteRelationsBySource(ctx, docID, string(models.RelSourceFrontmatter)); err != nil {
+		return fmt.Errorf("delete old frontmatter relations: %w", err)
+	}
+
 	relatesTo, ok := frontmatter["relates_to"]
 	if !ok {
 		return nil

--- a/internal/integration/lifecycle_test.go
+++ b/internal/integration/lifecycle_test.go
@@ -768,6 +768,478 @@ func TestMoveByPrefix_SamePrefix(t *testing.T) {
 	}
 }
 
+// TestDeleteUnresolvesIncomingWikiLinks verifies that deleting a document makes
+// incoming wiki_links dangling (to_doc = NONE) rather than deleting them.
+func TestDeleteUnresolvesIncomingWikiLinks(t *testing.T) {
+	ctx := context.Background()
+
+	user, err := testDB.CreateUser(ctx, models.UserInput{Name: "unresolve-user-" + fmt.Sprint(time.Now().UnixNano())})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	userID := models.MustRecordIDString(user.ID)
+
+	vaultSvc := vault.NewService(testDB)
+	v, err := vaultSvc.Create(ctx, userID, models.VaultInput{Name: "unresolve-" + fmt.Sprint(time.Now().UnixNano())})
+	if err != nil {
+		t.Fatalf("create vault: %v", err)
+	}
+	vaultID := models.MustRecordIDString(v.ID)
+
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig(), document.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
+
+	// Create doc B (target)
+	docB, err := docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/target.md",
+		Content: "# Target\n\nTarget content.", Source: models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create target doc: %v", err)
+	}
+	docBID := models.MustRecordIDString(docB.ID)
+	if err := docSvc.ProcessAllPending(ctx); err != nil {
+		t.Fatalf("process pending: %v", err)
+	}
+
+	// Create doc A (source) that links to Target
+	docA, err := docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/source.md",
+		Content: "# Source\n\nSee [[Target]].", Source: models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create source doc: %v", err)
+	}
+	docAID := models.MustRecordIDString(docA.ID)
+	if err := docSvc.ProcessAllPending(ctx); err != nil {
+		t.Fatalf("process pending: %v", err)
+	}
+
+	// Verify link from A to B is resolved
+	links, err := testDB.GetWikiLinks(ctx, docAID)
+	if err != nil {
+		t.Fatalf("get wiki-links: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("expected 1 wiki-link, got %d", len(links))
+	}
+	if links[0].ToDoc == nil {
+		t.Fatal("wiki-link should be resolved before delete")
+	}
+
+	// Delete doc B
+	if err := docSvc.Delete(ctx, vaultID, "/target.md"); err != nil {
+		t.Fatalf("delete target doc: %v", err)
+	}
+
+	// Verify doc B is gone
+	gone, err := testDB.GetDocumentByID(ctx, docBID)
+	if err != nil {
+		t.Fatalf("get deleted doc: %v", err)
+	}
+	if gone != nil {
+		t.Error("target doc should be deleted")
+	}
+
+	// Verify wiki-link from A still exists but is now dangling
+	links, err = testDB.GetWikiLinks(ctx, docAID)
+	if err != nil {
+		t.Fatalf("get wiki-links after delete: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("expected 1 wiki-link preserved, got %d", len(links))
+	}
+	if links[0].ToDoc != nil {
+		t.Error("wiki-link should be dangling after target deleted")
+	}
+	if links[0].RawTarget != "Target" {
+		t.Errorf("raw_target should be preserved, got %q", links[0].RawTarget)
+	}
+
+	if err := vaultSvc.Delete(ctx, vaultID); err != nil {
+		t.Fatalf("cleanup vault: %v", err)
+	}
+}
+
+// TestMoveUpdatesWikiLinkRawTargets verifies that moving a document updates
+// raw_target in wiki_links that reference the old path.
+func TestMoveUpdatesWikiLinkRawTargets(t *testing.T) {
+	ctx := context.Background()
+
+	user, err := testDB.CreateUser(ctx, models.UserInput{Name: "move-rawt-user-" + fmt.Sprint(time.Now().UnixNano())})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	userID := models.MustRecordIDString(user.ID)
+
+	vaultSvc := vault.NewService(testDB)
+	v, err := vaultSvc.Create(ctx, userID, models.VaultInput{Name: "move-rawt-" + fmt.Sprint(time.Now().UnixNano())})
+	if err != nil {
+		t.Fatalf("create vault: %v", err)
+	}
+	vaultID := models.MustRecordIDString(v.ID)
+
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig(), document.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
+
+	// Create target doc
+	_, err = docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/old/target.md",
+		Content: "# Target", Source: models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	if err := docSvc.ProcessAllPending(ctx); err != nil {
+		t.Fatalf("process pending: %v", err)
+	}
+
+	// Create source doc linking by path
+	docA, err := docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/source.md",
+		Content: "# Source\n\nSee [[/old/target.md]].", Source: models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create source: %v", err)
+	}
+	docAID := models.MustRecordIDString(docA.ID)
+	if err := docSvc.ProcessAllPending(ctx); err != nil {
+		t.Fatalf("process pending: %v", err)
+	}
+
+	// Move target doc
+	_, err = docSvc.Move(ctx, vaultID, "/old/target.md", "/new/target.md")
+	if err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	// Verify wiki-link raw_target was updated
+	links, err := testDB.GetWikiLinks(ctx, docAID)
+	if err != nil {
+		t.Fatalf("get wiki-links after move: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("expected 1 wiki-link, got %d", len(links))
+	}
+	if links[0].RawTarget != "/new/target.md" {
+		t.Errorf("expected raw_target '/new/target.md', got %q", links[0].RawTarget)
+	}
+
+	if err := vaultSvc.Delete(ctx, vaultID); err != nil {
+		t.Fatalf("cleanup vault: %v", err)
+	}
+}
+
+// TestMoveByPrefixUpdatesWikiLinkRawTargets verifies that MoveByPrefix
+// updates raw_targets for all wiki_links referencing paths under the old prefix.
+func TestMoveByPrefixUpdatesWikiLinkRawTargets(t *testing.T) {
+	ctx := context.Background()
+
+	user, err := testDB.CreateUser(ctx, models.UserInput{Name: "mbp-rawt-user-" + fmt.Sprint(time.Now().UnixNano())})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	userID := models.MustRecordIDString(user.ID)
+
+	vaultSvc := vault.NewService(testDB)
+	v, err := vaultSvc.Create(ctx, userID, models.VaultInput{Name: "mbp-rawt-" + fmt.Sprint(time.Now().UnixNano())})
+	if err != nil {
+		t.Fatalf("create vault: %v", err)
+	}
+	vaultID := models.MustRecordIDString(v.ID)
+
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig(), document.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
+
+	// Create docs under /old-dir/
+	_, err = docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/old-dir/a.md",
+		Content: "# A", Source: models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create a: %v", err)
+	}
+	if err := docSvc.ProcessAllPending(ctx); err != nil {
+		t.Fatalf("process pending: %v", err)
+	}
+
+	// Create source that references paths under /old-dir/
+	src, err := docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/source.md",
+		Content: "# Source\n\nSee [[/old-dir/a.md]].", Source: models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create source: %v", err)
+	}
+	srcID := models.MustRecordIDString(src.ID)
+	if err := docSvc.ProcessAllPending(ctx); err != nil {
+		t.Fatalf("process pending: %v", err)
+	}
+
+	// Move by prefix
+	count, err := docSvc.MoveByPrefix(ctx, vaultID, "/old-dir", "/new-dir")
+	if err != nil {
+		t.Fatalf("move by prefix: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 moved, got %d", count)
+	}
+
+	// Verify raw_target updated
+	links, err := testDB.GetWikiLinks(ctx, srcID)
+	if err != nil {
+		t.Fatalf("get wiki-links: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("expected 1 wiki-link, got %d", len(links))
+	}
+	if links[0].RawTarget != "/new-dir/a.md" {
+		t.Errorf("expected raw_target '/new-dir/a.md', got %q", links[0].RawTarget)
+	}
+
+	if err := vaultSvc.Delete(ctx, vaultID); err != nil {
+		t.Fatalf("cleanup vault: %v", err)
+	}
+}
+
+// TestProcessRelatesToDeleteThenRecreate verifies that updating a document's
+// relates_to frontmatter removes stale relations and creates new ones.
+func TestProcessRelatesToDeleteThenRecreate(t *testing.T) {
+	ctx := context.Background()
+
+	user, err := testDB.CreateUser(ctx, models.UserInput{Name: "relto-user-" + fmt.Sprint(time.Now().UnixNano())})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	userID := models.MustRecordIDString(user.ID)
+
+	vaultSvc := vault.NewService(testDB)
+	v, err := vaultSvc.Create(ctx, userID, models.VaultInput{Name: "relto-" + fmt.Sprint(time.Now().UnixNano())})
+	if err != nil {
+		t.Fatalf("create vault: %v", err)
+	}
+	vaultID := models.MustRecordIDString(v.ID)
+
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig(), document.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
+
+	// Create target docs
+	_, err = docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/target-a.md",
+		Content: "# Target A", Source: models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create target-a: %v", err)
+	}
+	_, err = docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/target-b.md",
+		Content: "# Target B", Source: models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create target-b: %v", err)
+	}
+	if err := docSvc.ProcessAllPending(ctx); err != nil {
+		t.Fatalf("process pending: %v", err)
+	}
+
+	// Create source doc with relates_to: [Target A]
+	src, err := docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/relto-src.md",
+		Content: "---\ntitle: Source\nrelates_to:\n  - Target A\n---\n# Source",
+		Source:  models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create source: %v", err)
+	}
+	srcID := models.MustRecordIDString(src.ID)
+	if err := docSvc.ProcessAllPending(ctx); err != nil {
+		t.Fatalf("process pending: %v", err)
+	}
+
+	// Verify relation to Target A exists
+	rels, err := testDB.GetRelations(ctx, srcID)
+	if err != nil {
+		t.Fatalf("get relations: %v", err)
+	}
+	if len(rels) != 1 {
+		t.Fatalf("expected 1 relation, got %d", len(rels))
+	}
+
+	// Update source to relates_to: [Target B] (removing Target A)
+	_, err = docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/relto-src.md",
+		Content: "---\ntitle: Source\nrelates_to:\n  - Target B\n---\n# Source Updated",
+		Source:  models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("update source: %v", err)
+	}
+	if err := docSvc.ProcessAllPending(ctx); err != nil {
+		t.Fatalf("process pending after update: %v", err)
+	}
+
+	// Verify: only relation to Target B exists (Target A was cleaned up)
+	rels, err = testDB.GetRelations(ctx, srcID)
+	if err != nil {
+		t.Fatalf("get relations after update: %v", err)
+	}
+	if len(rels) != 1 {
+		t.Fatalf("expected 1 relation after update, got %d", len(rels))
+	}
+
+	// Update source to remove all relates_to
+	_, err = docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/relto-src.md",
+		Content: "---\ntitle: Source\n---\n# Source No Relations",
+		Source:  models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("update source no rels: %v", err)
+	}
+	if err := docSvc.ProcessAllPending(ctx); err != nil {
+		t.Fatalf("process pending after remove: %v", err)
+	}
+
+	// Verify: no frontmatter relations remain
+	rels, err = testDB.GetRelations(ctx, srcID)
+	if err != nil {
+		t.Fatalf("get relations after remove: %v", err)
+	}
+	if len(rels) != 0 {
+		t.Errorf("expected 0 relations after removing relates_to, got %d", len(rels))
+	}
+
+	if err := vaultSvc.Delete(ctx, vaultID); err != nil {
+		t.Fatalf("cleanup vault: %v", err)
+	}
+}
+
+// TestLabelGraph verifies that ProcessDocument creates has_label edges
+// and that label graph queries work correctly.
+func TestLabelGraph(t *testing.T) {
+	ctx := context.Background()
+
+	user, err := testDB.CreateUser(ctx, models.UserInput{Name: "label-graph-user-" + fmt.Sprint(time.Now().UnixNano())})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	userID := models.MustRecordIDString(user.ID)
+
+	vaultSvc := vault.NewService(testDB)
+	v, err := vaultSvc.Create(ctx, userID, models.VaultInput{Name: "label-graph-" + fmt.Sprint(time.Now().UnixNano())})
+	if err != nil {
+		t.Fatalf("create vault: %v", err)
+	}
+	vaultID := models.MustRecordIDString(v.ID)
+
+	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig(), document.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
+
+	// Create docs with labels
+	doc1, err := docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/labeled-1.md",
+		Content: "---\nlabels: [go, backend]\n---\n# Doc 1",
+		Source:  models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create doc1: %v", err)
+	}
+	doc1ID := models.MustRecordIDString(doc1.ID)
+
+	doc2, err := docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/labeled-2.md",
+		Content: "---\nlabels: [go, frontend]\n---\n# Doc 2",
+		Source:  models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("create doc2: %v", err)
+	}
+	doc2ID := models.MustRecordIDString(doc2.ID)
+
+	if err := docSvc.ProcessAllPending(ctx); err != nil {
+		t.Fatalf("process pending: %v", err)
+	}
+
+	// Verify labels for doc1
+	labels, err := testDB.GetLabelsForDocument(ctx, doc1ID)
+	if err != nil {
+		t.Fatalf("get labels for doc1: %v", err)
+	}
+	if len(labels) != 2 {
+		t.Errorf("expected 2 labels for doc1, got %d: %v", len(labels), labels)
+	}
+
+	// Verify labels for doc2
+	labels, err = testDB.GetLabelsForDocument(ctx, doc2ID)
+	if err != nil {
+		t.Fatalf("get labels for doc2: %v", err)
+	}
+	if len(labels) != 2 {
+		t.Errorf("expected 2 labels for doc2, got %d: %v", len(labels), labels)
+	}
+
+	// Query by "go" — should return both
+	docs, err := testDB.GetDocumentsByLabel(ctx, vaultID, "go")
+	if err != nil {
+		t.Fatalf("get docs by label 'go': %v", err)
+	}
+	if len(docs) != 2 {
+		t.Errorf("expected 2 docs with 'go' label, got %d", len(docs))
+	}
+
+	// Query by "backend" — should return only doc1
+	docs, err = testDB.GetDocumentsByLabel(ctx, vaultID, "backend")
+	if err != nil {
+		t.Fatalf("get docs by label 'backend': %v", err)
+	}
+	if len(docs) != 1 {
+		t.Errorf("expected 1 doc with 'backend' label, got %d", len(docs))
+	}
+
+	// Update doc1 to change labels (remove "backend", add "infra")
+	_, err = docSvc.Create(ctx, models.DocumentInput{
+		VaultID: vaultID, Path: "/labeled-1.md",
+		Content: "---\nlabels: [go, infra]\n---\n# Doc 1 Updated",
+		Source:  models.SourceManual,
+	})
+	if err != nil {
+		t.Fatalf("update doc1: %v", err)
+	}
+	if err := docSvc.ProcessAllPending(ctx); err != nil {
+		t.Fatalf("process pending after update: %v", err)
+	}
+
+	// Verify "backend" no longer returns doc1
+	docs, err = testDB.GetDocumentsByLabel(ctx, vaultID, "backend")
+	if err != nil {
+		t.Fatalf("get docs by label 'backend' after update: %v", err)
+	}
+	if len(docs) != 0 {
+		t.Errorf("expected 0 docs with 'backend' label after update, got %d", len(docs))
+	}
+
+	// Verify "infra" returns doc1
+	docs, err = testDB.GetDocumentsByLabel(ctx, vaultID, "infra")
+	if err != nil {
+		t.Fatalf("get docs by label 'infra': %v", err)
+	}
+	if len(docs) != 1 {
+		t.Errorf("expected 1 doc with 'infra' label, got %d", len(docs))
+	}
+
+	// Delete doc1 — has_label edges should be cleaned up
+	if err := docSvc.Delete(ctx, vaultID, "/labeled-1.md"); err != nil {
+		t.Fatalf("delete doc1: %v", err)
+	}
+
+	labels, err = testDB.GetLabelsForDocument(ctx, doc1ID)
+	if err != nil {
+		t.Fatalf("get labels for deleted doc1: %v", err)
+	}
+	if len(labels) != 0 {
+		t.Errorf("expected 0 labels for deleted doc, got %d: %v", len(labels), labels)
+	}
+
+	if err := vaultSvc.Delete(ctx, vaultID); err != nil {
+		t.Fatalf("cleanup vault: %v", err)
+	}
+}
+
 // TestSyncChunks_PreservesUnchangedChunks verifies the content-based chunk diffing:
 // unchanged chunks keep their embeddings, changed chunks get new embed_at, removed chunks are deleted.
 func TestSyncChunks_PreservesUnchangedChunks(t *testing.T) {

--- a/internal/models/label.go
+++ b/internal/models/label.go
@@ -1,0 +1,15 @@
+package models
+
+import (
+	"time"
+
+	surrealmodels "github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// Label represents a label record backed by the label table.
+type Label struct {
+	ID        surrealmodels.RecordID `json:"id"`
+	Name      string                 `json:"name"`
+	Vault     surrealmodels.RecordID `json:"vault"`
+	CreatedAt time.Time              `json:"created_at"`
+}


### PR DESCRIPTION
Add label graph system, improve wiki-link lifecycle on document delete/move, and fix frontmatter relation sync.

## New Features
- **Label graph**: `label` table + `has_label` relation edges, replacing flat `document.labels` array for graph queries. `EnsureLabel`, `SyncDocumentLabels`, `GetDocumentsByLabel`, `GetLabelsForDocument`.
- **Wiki-link unresolve on delete**: Deleting a document sets incoming wiki-links to dangling (`to_doc = NONE`) instead of deleting them, preserving backlink references.
- **Raw_target updates on move**: `Move` and `MoveByPrefix` update `wiki_link.raw_target` so links stay consistent after renames.
- **Delete-then-recreate for frontmatter relations**: `processRelatesTo` deletes old frontmatter-derived relations before recreating, preventing stale relation accumulation.
- **New DB index**: `idx_wiki_link_to_doc` for efficient unresolve queries.

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)