### PR TITLE
fix: silently discard unsupported files in WebDAV

### DIFF
--- a/internal/integration/webdav_test.go
+++ b/internal/integration/webdav_test.go
@@ -267,19 +267,27 @@ func TestWebDAV_Move(t *testing.T) {
 	}
 }
 
-func TestWebDAV_NonMarkdownRejected(t *testing.T) {
+func TestWebDAV_UnsupportedFileSilentlyDiscarded(t *testing.T) {
 	srv, vaultID := setupWebDAV(t, "nonmd")
 	vaultName := vaultNameFromID(vaultID)
 
+	// PUT .txt should be silently accepted (prevents Finder batch-copy abort)
 	req := mustNewRequest(t, http.MethodPut, davURL(srv, vaultName, "/file.txt"), strings.NewReader("hello"))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("PUT .txt: %v", err)
 	}
 	resp.Body.Close()
-	// The webdav library translates os.ErrPermission from OpenFile into a 404 on PUT.
-	if resp.StatusCode < 400 {
-		t.Errorf("PUT .txt status = %d, want error status", resp.StatusCode)
+	requireStatus(t, resp, "PUT .txt", http.StatusCreated)
+
+	// GET .txt should 404 (not stored)
+	resp, err = http.Get(davURL(srv, vaultName, "/file.txt"))
+	if err != nil {
+		t.Fatalf("GET .txt: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("GET .txt status = %d, want 404", resp.StatusCode)
 	}
 }
 
@@ -1270,22 +1278,20 @@ func TestWebDAV_FinderTwoPhasePutAborted(t *testing.T) {
 	}
 }
 
-func TestWebDAV_NonImageNonMarkdownRejected(t *testing.T) {
+func TestWebDAV_UnsupportedVsImageFiles(t *testing.T) {
 	srv, vaultID := setupWebDAV(t, "reject-nonimage")
 	vaultName := vaultNameFromID(vaultID)
 
-	// PUT a .txt file should be rejected
+	// PUT a .txt file should be silently accepted but discarded
 	req := mustNewRequest(t, http.MethodPut, davURL(srv, vaultName, "/file.txt"), strings.NewReader("hello"))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("PUT: %v", err)
 	}
 	resp.Body.Close()
-	if resp.StatusCode < 400 {
-		t.Errorf("PUT .txt status = %d, want error", resp.StatusCode)
-	}
+	requireStatus(t, resp, "PUT .txt", http.StatusCreated)
 
-	// PUT a .png file should be accepted
+	// PUT a .png file should be accepted and stored
 	req = mustNewRequest(t, http.MethodPut, davURL(srv, vaultName, "/ok.png"), bytes.NewReader(testPNG))
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {

--- a/internal/webdav/file.go
+++ b/internal/webdav/file.go
@@ -196,7 +196,8 @@ func (d *dirFile) Stat() (fs.FileInfo, error) {
 }
 
 // nopFile silently accepts and discards writes. Used for macOS metadata
-// files (._*, .DS_Store) so Finder doesn't abort the whole drag-and-drop.
+// files (._*, .DS_Store) and unsupported file types (.pdf, .txt, .docx, etc.)
+// so Finder doesn't abort batch drag-and-drop operations.
 type nopFile struct {
 	name    string
 	modTime time.Time
@@ -209,7 +210,11 @@ func (f *nopFile) Read([]byte) (int, error)       { return 0, io.EOF }
 func (f *nopFile) Write(p []byte) (int, error)    { return len(p), nil }
 func (f *nopFile) Seek(int64, int) (int64, error) { return 0, nil }
 func (f *nopFile) Close() error {
-	slog.Debug("webdav: discarded OS metadata file", "path", f.name)
+	if isOSMetadataFile(f.name) {
+		slog.Debug("webdav: discarded OS metadata file", "path", f.name)
+	} else {
+		slog.Info("webdav: discarded unsupported file", "path", f.name)
+	}
 	return nil
 }
 func (f *nopFile) Readdir(int) ([]fs.FileInfo, error) { return nil, os.ErrInvalid }

--- a/internal/webdav/fs.go
+++ b/internal/webdav/fs.go
@@ -156,7 +156,7 @@ func (f *FS) OpenFile(ctx context.Context, name string, flag int, perm os.FileMo
 			return newAssetWriteFile(name, f.vaultID, f.assetSvc, time.Now(), true, f.pending), nil
 		}
 		if !isMarkdownFile(name) {
-			return nil, errNotMarkdown
+			return newNopFile(name), nil
 		}
 		return newWriteFile(name, f.vaultID, f.docService, nil, time.Now(), true, f.pending), nil
 	}
@@ -171,8 +171,8 @@ func (f *FS) RemoveAll(ctx context.Context, name string) error {
 		return fmt.Errorf("cannot remove root directory")
 	}
 
-	// macOS metadata files are never stored — nothing to remove
-	if isOSMetadataFile(name) {
+	// OS metadata and unsupported file types are never stored — nothing to remove
+	if isOSMetadataFile(name) || isUnsupportedFile(name) {
 		return nil
 	}
 
@@ -233,8 +233,10 @@ func (f *FS) Rename(ctx context.Context, oldName, newName string) error {
 	oldName = normalizeName(oldName)
 	newName = normalizeName(newName)
 
-	// macOS metadata files are never stored — nothing to rename
-	if isOSMetadataFile(oldName) {
+	// OS metadata and unsupported file types are never stored — nothing to rename.
+	// Note: only oldName is checked. Renaming a supported file *to* an unsupported
+	// extension is caught later by errNotMarkdown, protecting data integrity.
+	if isOSMetadataFile(oldName) || isUnsupportedFile(oldName) {
 		return nil
 	}
 
@@ -301,8 +303,8 @@ func (f *FS) Stat(ctx context.Context, name string) (os.FileInfo, error) {
 		return &fileInfo{name: "/", isDir: true, modTime: time.Now()}, nil
 	}
 
-	// macOS metadata files are never stored — always report not found
-	if isOSMetadataFile(name) {
+	// OS metadata and unsupported file types are never stored — always report not found
+	if isOSMetadataFile(name) || isUnsupportedFile(name) {
 		return nil, os.ErrNotExist
 	}
 
@@ -503,6 +505,15 @@ func isOSMetadataFile(name string) bool {
 
 // errNotMarkdown is returned when a non-markdown, non-image file is created or renamed to.
 var errNotMarkdown = fmt.Errorf("only markdown (.md) and image files are allowed: %w", os.ErrPermission)
+
+// isUnsupportedFile returns true for files that are neither markdown, image,
+// nor OS metadata. Extensionless paths are excluded (likely directories).
+func isUnsupportedFile(name string) bool {
+	if path.Ext(name) == "" {
+		return false
+	}
+	return !isMarkdownFile(name) && !models.IsImageFile(name) && !isOSMetadataFile(name)
+}
 
 // normalizeName cleans up a WebDAV path to match our internal path format.
 func normalizeName(name string) string {

--- a/internal/webdav/fs_test.go
+++ b/internal/webdav/fs_test.go
@@ -106,6 +106,41 @@ func TestIsOSMetadataFile(t *testing.T) {
 	}
 }
 
+func TestIsUnsupportedFile(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// Unsupported file types
+		{"/docs/document.pdf", true},
+		{"/docs/readme.txt", true},
+		{"/docs/report.docx", true},
+		{"/docs/archive.zip", true},
+		// Markdown files — supported
+		{"/notes/readme.md", false},
+		{"/notes/README.MD", false},
+		// Image files — supported
+		{"/images/photo.png", false},
+		{"/images/photo.jpg", false},
+		{"/images/photo.webp", false},
+		// OS metadata files — handled separately
+		{"/notes/._file.md", false},
+		{"/.DS_Store", false},
+		// No extension — likely a directory
+		{"/notes", false},
+		{"/", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isUnsupportedFile(tt.name)
+			if got != tt.want {
+				t.Errorf("isUnsupportedFile(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNopFile(t *testing.T) {
 	f := newNopFile("/notes/._foo.md")
 

--- a/internal/webdav/handler.go
+++ b/internal/webdav/handler.go
@@ -101,13 +101,14 @@ func NewHandler(
 		}
 		vaultName := parts[0]
 
-		// Fast-path: short-circuit OS metadata files (._*, .DS_Store) before auth.
-		// The majority of Finder's requests are OS metadata files that never touch real data.
+		// Fast-path: short-circuit OS metadata files (._*, .DS_Store) and unsupported
+		// file types (.pdf, .txt, .docx, etc.) before auth. These files are never stored,
+		// so we return canned responses to prevent macOS Finder from aborting batch copies.
 		filePath := ""
 		if len(parts) > 1 {
 			filePath = "/" + parts[1]
 		}
-		if filePath != "" && isOSMetadataFile(filePath) {
+		if filePath != "" && (isOSMetadataFile(filePath) || isUnsupportedFile(filePath)) {
 			switch r.Method {
 			case "PROPFIND", http.MethodGet, http.MethodHead:
 				http.Error(w, "not found", http.StatusNotFound)
@@ -115,9 +116,12 @@ func NewHandler(
 				// Drain body so connection stays clean for keep-alive.
 				// Error is harmless: body is discarded and connection may just close.
 				_, _ = io.Copy(io.Discard, r.Body)
+				if isUnsupportedFile(filePath) {
+					slog.Info("webdav: discarded unsupported file", "path", filePath)
+				}
 				w.WriteHeader(http.StatusCreated)
 			case "LOCK":
-				writeOSMetadataLockResponse(w, filePath)
+				writeFakeLockResponse(w, filePath)
 			case "UNLOCK", http.MethodDelete:
 				w.WriteHeader(http.StatusNoContent)
 			default:
@@ -217,10 +221,10 @@ func isWriteMethod(method string) bool {
 	return false
 }
 
-// writeOSMetadataLockResponse writes a valid 200 LOCK response with a fake lock
-// token for OS metadata files. This prevents macOS Finder from aborting the entire
-// copy operation with an "item is in use" error when it tries to LOCK .DS_Store.
-func writeOSMetadataLockResponse(w http.ResponseWriter, filePath string) {
+// writeFakeLockResponse writes a valid 200 LOCK response with a fake lock token
+// for files that are silently discarded (OS metadata, unsupported file types).
+// This prevents macOS Finder from aborting the entire copy operation.
+func writeFakeLockResponse(w http.ResponseWriter, filePath string) {
 	token := "opaquelocktoken:" + uuid.NewString()
 	body := fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
 <D:prop xmlns:D="DAV:">
@@ -240,6 +244,6 @@ func writeOSMetadataLockResponse(w http.ResponseWriter, filePath string) {
 	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 	w.Header().Set("Lock-Token", "<"+token+">")
 	w.WriteHeader(http.StatusOK)
-	// Write error is harmless: response is best-effort for OS metadata files.
+	// Write error is harmless: response is best-effort for discarded files.
 	_, _ = io.WriteString(w, body)
 }

--- a/internal/webdav/handler_test.go
+++ b/internal/webdav/handler_test.go
@@ -59,6 +59,105 @@ func TestHandler_OSMetadataFastPath(t *testing.T) {
 	})
 }
 
+func TestHandler_UnsupportedFileFastPath(t *testing.T) {
+	// Handler with nil dependencies — if the fast path works,
+	// these are never touched and we don't panic.
+	handler := NewHandler(context.Background(), "/dav/", nil, nil, nil, nil, true, 0)
+
+	tests := []struct {
+		method string
+		path   string
+		want   int
+	}{
+		// PUT on unsupported files should return 201 (accepted, discarded)
+		{"PUT", "/dav/somevault/doc.pdf", http.StatusCreated},
+		{"PUT", "/dav/somevault/notes.txt", http.StatusCreated},
+		{"PUT", "/dav/somevault/report.docx", http.StatusCreated},
+		// PROPFIND/GET/HEAD on unsupported files should return 404
+		{"PROPFIND", "/dav/somevault/doc.pdf", http.StatusNotFound},
+		{"GET", "/dav/somevault/doc.pdf", http.StatusNotFound},
+		{"HEAD", "/dav/somevault/doc.pdf", http.StatusNotFound},
+		// LOCK on unsupported files should return 200 with fake lock token
+		{"LOCK", "/dav/somevault/doc.pdf", http.StatusOK},
+		// UNLOCK/DELETE on unsupported files should return 204
+		{"UNLOCK", "/dav/somevault/doc.pdf", http.StatusNoContent},
+		{"DELETE", "/dav/somevault/doc.pdf", http.StatusNoContent},
+		// COPY/MOVE on unsupported files should return 204 (nothing to copy/move)
+		{"COPY", "/dav/somevault/doc.pdf", http.StatusNoContent},
+		{"MOVE", "/dav/somevault/doc.pdf", http.StatusNoContent},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			if rec.Code != tt.want {
+				t.Errorf("got %d, want %d", rec.Code, tt.want)
+			}
+		})
+	}
+
+	// Verify LOCK returns Lock-Token header
+	t.Run("LOCK Lock-Token header", func(t *testing.T) {
+		req := httptest.NewRequest("LOCK", "/dav/somevault/doc.pdf", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("got %d, want 200", rec.Code)
+		}
+		if rec.Header().Get("Lock-Token") == "" {
+			t.Error("expected Lock-Token header in LOCK response")
+		}
+	})
+}
+
+func TestHandler_ImageFilesNotShortCircuited(t *testing.T) {
+	// Image files (.png, .jpg) are supported — they should NOT be caught
+	// by the unsupported file fast path. With nil deps, reaching the real
+	// handler will panic, proving the fast path didn't intercept.
+	handler := NewHandler(context.Background(), "/dav/", nil, nil, nil, nil, true, 0)
+	req := httptest.NewRequest("PROPFIND", "/dav/somevault/photo.png", nil)
+	rec := httptest.NewRecorder()
+
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		handler.ServeHTTP(rec, req)
+	}()
+
+	if !panicked {
+		t.Error("expected panic for .png file (proves request reached auth/DB code with nil deps)")
+	}
+}
+
+func TestHandler_FolderPathsNotShortCircuited(t *testing.T) {
+	// Extensionless paths (likely directories) should NOT be caught by the
+	// unsupported file fast path. With nil deps, reaching the real handler
+	// will panic, proving the fast path didn't intercept.
+	handler := NewHandler(context.Background(), "/dav/", nil, nil, nil, nil, true, 0)
+	req := httptest.NewRequest("PROPFIND", "/dav/somevault/notes", nil)
+	rec := httptest.NewRecorder()
+
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		handler.ServeHTTP(rec, req)
+	}()
+
+	if !panicked {
+		t.Error("expected panic for extensionless path (proves request reached auth/DB code with nil deps)")
+	}
+}
+
 func TestHandler_RealFilesNotShortCircuited(t *testing.T) {
 	// A request for a real .md file with nil deps should panic,
 	// proving the fast path did NOT intercept it.


### PR DESCRIPTION
## Summary

- **Silently accept and discard unsupported file types** (PDF, txt, docx, zip, etc.) during WebDAV uploads instead of returning errors that cause macOS Finder to abort entire batch drag-and-drop operations
- **Extend handler fast-path** to short-circuit unsupported files before auth, matching the existing OS metadata pattern
- **Log discarded unsupported files at Info level** (vs Debug for OS metadata) for visibility

## Details

Previously, dragging a folder containing mixed file types (markdown + PDFs) onto a WebDAV-mounted vault in Finder would fail partway through — the error on the first unsupported file caused Finder to abort the remaining copies. Now unsupported files return 201 Created on PUT (silently discarded), 404 on GET, and fake LOCK responses for Finder compatibility.

Key changes:
- `isUnsupportedFile()` helper: true for files that aren't markdown, image, or OS metadata
- Handler fast-path extended to cover unsupported files (no auth needed)
- `nopFile.Close()` logs at Info for unsupported files vs Debug for OS metadata
- Renamed `writeOSMetadataLockResponse` → `writeFakeLockResponse`

## Test plan

- [x] `TestIsUnsupportedFile` — unit tests for the new helper
- [x] `TestHandler_UnsupportedFileFastPath` — all HTTP methods return correct status codes
- [x] `TestHandler_ImageFilesNotShortCircuited` — images still reach real handler
- [x] `TestHandler_FolderPathsNotShortCircuited` — directories still reach real handler
- [x] `TestWebDAV_UnsupportedFileSilentlyDiscarded` — integration: PUT 201, GET 404
- [x] `TestWebDAV_UnsupportedVsImageFiles` — integration: txt discarded, png stored
- [x] All existing tests pass (`just test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)