### PR TITLE
fix: WebDAV Finder copy errors

### DIFF
--- a/cmd/knowhow/cmd_serve.go
+++ b/cmd/knowhow/cmd_serve.go
@@ -91,6 +91,11 @@ func runServe(_ *cobra.Command, _ []string) error {
 		}
 	}()
 
+	// serverCtx is cancelled on shutdown to stop background goroutines
+	// (e.g. WebDAV pending sweep).
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
+
 	// Listen for SIGHUP to reload LLM config from .env
 	sighup := make(chan os.Signal, 1)
 	signal.Notify(sighup, syscall.SIGHUP)
@@ -147,6 +152,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 
 	// WebDAV endpoint for document editing with any editor
 	var davHandler http.Handler = knowhowdav.NewHandler(
+		serverCtx,
 		"/dav/",
 		app.DBClient(),
 		app.DocumentService(),
@@ -208,7 +214,6 @@ func runServe(_ *cobra.Command, _ []string) error {
 		IdleTimeout:       120 * time.Second,
 	}
 
-	// Wait for interrupt signal
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.23.1 // indirect
 	github.com/anthropics/anthropic-sdk-go v1.26.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.41.3 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.41.3
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.6 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.11 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.19 // indirect
@@ -107,7 +107,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
 	github.com/googleapis/gax-go/v2 v2.17.0 // indirect
 	github.com/goph/emperror v0.17.2 // indirect

--- a/internal/integration/webdav_test.go
+++ b/internal/integration/webdav_test.go
@@ -61,7 +61,7 @@ func setupWebDAV(t *testing.T, suffix string) (*httptest.Server, string) {
 	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig(), document.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
 
 	assetSvc := asset.NewService(testDB, nil)
-	handler := knowhowdav.NewHandler("/dav/", testDB, docSvc, assetSvc, vaultSvc, true, 1024*1024)
+	handler := knowhowdav.NewHandler(ctx, "/dav/", testDB, docSvc, assetSvc, vaultSvc, true, 1024*1024)
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
@@ -443,7 +443,7 @@ func setupWebDAVWithAuth(t *testing.T, suffix string) (*httptest.Server, string,
 
 	docSvc := document.NewService(testDB, nil, parser.DefaultChunkConfig(), document.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
 	assetSvc := asset.NewService(testDB, nil)
-	handler := knowhowdav.NewHandler("/dav/", testDB, docSvc, assetSvc, vaultSvc, false, 1024*1024)
+	handler := knowhowdav.NewHandler(ctx, "/dav/", testDB, docSvc, assetSvc, vaultSvc, false, 1024*1024)
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
@@ -1145,6 +1145,128 @@ func TestWebDAV_AssetFinderTwoPhasePut(t *testing.T) {
 	ct := resp.Header.Get("Content-Type")
 	if ct != "image/png" {
 		t.Errorf("Content-Type = %q, want image/png", ct)
+	}
+}
+
+func TestWebDAV_FinderTwoPhasePutComplete(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "finder-2phase-complete")
+	vaultName := vaultNameFromID(vaultID)
+	url := davURL(srv, vaultName, "/finder-doc.md")
+
+	// Phase 1: LOCK (x/net/webdav creates file via OpenFile with O_CREATE)
+	lockBody := `<?xml version="1.0" encoding="utf-8"?>
+<D:lockinfo xmlns:D="DAV:">
+  <D:lockscope><D:exclusive/></D:lockscope>
+  <D:locktype><D:write/></D:locktype>
+  <D:owner><D:href>finder</D:href></D:owner>
+</D:lockinfo>`
+	req := mustNewRequest(t, "LOCK", url, strings.NewReader(lockBody))
+	req.Header.Set("Content-Type", "application/xml")
+	req.Header.Set("Timeout", "Second-60")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("LOCK: %v", err)
+	}
+	lockToken := resp.Header.Get("Lock-Token")
+	resp.Body.Close()
+	requireStatus(t, resp, "LOCK", http.StatusOK, http.StatusCreated)
+	if lockToken == "" {
+		t.Fatal("LOCK response missing Lock-Token header")
+	}
+
+	// Phase 2: PUT with empty body (Finder "claim")
+	req = mustNewRequest(t, http.MethodPut, url, strings.NewReader(""))
+	req.Header.Set("If", "("+lockToken+")")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT empty: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "PUT empty", http.StatusCreated, http.StatusNoContent)
+
+	// Phase 3: PROPFIND to verify file exists (should return 207 even though
+	// the file is only in the pending set, not yet in DB)
+	req = mustNewRequest(t, "PROPFIND", url, nil)
+	req.Header.Set("Depth", "0")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PROPFIND: %v", err)
+	}
+	propBody := string(mustReadAll(t, resp.Body))
+	resp.Body.Close()
+	requireStatus(t, resp, "PROPFIND", http.StatusMultiStatus)
+	if !strings.Contains(propBody, "finder-doc.md") {
+		t.Errorf("PROPFIND missing filename in response:\n%s", propBody)
+	}
+
+	// Phase 4: PUT with real content
+	realContent := "# Finder Document\n\nWritten by Finder.\n"
+	req = mustNewRequest(t, http.MethodPut, url, strings.NewReader(realContent))
+	req.Header.Set("If", "("+lockToken+")")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT real: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "PUT real", http.StatusCreated, http.StatusNoContent)
+
+	// Phase 5: UNLOCK
+	req = mustNewRequest(t, "UNLOCK", url, nil)
+	req.Header.Set("Lock-Token", lockToken)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("UNLOCK: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "UNLOCK", http.StatusNoContent)
+
+	// Verify: GET returns the real content
+	resp, err = http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	requireStatus(t, resp, "GET", http.StatusOK)
+	body := string(mustReadAll(t, resp.Body))
+	if body != realContent {
+		t.Errorf("GET body = %q, want %q", body, realContent)
+	}
+}
+
+func TestWebDAV_FinderTwoPhasePutAborted(t *testing.T) {
+	srv, vaultID := setupWebDAV(t, "finder-2phase-abort")
+	vaultName := vaultNameFromID(vaultID)
+	url := davURL(srv, vaultName, "/aborted.md")
+
+	// Phase 1: PUT with empty body (claim the file)
+	req := mustNewRequest(t, http.MethodPut, url, strings.NewReader(""))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT empty: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "PUT empty", http.StatusCreated, http.StatusNoContent)
+
+	// PROPFIND should succeed (file is in pending set)
+	req = mustNewRequest(t, "PROPFIND", url, nil)
+	req.Header.Set("Depth", "0")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PROPFIND: %v", err)
+	}
+	resp.Body.Close()
+	requireStatus(t, resp, "PROPFIND (pending)", http.StatusMultiStatus)
+
+	// Simulate abort: no real PUT follows. The pending entry should be
+	// cleaned up by the sweep goroutine. We can't easily wait for the sweep
+	// in a test, so instead verify that the document was NOT written to DB.
+	ctx := context.Background()
+	doc, err := testDB.GetDocumentByPath(ctx, vaultID, "/aborted.md")
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	if doc != nil {
+		t.Error("expected no document in DB for aborted two-phase PUT, but found one")
 	}
 }
 

--- a/internal/webdav/file.go
+++ b/internal/webdav/file.go
@@ -32,6 +32,16 @@ func newReadFile(name string, doc *models.Document) *readFile {
 	}
 }
 
+// newEmptyReadFile returns a read file with no content. Used for pending paths
+// that have been claimed but not yet written — allows PROPFIND and GET to succeed.
+func newEmptyReadFile(name string) *readFile {
+	return &readFile{
+		name:   name,
+		doc:    &models.Document{Content: "", UpdatedAt: time.Now()},
+		reader: bytes.NewReader(nil),
+	}
+}
+
 func (f *readFile) Read(p []byte) (int, error) { return f.reader.Read(p) }
 func (f *readFile) Write([]byte) (int, error)  { return 0, os.ErrPermission }
 func (f *readFile) Seek(offset int64, whence int) (int64, error) {
@@ -59,15 +69,19 @@ type writeFile struct {
 	name       string
 	vaultID    string
 	docService *document.Service
-	buf     bytes.Buffer
-	modTime time.Time
+	pending    *pendingSet
+	isNew      bool
+	buf        bytes.Buffer
+	modTime    time.Time
 }
 
-func newWriteFile(name, vaultID string, docService *document.Service, initial []byte, modTime time.Time) *writeFile {
+func newWriteFile(name, vaultID string, docService *document.Service, initial []byte, modTime time.Time, isNew bool, pending *pendingSet) *writeFile {
 	wf := &writeFile{
 		name:       name,
 		vaultID:    vaultID,
 		docService: docService,
+		pending:    pending,
+		isNew:      isNew,
 		modTime:    modTime,
 	}
 	if initial != nil {
@@ -87,10 +101,23 @@ func (f *writeFile) Write(p []byte) (int, error) {
 
 // Close persists the document. Finder sends an initial PUT with
 // Content-Length=0 to "claim" the file, then verifies with PROPFIND.
-// We must create the document even when empty, otherwise PROPFIND → 404
-// triggers Finder error -43.
+// To avoid ghost empty documents when the copy is aborted mid-way,
+// empty content on new files is deferred to the pending set instead of
+// being written to the DB. Non-empty content always persists immediately.
 func (f *writeFile) Close() error {
 	content := f.buf.String()
+
+	// New file with empty content — add to pending set, skip DB write.
+	// Finder will send the real content in a subsequent PUT.
+	if content == "" && f.isNew {
+		f.pending.Add(f.name)
+		slog.Debug("webdav: document deferred to pending set", "path", f.name, "vault", f.vaultID)
+		return nil
+	}
+
+	// Real content arrived — remove from pending and persist to DB.
+	f.pending.Remove(f.name)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -227,15 +254,19 @@ type assetWriteFile struct {
 	name     string
 	vaultID  string
 	assetSvc *asset.Service
+	pending  *pendingSet
+	isNew    bool
 	buf      bytes.Buffer
 	modTime  time.Time
 }
 
-func newAssetWriteFile(name, vaultID string, assetSvc *asset.Service, modTime time.Time) *assetWriteFile {
+func newAssetWriteFile(name, vaultID string, assetSvc *asset.Service, modTime time.Time, isNew bool, pending *pendingSet) *assetWriteFile {
 	return &assetWriteFile{
 		name:     name,
 		vaultID:  vaultID,
 		assetSvc: assetSvc,
+		pending:  pending,
+		isNew:    isNew,
 		modTime:  modTime,
 	}
 }
@@ -250,6 +281,17 @@ func (f *assetWriteFile) Write(p []byte) (int, error) {
 
 func (f *assetWriteFile) Close() error {
 	data := f.buf.Bytes()
+
+	// New asset with empty content — add to pending set, skip DB write.
+	if len(data) == 0 && f.isNew {
+		f.pending.Add(f.name)
+		slog.Debug("webdav: asset deferred to pending set", "path", f.name, "vault", f.vaultID)
+		return nil
+	}
+
+	// Real content arrived — remove from pending and persist to DB.
+	f.pending.Remove(f.name)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 

--- a/internal/webdav/fs.go
+++ b/internal/webdav/fs.go
@@ -31,17 +31,19 @@ type FS struct {
 	docService   *document.Service
 	assetSvc     *asset.Service
 	vaultSvc     *vault.Service
+	pending      *pendingSet
 	virtualFiles []VirtualFile
 }
 
 // NewFS creates a WebDAV filesystem for the given vault.
-func NewFS(vaultID string, db *db.Client, docService *document.Service, assetSvc *asset.Service, vaultSvc *vault.Service) *FS {
+func NewFS(vaultID string, db *db.Client, docService *document.Service, assetSvc *asset.Service, vaultSvc *vault.Service, pending *pendingSet) *FS {
 	return &FS{
 		vaultID:      vaultID,
 		db:           db,
 		docService:   docService,
 		assetSvc:     assetSvc,
 		vaultSvc:     vaultSvc,
+		pending:      pending,
 		virtualFiles: defaultVirtualFiles(db),
 	}
 }
@@ -101,7 +103,7 @@ func (f *FS) OpenFile(ctx context.Context, name string, flag int, perm os.FileMo
 				return nil, errNotMarkdown
 			}
 			// Open for writing — PUT is a full replacement, don't pre-load existing content
-			return newWriteFile(name, f.vaultID, f.docService, nil, doc.UpdatedAt), nil
+			return newWriteFile(name, f.vaultID, f.docService, nil, doc.UpdatedAt, false, f.pending), nil
 		}
 		return newReadFile(name, doc), nil
 	}
@@ -114,7 +116,7 @@ func (f *FS) OpenFile(ctx context.Context, name string, flag int, perm os.FileMo
 			return nil, fmt.Errorf("open %s: %w", name, err)
 		}
 		if assetMeta != nil {
-			return newAssetWriteFile(name, f.vaultID, f.assetSvc, assetMeta.UpdatedAt), nil
+			return newAssetWriteFile(name, f.vaultID, f.assetSvc, assetMeta.UpdatedAt, false, f.pending), nil
 		}
 	} else {
 		assetObj, err := f.assetSvc.Get(ctx, f.vaultID, name)
@@ -135,15 +137,28 @@ func (f *FS) OpenFile(ctx context.Context, name string, flag int, perm os.FileMo
 		return f.openDir(ctx, name, folder.CreatedAt)
 	}
 
+	// Check pending set before creating — file may have been claimed already
+	if f.pending.Has(name) {
+		if flag&(os.O_WRONLY|os.O_RDWR|os.O_CREATE) != 0 {
+			// Subsequent write to a pending file (the real content PUT)
+			if models.IsImageFile(name) {
+				return newAssetWriteFile(name, f.vaultID, f.assetSvc, time.Now(), false, f.pending), nil
+			}
+			return newWriteFile(name, f.vaultID, f.docService, nil, time.Now(), false, f.pending), nil
+		}
+		// Read-only open on a pending path — return empty read file
+		return newEmptyReadFile(name), nil
+	}
+
 	// Not found — if creating, open for write
 	if flag&os.O_CREATE != 0 {
 		if models.IsImageFile(name) {
-			return newAssetWriteFile(name, f.vaultID, f.assetSvc, time.Now()), nil
+			return newAssetWriteFile(name, f.vaultID, f.assetSvc, time.Now(), true, f.pending), nil
 		}
 		if !isMarkdownFile(name) {
 			return nil, errNotMarkdown
 		}
-		return newWriteFile(name, f.vaultID, f.docService, nil, time.Now()), nil
+		return newWriteFile(name, f.vaultID, f.docService, nil, time.Now(), true, f.pending), nil
 	}
 
 	return nil, os.ErrNotExist
@@ -160,6 +175,9 @@ func (f *FS) RemoveAll(ctx context.Context, name string) error {
 	if isOSMetadataFile(name) {
 		return nil
 	}
+
+	// Clean up pending entry if present
+	wasPending := f.pending.Remove(name)
 
 	// Virtual files are read-only
 	if f.isVirtualFilePath(name) {
@@ -199,6 +217,11 @@ func (f *FS) RemoveAll(ctx context.Context, name string) error {
 		if err := f.vaultSvc.DeleteFolder(ctx, f.vaultID, name); err != nil {
 			return fmt.Errorf("remove folder %s: %w", name, err)
 		}
+		return nil
+	}
+
+	// File was only in the pending set (not yet persisted to DB)
+	if wasPending {
 		return nil
 	}
 
@@ -260,6 +283,11 @@ func (f *FS) Rename(ctx context.Context, oldName, newName string) error {
 			return fmt.Errorf("rename folder %s to %s: %w", oldName, newName, err)
 		}
 		return nil
+	}
+
+	// Pending file exists in memory but not in DB — cannot rename
+	if f.pending.Has(oldName) {
+		return fmt.Errorf("rename %s: %w", oldName, os.ErrPermission)
 	}
 
 	return os.ErrNotExist
@@ -334,6 +362,20 @@ func (f *FS) Stat(ctx context.Context, name string) (os.FileInfo, error) {
 			isDir:   true,
 			modTime: folder.CreatedAt,
 		}, nil
+	}
+
+	// Check pending set — file was claimed but not yet persisted to DB
+	if f.pending.Has(name) {
+		fi := &fileInfo{
+			name:    path.Base(name),
+			modTime: time.Now(),
+		}
+		if isMarkdownFile(name) {
+			fi.contentType = markdownContentType
+		} else if models.IsImageFile(name) {
+			fi.contentType = models.MimeTypeFromExt(name)
+		}
+		return fi, nil
 	}
 
 	return nil, os.ErrNotExist

--- a/internal/webdav/handler.go
+++ b/internal/webdav/handler.go
@@ -1,14 +1,19 @@
 package webdav
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"html"
 	"io"
 	"log/slog"
 	"net/http"
 	"os"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/google/uuid"
 	"golang.org/x/net/webdav"
 
 	"github.com/raphi011/knowhow/internal/asset"
@@ -19,11 +24,36 @@ import (
 	"github.com/raphi011/knowhow/internal/vault"
 )
 
+// vaultMap is a lazily-initialized, concurrent-safe per-vault store.
+type vaultMap[T any] struct {
+	m     sync.Map
+	newFn func() T
+}
+
+func newVaultMap[T any](newFn func() T) *vaultMap[T] {
+	return &vaultMap[T]{newFn: newFn}
+}
+
+func (vm *vaultMap[T]) Get(vaultID string) T {
+	if v, ok := vm.m.Load(vaultID); ok {
+		return v.(T)
+	}
+	v, _ := vm.m.LoadOrStore(vaultID, vm.newFn())
+	return v.(T)
+}
+
+func (vm *vaultMap[T]) Range(fn func(vaultID string, v T) bool) {
+	vm.m.Range(func(key, value any) bool {
+		return fn(key.(string), value.(T))
+	})
+}
+
 // NewHandler creates an http.Handler that serves WebDAV for vault documents.
 // The path prefix is stripped from incoming requests (e.g. "/dav/default/").
 // Auth uses HTTP Basic Auth where the password is a knowhow API token.
 // maxPutBytes limits the size of PUT request bodies (0 = no limit).
 func NewHandler(
+	ctx context.Context,
 	pathPrefix string,
 	dbClient *db.Client,
 	docService *document.Service,
@@ -33,15 +63,29 @@ func NewHandler(
 	maxPutBytes int64,
 ) http.Handler {
 	// Per-vault lock systems to isolate WebDAV locks across vaults.
-	var lockSystems sync.Map // vaultID → webdav.LockSystem
+	lockSystems := newVaultMap(func() webdav.LockSystem { return webdav.NewMemLS() })
 
-	getLockSystem := func(vaultID string) webdav.LockSystem {
-		if ls, ok := lockSystems.Load(vaultID); ok {
-			return ls.(webdav.LockSystem)
+	// Per-vault pending sets track files claimed by Finder's two-phase PUT
+	// but not yet written with real content. Prevents ghost empty documents.
+	pendingSets := newVaultMap(func() *pendingSet { return newPendingSet() })
+
+	// Background goroutine sweeps expired pending entries every 30s.
+	// Stops when ctx is cancelled (server shutdown).
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				pendingSets.Range(func(_ string, ps *pendingSet) bool {
+					ps.Sweep(60 * time.Second)
+					return true
+				})
+			}
 		}
-		ls, _ := lockSystems.LoadOrStore(vaultID, webdav.NewMemLS())
-		return ls.(webdav.LockSystem)
-	}
+	}()
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Always advertise WebDAV compliance so clients (e.g. macOS Finder)
@@ -73,9 +117,7 @@ func NewHandler(
 				_, _ = io.Copy(io.Discard, r.Body)
 				w.WriteHeader(http.StatusCreated)
 			case "LOCK":
-				// Reject lock on metadata files — returning 423 tells clients
-				// locking is not available, which they handle gracefully.
-				w.WriteHeader(http.StatusLocked)
+				writeOSMetadataLockResponse(w, filePath)
 			case "UNLOCK", http.MethodDelete:
 				w.WriteHeader(http.StatusNoContent)
 			default:
@@ -139,10 +181,10 @@ func NewHandler(
 		}
 
 		// Create per-request WebDAV handler with the resolved vault
-		davFS := NewFS(vaultID, dbClient, docService, assetSvc, vaultSvc)
+		davFS := NewFS(vaultID, dbClient, docService, assetSvc, vaultSvc, pendingSets.Get(vaultID))
 		davHandler := &webdav.Handler{
 			FileSystem: davFS,
-			LockSystem: getLockSystem(vaultID),
+			LockSystem: lockSystems.Get(vaultID),
 			Prefix:     pathPrefix + vaultName,
 			Logger: func(r *http.Request, err error) {
 				if err == nil {
@@ -173,4 +215,31 @@ func isWriteMethod(method string) bool {
 		return true
 	}
 	return false
+}
+
+// writeOSMetadataLockResponse writes a valid 200 LOCK response with a fake lock
+// token for OS metadata files. This prevents macOS Finder from aborting the entire
+// copy operation with an "item is in use" error when it tries to LOCK .DS_Store.
+func writeOSMetadataLockResponse(w http.ResponseWriter, filePath string) {
+	token := "opaquelocktoken:" + uuid.NewString()
+	body := fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<D:prop xmlns:D="DAV:">
+  <D:lockdiscovery>
+    <D:activelock>
+      <D:locktype><D:write/></D:locktype>
+      <D:lockscope><D:exclusive/></D:lockscope>
+      <D:depth>0</D:depth>
+      <D:owner><D:href>finder</D:href></D:owner>
+      <D:timeout>Second-60</D:timeout>
+      <D:locktoken><D:href>%s</D:href></D:locktoken>
+      <D:lockroot><D:href>%s</D:href></D:lockroot>
+    </D:activelock>
+  </D:lockdiscovery>
+</D:prop>`, token, html.EscapeString(filePath))
+
+	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+	w.Header().Set("Lock-Token", "<"+token+">")
+	w.WriteHeader(http.StatusOK)
+	// Write error is harmless: response is best-effort for OS metadata files.
+	_, _ = io.WriteString(w, body)
 }

--- a/internal/webdav/handler_test.go
+++ b/internal/webdav/handler_test.go
@@ -1,6 +1,7 @@
 package webdav
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,7 +10,7 @@ import (
 func TestHandler_OSMetadataFastPath(t *testing.T) {
 	// Handler with nil dependencies — if the fast path works,
 	// these are never touched and we don't panic.
-	handler := NewHandler("/dav/", nil, nil, nil, nil, true, 0)
+	handler := NewHandler(context.Background(), "/dav/", nil, nil, nil, nil, true, 0)
 
 	tests := []struct {
 		method string
@@ -25,8 +26,8 @@ func TestHandler_OSMetadataFastPath(t *testing.T) {
 		// PUT on ._ files should return 201 (accepted, discarded)
 		{"PUT", "/dav/somevault/._file.md", http.StatusCreated},
 		{"PUT", "/dav/somevault/.DS_Store", http.StatusCreated},
-		// LOCK on ._ files should return 423 (rejected)
-		{"LOCK", "/dav/somevault/._file.md", http.StatusLocked},
+		// LOCK on ._ files should return 200 with fake lock token
+		{"LOCK", "/dav/somevault/._file.md", http.StatusOK},
 		// UNLOCK on ._ files should return 204
 		{"UNLOCK", "/dav/somevault/._file.md", http.StatusNoContent},
 		// DELETE on ._ files should return 204
@@ -43,12 +44,25 @@ func TestHandler_OSMetadataFastPath(t *testing.T) {
 			}
 		})
 	}
+
+	// Verify LOCK returns Lock-Token header
+	t.Run("LOCK Lock-Token header", func(t *testing.T) {
+		req := httptest.NewRequest("LOCK", "/dav/somevault/.DS_Store", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("got %d, want 200", rec.Code)
+		}
+		if rec.Header().Get("Lock-Token") == "" {
+			t.Error("expected Lock-Token header in LOCK response")
+		}
+	})
 }
 
 func TestHandler_RealFilesNotShortCircuited(t *testing.T) {
 	// A request for a real .md file with nil deps should panic,
 	// proving the fast path did NOT intercept it.
-	handler := NewHandler("/dav/", nil, nil, nil, nil, true, 0)
+	handler := NewHandler(context.Background(), "/dav/", nil, nil, nil, nil, true, 0)
 	req := httptest.NewRequest("PROPFIND", "/dav/somevault/readme.md", nil)
 	rec := httptest.NewRecorder()
 

--- a/internal/webdav/pending.go
+++ b/internal/webdav/pending.go
@@ -1,0 +1,69 @@
+package webdav
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// pendingSet tracks paths that have been claimed but not yet persisted to the DB.
+// This prevents ghost empty documents when Finder's two-phase PUT is interrupted.
+// Each path maps to the time it was claimed, used by Sweep to expire stale entries.
+type pendingSet struct {
+	mu    sync.RWMutex
+	paths map[string]time.Time
+}
+
+func newPendingSet() *pendingSet {
+	return &pendingSet{paths: make(map[string]time.Time)}
+}
+
+// Add registers a path as pending (claimed but not yet written).
+func (ps *pendingSet) Add(path string) {
+	if ps == nil {
+		return
+	}
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	ps.paths[path] = time.Now()
+}
+
+// Remove removes a path from the pending set (file got real content or was deleted).
+// Returns true if the path was present.
+func (ps *pendingSet) Remove(path string) bool {
+	if ps == nil {
+		return false
+	}
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	_, ok := ps.paths[path]
+	delete(ps.paths, path)
+	return ok
+}
+
+// Has returns true if the path is in the pending set.
+func (ps *pendingSet) Has(path string) bool {
+	if ps == nil {
+		return false
+	}
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+	_, ok := ps.paths[path]
+	return ok
+}
+
+// Sweep removes entries older than ttl.
+func (ps *pendingSet) Sweep(ttl time.Duration) {
+	if ps == nil {
+		return
+	}
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	cutoff := time.Now().Add(-ttl)
+	for p, claimedAt := range ps.paths {
+		if claimedAt.Before(cutoff) {
+			slog.Debug("webdav: sweeping expired pending entry", "path", p, "claimedAt", claimedAt)
+			delete(ps.paths, p)
+		}
+	}
+}

--- a/internal/webdav/pending_test.go
+++ b/internal/webdav/pending_test.go
@@ -1,0 +1,74 @@
+package webdav
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestPendingSet_AddHasRemove(t *testing.T) {
+	ps := newPendingSet()
+
+	if ps.Has("/test.md") {
+		t.Error("expected Has to return false for unknown path")
+	}
+
+	ps.Add("/test.md")
+	if !ps.Has("/test.md") {
+		t.Error("expected Has to return true after Add")
+	}
+
+	if !ps.Remove("/test.md") {
+		t.Error("expected Remove to return true for existing path")
+	}
+	if ps.Has("/test.md") {
+		t.Error("expected Has to return false after Remove")
+	}
+	if ps.Remove("/test.md") {
+		t.Error("expected Remove to return false for already-removed path")
+	}
+}
+
+func TestPendingSet_Sweep(t *testing.T) {
+	ps := newPendingSet()
+
+	// Add an entry with a backdated claimedAt
+	ps.mu.Lock()
+	ps.paths["/old.md"] = time.Now().Add(-2 * time.Minute)
+	ps.paths["/new.md"] = time.Now()
+	ps.mu.Unlock()
+
+	ps.Sweep(1 * time.Minute)
+
+	if ps.Has("/old.md") {
+		t.Error("expected old entry to be swept")
+	}
+	if !ps.Has("/new.md") {
+		t.Error("expected new entry to survive sweep")
+	}
+}
+
+func TestPendingSet_ConcurrentAccess(t *testing.T) {
+	ps := newPendingSet()
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(3)
+		path := "/file" + string(rune('a'+i%26)) + ".md"
+		go func() {
+			defer wg.Done()
+			ps.Add(path)
+		}()
+		go func() {
+			defer wg.Done()
+			ps.Has(path)
+		}()
+		go func() {
+			defer wg.Done()
+			ps.Remove(path)
+		}()
+	}
+
+	wg.Wait()
+	// No panic = success for concurrent access test
+}


### PR DESCRIPTION
Fix two macOS Finder issues when copying files into the WebDAV mount:

1. **Fake LOCK for OS metadata** — `.DS_Store`/`._*` LOCK now returns 200 with a fake lock token instead of 423. Finder interpreted 423 as "item is in use" and aborted the entire copy operation.

2. **Pending set prevents ghost documents** — Empty-content writes from Finder's two-phase PUT are deferred to an in-memory pending set instead of being persisted to DB. A background goroutine sweeps abandoned entries after 60s.

## New Features
- `pendingSet` type tracks claimed-but-not-persisted WebDAV paths
- `writeOSMetadataLockResponse` returns valid LOCK XML for OS metadata files
- `Stat()` returns synthetic fileInfo for pending paths so PROPFIND works

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)