### PR TITLE
feat: instrumentation logging with context propagation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,50 @@ return fmt.Errorf("create document: %w", err)
 - `fmt.Errorf("Create vault: %w", err)` — wrong
 - Proper nouns and acronyms that are normally capitalized (e.g. `KNOWHOW_BEDROCK_*`, `HTTP 500`) are fine
 
+## Structured Logging & Instrumentation
+
+All new code should use the project's structured logging patterns:
+
+### Context-carried loggers (`logutil`)
+
+Always use `logutil.FromCtx(ctx)` instead of bare `slog.Debug/Info/Warn/Error`. This ensures request-scoped fields (`request_id`, `user_id`, `vault_id`) propagate automatically:
+
+```go
+logger := logutil.FromCtx(ctx)
+logger.Debug("operation starting", "key", value)
+```
+
+When a function has a fixed attribute (e.g. model name), bake it into the logger once:
+```go
+logger := logutil.FromCtx(ctx).With("model", m.modelName)
+logger.Debug("starting", "input_len", len(input))  // model is automatic
+```
+
+### DB operations — `defer c.logOp(ctx, op, time.Now())`
+
+Every public DB query method must include `defer c.logOp(ctx, "table.operation", time.Now())` as its first line. This logs timing at Debug level AND records metrics. Do NOT also call `startOp`/`recordTiming` — `logOp` handles both.
+
+```go
+func (c *Client) GetFoo(ctx context.Context, id string) (*Foo, error) {
+    defer c.logOp(ctx, "foo.get", time.Now())
+    // ... query ...
+}
+```
+
+For parent methods that delegate to private helpers (e.g. `UpsertAsset` → `createAsset`/`updateAsset`), only instrument the parent to avoid duplicate log lines.
+
+### Middleware logger enrichment
+
+When middleware adds context (e.g. `user_id`, `conversation_id`), enrich the context logger:
+```go
+logger := logutil.FromCtx(ctx).With("user_id", userID)
+ctx = logutil.WithLogger(ctx, logger)
+```
+
+### Environment variables
+
+All env vars use the `KNOWHOW_` prefix: `KNOWHOW_LOG_LEVEL`, `KNOWHOW_LOG_FILE`, etc.
+
 ## REST API
 
 The server exposes a REST API at `/api/` for CLI and TUI communication:

--- a/cmd/knowhow/cmd_serve.go
+++ b/cmd/knowhow/cmd_serve.go
@@ -51,16 +51,31 @@ func init() {
 	serveCmd.Flags().BoolVar(&serveNoAuth, "no-auth", envOrDefaultBool("KNOWHOW_NO_AUTH", false), "disable token authentication")
 	serveCmd.Flags().BoolVar(&serveSSH, "ssh", envOrDefaultBool("KNOWHOW_SSH_ENABLED", false), "enable SSH/SFTP server")
 	serveCmd.Flags().IntVar(&serveSSHPort, "ssh-port", envOrDefaultInt("KNOWHOW_SSH_PORT", 2222), "SSH server port")
-	serveCmd.Flags().StringVar(&serveLogLevel, "log-level", envOrDefault("LOG_LEVEL", "info"), "log level (debug, info, warn, error)")
+	serveCmd.Flags().StringVar(&serveLogLevel, "log-level", envOrDefault("KNOWHOW_LOG_LEVEL", "info"), "log level (debug, info, warn, error)")
 }
 
 func runServe(_ *cobra.Command, _ []string) error {
-	// Initialize logging
+	// Initialize logging with dynamic level
+	var levelVar slog.LevelVar
 	var level slog.Level
 	if err := level.UnmarshalText([]byte(serveLogLevel)); err != nil {
 		return fmt.Errorf("invalid log level %q: %w", serveLogLevel, err)
 	}
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+	levelVar.Set(level)
+
+	logFile := os.Getenv("KNOWHOW_LOG_FILE")
+	if logFile == "" {
+		logFile = "knowhow.log"
+	}
+	logger, logCleanup, err := config.SetupLogger(logFile, &levelVar)
+	if err != nil {
+		return fmt.Errorf("setup logger: %w", err)
+	}
+	defer func() {
+		if err := logCleanup(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to close log file: %v\n", err)
+		}
+	}()
 	slog.SetDefault(logger)
 
 	port := fmt.Sprintf("%d", servePort)
@@ -107,9 +122,20 @@ func runServe(_ *cobra.Command, _ []string) error {
 						slog.Error("ReloadLLM panicked", "error", p)
 					}
 				}()
-				slog.Info("SIGHUP received, reloading LLM config")
+				slog.Info("SIGHUP received, reloading config")
 				if err := app.ReloadLLM(); err != nil {
 					slog.Warn("LLM reload failed", "error", err)
+				}
+				// Reload log level from environment
+				if newLevel := os.Getenv("KNOWHOW_LOG_LEVEL"); newLevel != "" {
+					var parsed slog.Level
+					if err := parsed.UnmarshalText([]byte(newLevel)); err != nil {
+						slog.Warn("invalid KNOWHOW_LOG_LEVEL after reload", "value", newLevel, "error", err)
+					} else if parsed != levelVar.Level() {
+						old := levelVar.Level()
+						levelVar.Set(parsed)
+						slog.Info("log level changed", "old", old, "new", parsed)
+					}
 				}
 			}()
 		}
@@ -208,7 +234,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 
 	httpServer := &http.Server{
 		Addr:              ":" + port,
-		Handler:           mux,
+		Handler:           api.RequestLogMiddleware(mux),
 		ReadHeaderTimeout: 5 * time.Second,
 		WriteTimeout:      120 * time.Second,
 		IdleTimeout:       120 * time.Second,

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/raphi011/knowhow/internal/auth"
+	"github.com/raphi011/knowhow/internal/logutil"
 	"github.com/raphi011/knowhow/internal/models"
 )
 
@@ -75,6 +76,13 @@ func (s *Service) HandleChat() http.HandlerFunc {
 			flusher.Flush()
 		}
 
+		// Enrich context logger with conversation and vault info
+		chatLogger := logutil.FromCtx(r.Context()).With(
+			"conversation_id", body.ConversationID,
+			"vault_id", body.VaultID,
+		)
+		ctx := logutil.WithLogger(r.Context(), chatLogger)
+
 		req := ChatRequest{
 			ConversationID: body.ConversationID,
 			VaultID:        body.VaultID,
@@ -84,8 +92,8 @@ func (s *Service) HandleChat() http.HandlerFunc {
 			AutoApprove:    body.AutoApprove,
 		}
 
-		if err := s.Chat(r.Context(), req, emit); err != nil {
-			slog.Error("agent chat error", "error", err, "vault_id", req.VaultID, "user_id", req.UserID)
+		if err := s.Chat(ctx, req, emit); err != nil {
+			logutil.FromCtx(ctx).Error("agent chat error", "error", err)
 			emit(StreamEvent{Type: "error", Content: "Failed to process chat request. Please try again."})
 		}
 	}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/raphi011/knowhow/internal/logutil"
+)
+
+// RequestLogMiddleware generates a request_id, enriches the context logger,
+// and logs request completion at Debug level with timing.
+func RequestLogMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		requestID := uuid.NewString()
+
+		logger := slog.Default().With(
+			"request_id", requestID,
+			"method", r.Method,
+			"path", r.URL.Path,
+		)
+		ctx := logutil.WithLogger(r.Context(), logger)
+
+		rec := &statusRecorder{ResponseWriter: w, statusCode: http.StatusOK}
+		next.ServeHTTP(rec, r.WithContext(ctx))
+
+		logger.Debug("http request", "status", rec.statusCode, "duration_ms", time.Since(start).Milliseconds())
+	})
+}
+
+// statusRecorder wraps http.ResponseWriter to capture the status code.
+type statusRecorder struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.statusCode = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+// Unwrap returns the underlying ResponseWriter so http.Flusher and other
+// interfaces can be discovered via ResponseController.
+func (r *statusRecorder) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
+}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/raphi011/knowhow/internal/logutil"
+)
+
+func TestRequestLogMiddleware_setsRequestID(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	prev := slog.Default()
+	slog.SetDefault(logger)
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	handler := RequestLogMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify logger is in context with request_id
+		l := logutil.FromCtx(r.Context())
+		l.Info("inner handler")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	output := buf.String()
+	if !strings.Contains(output, "request_id=") {
+		t.Errorf("expected request_id in log output, got: %s", output)
+	}
+	if !strings.Contains(output, "http request") {
+		t.Errorf("expected 'http request' log line, got: %s", output)
+	}
+	if !strings.Contains(output, "duration_ms=") {
+		t.Errorf("expected duration_ms in log output, got: %s", output)
+	}
+}
+
+func TestRequestLogMiddleware_capturesStatusCode(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	prev := slog.Default()
+	slog.SetDefault(logger)
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	handler := RequestLogMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/missing", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	output := buf.String()
+	if !strings.Contains(output, "status=404") {
+		t.Errorf("expected status=404 in log output, got: %s", output)
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/raphi011/knowhow/internal/db"
+	"github.com/raphi011/knowhow/internal/logutil"
 )
 
 // NoAuthMiddleware injects an admin AuthContext with access to all vaults,
@@ -18,7 +19,10 @@ func NoAuthMiddleware(next http.Handler) http.Handler {
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return
 		}
-		next.ServeHTTP(w, r.WithContext(WithAuth(r.Context(), ac)))
+		ctx := WithAuth(r.Context(), ac)
+		logger := logutil.FromCtx(ctx).With("user_id", ac.UserID)
+		ctx = logutil.WithLogger(ctx, logger)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 
@@ -40,7 +44,10 @@ func Middleware(dbClient *db.Client) func(http.Handler) http.Handler {
 				return
 			}
 
-			next.ServeHTTP(w, r.WithContext(WithAuth(r.Context(), ac)))
+			ctx := WithAuth(r.Context(), ac)
+			logger := logutil.FromCtx(ctx).With("user_id", ac.UserID)
+			ctx = logutil.WithLogger(ctx, logger)
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -9,24 +10,22 @@ import (
 )
 
 // SetupLogger creates a dual-output logger: text to stderr, JSON to file.
-// Returns the logger and a cleanup function to close the file.
-func SetupLogger(logFile string, level slog.Level) (*slog.Logger, func() error) {
+// Both handlers share the given LevelVar so level changes apply to both.
+// Returns the logger, a cleanup function to close the file, and any error.
+func SetupLogger(logFile string, levelVar *slog.LevelVar) (*slog.Logger, func() error, error) {
 	// Stderr handler (text for readability)
 	stderrHandler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: level,
+		Level: levelVar,
 	})
 
-	// Try to open log file
 	file, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
-		// Fall back to stderr-only if file fails
-		slog.Error("failed to open log file, using stderr only", "error", err, "file", logFile)
-		return slog.New(stderrHandler), func() error { return nil }
+		return nil, nil, fmt.Errorf("open log file %s: %w", logFile, err)
 	}
 
 	// File handler (JSON for machine parsing)
 	fileHandler := slog.NewJSONHandler(file, &slog.HandlerOptions{
-		Level: level,
+		Level: levelVar,
 	})
 
 	// Fanout to both handlers
@@ -36,12 +35,12 @@ func SetupLogger(logFile string, level slog.Level) (*slog.Logger, func() error) 
 		return file.Close()
 	}
 
-	return logger, cleanup
+	return logger, cleanup, nil
 }
 
 // SetupLoggerWithWriters creates a logger with custom writers (for testing).
-func SetupLoggerWithWriters(stderr, file io.Writer, level slog.Level) *slog.Logger {
-	stderrHandler := slog.NewTextHandler(stderr, &slog.HandlerOptions{Level: level})
-	fileHandler := slog.NewJSONHandler(file, &slog.HandlerOptions{Level: level})
+func SetupLoggerWithWriters(stderr, file io.Writer, levelVar *slog.LevelVar) *slog.Logger {
+	stderrHandler := slog.NewTextHandler(stderr, &slog.HandlerOptions{Level: levelVar})
+	fileHandler := slog.NewJSONHandler(file, &slog.HandlerOptions{Level: levelVar})
 	return slog.New(slogmulti.Fanout(stderrHandler, fileHandler))
 }

--- a/internal/config/logging_test.go
+++ b/internal/config/logging_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestSetupLoggerWithWriters_dynamicLevel(t *testing.T) {
+	var stderr, file bytes.Buffer
+
+	levelVar := &slog.LevelVar{}
+	levelVar.Set(slog.LevelWarn)
+
+	logger := SetupLoggerWithWriters(&stderr, &file, levelVar)
+
+	// Debug should be suppressed at Warn level
+	logger.Debug("should be suppressed")
+	if stderr.Len() > 0 {
+		t.Error("debug message should be suppressed at warn level")
+	}
+
+	// Warn should appear
+	logger.Warn("visible warning")
+	if !strings.Contains(stderr.String(), "visible warning") {
+		t.Errorf("expected warning in stderr, got: %s", stderr.String())
+	}
+	if !strings.Contains(file.String(), "visible warning") {
+		t.Errorf("expected warning in file, got: %s", file.String())
+	}
+
+	// Switch to Debug level
+	stderr.Reset()
+	file.Reset()
+	levelVar.Set(slog.LevelDebug)
+
+	logger.Debug("now visible")
+	if !strings.Contains(stderr.String(), "now visible") {
+		t.Errorf("expected debug message in stderr after level change, got: %s", stderr.String())
+	}
+	if !strings.Contains(file.String(), "now visible") {
+		t.Errorf("expected debug message in file after level change, got: %s", file.String())
+	}
+}

--- a/internal/db/client.go
+++ b/internal/db/client.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/raphi011/knowhow/internal/logutil"
 	"github.com/raphi011/knowhow/internal/metrics"
 	"github.com/surrealdb/surrealdb.go"
 	"github.com/surrealdb/surrealdb.go/contrib/rews"
@@ -237,18 +238,16 @@ func (c *Client) monitorConnection() {
 	}
 }
 
-// recordTiming records operation timing if metrics are enabled.
-func (c *Client) recordTiming(op string, start time.Time) {
-	if c.metrics != nil {
-		c.metrics.RecordTiming(op, time.Since(start))
-	}
-}
-
-// startOp marks connection active and returns start time for timing.
-// Usage: start := c.startOp(); defer c.recordTiming(metrics.OpDBQuery, start)
-func (c *Client) startOp() time.Time {
+// logOp logs a database operation at Debug level with timing and records metrics.
+// It combines the responsibilities of the former logOp, startOp, and recordTiming
+// into a single deferred call.
+func (c *Client) logOp(ctx context.Context, op string, start time.Time) {
 	c.lastActive.Store(time.Now().Unix())
-	return time.Now()
+	elapsed := time.Since(start)
+	logutil.FromCtx(ctx).Debug("db query", "op", op, "duration_ms", elapsed.Milliseconds())
+	if c.metrics != nil {
+		c.metrics.RecordTiming("db."+op, elapsed)
+	}
 }
 
 // DB returns the underlying SurrealDB client for queries.

--- a/internal/db/queries_asset.go
+++ b/internal/db/queries_asset.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/surrealdb/surrealdb.go"
@@ -16,6 +17,7 @@ import (
 // Uses check-then-create/update to work around SurrealDB v3's UPSERT ... WHERE
 // not creating new records when no match exists.
 func (c *Client) UpsertAsset(ctx context.Context, input models.AssetInput) (*models.Asset, error) {
+	defer c.logOp(ctx, "asset.upsert", time.Now())
 	// Normalize nil to empty slice — SurrealDB rejects NULL for bytes fields.
 	if input.Data == nil {
 		input.Data = []byte{}
@@ -110,6 +112,7 @@ func (c *Client) updateAsset(ctx context.Context, input models.AssetInput, conte
 
 // GetAssetByPath returns the full asset (including data) by vault+path.
 func (c *Client) GetAssetByPath(ctx context.Context, vaultID, path string) (*models.Asset, error) {
+	defer c.logOp(ctx, "asset.get_by_path", time.Now())
 	sql := `SELECT * FROM asset WHERE vault = type::record("vault", $vault_id) AND path = $path LIMIT 1`
 	results, err := surrealdb.Query[[]models.Asset](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
@@ -126,6 +129,7 @@ func (c *Client) GetAssetByPath(ctx context.Context, vaultID, path string) (*mod
 
 // GetAssetMetaByPath returns lightweight asset metadata (no data bytes).
 func (c *Client) GetAssetMetaByPath(ctx context.Context, vaultID, path string) (*models.AssetMeta, error) {
+	defer c.logOp(ctx, "asset.get_meta_by_path", time.Now())
 	sql := `SELECT path, mime_type, size, content_hash, created_at, updated_at FROM asset WHERE vault = type::record("vault", $vault_id) AND path = $path LIMIT 1`
 	results, err := surrealdb.Query[[]models.AssetMeta](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
@@ -142,6 +146,7 @@ func (c *Client) GetAssetMetaByPath(ctx context.Context, vaultID, path string) (
 
 // ListAssetMetas returns lightweight metadata for assets in a vault, optionally filtered by folder prefix.
 func (c *Client) ListAssetMetas(ctx context.Context, vaultID string, folder *string) ([]models.AssetMeta, error) {
+	defer c.logOp(ctx, "asset.list_metas", time.Now())
 	vars := map[string]any{
 		"vault_id": bareID("vault", vaultID),
 	}
@@ -169,6 +174,7 @@ func (c *Client) ListAssetMetas(ctx context.Context, vaultID string, folder *str
 
 // DeleteAsset deletes an asset by vault+path.
 func (c *Client) DeleteAsset(ctx context.Context, vaultID, path string) error {
+	defer c.logOp(ctx, "asset.delete", time.Now())
 	sql := `DELETE FROM asset WHERE vault = type::record("vault", $vault_id) AND path = $path`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
@@ -182,6 +188,7 @@ func (c *Client) DeleteAsset(ctx context.Context, vaultID, path string) error {
 // DeleteAssetsByPrefix deletes all assets in a vault whose path starts with the given prefix.
 // Returns the number of deleted assets.
 func (c *Client) DeleteAssetsByPrefix(ctx context.Context, vaultID, pathPrefix string) (int, error) {
+	defer c.logOp(ctx, "asset.delete_by_prefix", time.Now())
 	sql := `DELETE FROM asset WHERE vault = type::record("vault", $vault_id) AND string::starts_with(path, $prefix) RETURN BEFORE`
 	results, err := surrealdb.Query[[]models.Asset](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
@@ -198,6 +205,7 @@ func (c *Client) DeleteAssetsByPrefix(ctx context.Context, vaultID, pathPrefix s
 
 // MoveAsset updates an asset's path and mime_type.
 func (c *Client) MoveAsset(ctx context.Context, vaultID, oldPath, newPath string) error {
+	defer c.logOp(ctx, "asset.move", time.Now())
 	newMime := models.MimeTypeFromExt(newPath)
 	sql := `UPDATE asset SET path = $new_path, mime_type = $mime_type WHERE vault = type::record("vault", $vault_id) AND path = $old_path`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
@@ -214,6 +222,7 @@ func (c *Client) MoveAsset(ctx context.Context, vaultID, oldPath, newPath string
 // MoveAssetsByPrefix updates all assets whose path starts with oldPrefix to use newPrefix.
 // Returns the number of moved assets.
 func (c *Client) MoveAssetsByPrefix(ctx context.Context, vaultID, oldPrefix, newPrefix string) (int, error) {
+	defer c.logOp(ctx, "asset.move_by_prefix", time.Now())
 	sql := `
 		UPDATE asset
 		SET path = string::concat($new_prefix, string::slice(path, string::len($old_prefix))),

--- a/internal/db/queries_chunk.go
+++ b/internal/db/queries_chunk.go
@@ -11,6 +11,7 @@ import (
 )
 
 func (c *Client) CreateChunks(ctx context.Context, chunks []models.ChunkInput) error {
+	defer c.logOp(ctx, "chunk.create", time.Now())
 	if len(chunks) == 0 {
 		return nil
 	}
@@ -77,6 +78,7 @@ func (c *Client) CreateChunks(ctx context.Context, chunks []models.ChunkInput) e
 }
 
 func (c *Client) GetChunks(ctx context.Context, documentID string) ([]models.Chunk, error) {
+	defer c.logOp(ctx, "chunk.get", time.Now())
 	sql := `SELECT * FROM chunk WHERE document = type::record("document", $doc_id) ORDER BY position ASC`
 	results, err := surrealdb.Query[[]models.Chunk](ctx, c.DB(), sql, map[string]any{
 		"doc_id": documentID,
@@ -91,6 +93,7 @@ func (c *Client) GetChunks(ctx context.Context, documentID string) ([]models.Chu
 }
 
 func (c *Client) DeleteChunks(ctx context.Context, documentID string) error {
+	defer c.logOp(ctx, "chunk.delete", time.Now())
 	sql := `DELETE FROM chunk WHERE document = type::record("document", $doc_id)`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
 		"doc_id": documentID,
@@ -102,6 +105,7 @@ func (c *Client) DeleteChunks(ctx context.Context, documentID string) error {
 
 // DeleteChunkByID deletes a single chunk by its ID.
 func (c *Client) DeleteChunkByID(ctx context.Context, id string) error {
+	defer c.logOp(ctx, "chunk.delete_by_id", time.Now())
 	sql := `DELETE type::record("chunk", $id)`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
 		"id": id,
@@ -113,6 +117,7 @@ func (c *Client) DeleteChunkByID(ctx context.Context, id string) error {
 
 // UpdateChunkPosition updates only the position field of a chunk.
 func (c *Client) UpdateChunkPosition(ctx context.Context, id string, position int) error {
+	defer c.logOp(ctx, "chunk.update_position", time.Now())
 	sql := `UPDATE type::record("chunk", $id) SET position = $position`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
 		"id":       id,
@@ -128,6 +133,7 @@ func (c *Client) UpdateChunkPosition(ctx context.Context, id string, position in
 // those specific records — clearing embed_at and returning the BEFORE state so the
 // caller gets the content to embed. This prevents double-processing.
 func (c *Client) ClaimChunksForEmbedding(ctx context.Context, limit int) ([]models.Chunk, error) {
+	defer c.logOp(ctx, "chunk.claim_for_embedding", time.Now())
 	sql := `
 		UPDATE (
 			SELECT id, embed_at FROM chunk
@@ -152,6 +158,7 @@ func (c *Client) ClaimChunksForEmbedding(ctx context.Context, limit int) ([]mode
 
 // UpdateChunkEmbedding sets the embedding vector on a chunk after the worker embeds it.
 func (c *Client) UpdateChunkEmbedding(ctx context.Context, id string, embedding []float32) error {
+	defer c.logOp(ctx, "chunk.update_embedding", time.Now())
 	sql := `UPDATE type::record("chunk", $id) SET embedding = $embedding`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
 		"id":        id,
@@ -165,6 +172,7 @@ func (c *Client) UpdateChunkEmbedding(ctx context.Context, id string, embedding 
 // RescheduleChunkEmbedding re-schedules a chunk for embedding after a failure.
 // Uses a 30s backoff to avoid tight retry storms during provider outages.
 func (c *Client) RescheduleChunkEmbedding(ctx context.Context, id string) error {
+	defer c.logOp(ctx, "chunk.reschedule_embedding", time.Now())
 	retryAt := time.Now().UTC().Add(30 * time.Second)
 	sql := `UPDATE type::record("chunk", $id) SET embed_at = $embed_at`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{

--- a/internal/db/queries_conversation.go
+++ b/internal/db/queries_conversation.go
@@ -3,12 +3,14 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/surrealdb/surrealdb.go"
 )
 
 func (c *Client) CreateConversation(ctx context.Context, vaultID, userID string) (*models.Conversation, error) {
+	defer c.logOp(ctx, "conversation.create", time.Now())
 	sql := `
 		CREATE conversation SET
 			vault = type::record("vault", $vault_id),
@@ -29,6 +31,7 @@ func (c *Client) CreateConversation(ctx context.Context, vaultID, userID string)
 }
 
 func (c *Client) GetConversation(ctx context.Context, id string) (*models.Conversation, error) {
+	defer c.logOp(ctx, "conversation.get", time.Now())
 	sql := `SELECT * FROM type::record("conversation", $id)`
 	results, err := surrealdb.Query[[]models.Conversation](ctx, c.DB(), sql, map[string]any{
 		"id": bareID("conversation", id),
@@ -43,6 +46,7 @@ func (c *Client) GetConversation(ctx context.Context, id string) (*models.Conver
 }
 
 func (c *Client) ListConversations(ctx context.Context, vaultID, userID string) ([]models.Conversation, error) {
+	defer c.logOp(ctx, "conversation.list", time.Now())
 	sql := `SELECT * FROM conversation WHERE vault = type::record("vault", $vault_id) AND user = type::record("user", $user_id) ORDER BY updated_at DESC`
 	results, err := surrealdb.Query[[]models.Conversation](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
@@ -58,6 +62,7 @@ func (c *Client) ListConversations(ctx context.Context, vaultID, userID string) 
 }
 
 func (c *Client) UpdateConversationTitle(ctx context.Context, id, title string) error {
+	defer c.logOp(ctx, "conversation.update_title", time.Now())
 	sql := `UPDATE type::record("conversation", $id) SET title = $title`
 	_, err := surrealdb.Query[[]models.Conversation](ctx, c.DB(), sql, map[string]any{
 		"id":    bareID("conversation", id),
@@ -70,6 +75,7 @@ func (c *Client) UpdateConversationTitle(ctx context.Context, id, title string) 
 }
 
 func (c *Client) DeleteConversation(ctx context.Context, id string) error {
+	defer c.logOp(ctx, "conversation.delete", time.Now())
 	sql := `DELETE type::record("conversation", $id)`
 	_, err := surrealdb.Query[[]models.Conversation](ctx, c.DB(), sql, map[string]any{
 		"id": bareID("conversation", id),
@@ -81,6 +87,7 @@ func (c *Client) DeleteConversation(ctx context.Context, id string) error {
 }
 
 func (c *Client) UpdateConversationTokens(ctx context.Context, id string, inputTokens, outputTokens int64) error {
+	defer c.logOp(ctx, "conversation.update_tokens", time.Now())
 	sql := `UPDATE type::record("conversation", $id) SET token_input += $input, token_output += $output`
 	_, err := surrealdb.Query[[]models.Conversation](ctx, c.DB(), sql, map[string]any{
 		"id":     bareID("conversation", id),
@@ -94,6 +101,7 @@ func (c *Client) UpdateConversationTokens(ctx context.Context, id string, inputT
 }
 
 func (c *Client) CreateMessage(ctx context.Context, conversationID string, role models.MessageRole, content string, docRefs []string, toolName, toolInput, toolMeta, toolCallID, toolCalls *string) (*models.Message, error) {
+	defer c.logOp(ctx, "message.create", time.Now())
 	if docRefs == nil {
 		docRefs = []string{}
 	}
@@ -131,6 +139,7 @@ func (c *Client) CreateMessage(ctx context.Context, conversationID string, role 
 }
 
 func (c *Client) ListMessages(ctx context.Context, conversationID string) ([]models.Message, error) {
+	defer c.logOp(ctx, "message.list", time.Now())
 	sql := `SELECT * FROM message WHERE conversation = type::record("conversation", $conversation_id) ORDER BY created_at ASC`
 	results, err := surrealdb.Query[[]models.Message](ctx, c.DB(), sql, map[string]any{
 		"conversation_id": bareID("conversation", conversationID),

--- a/internal/db/queries_document.go
+++ b/internal/db/queries_document.go
@@ -29,6 +29,7 @@ type SyncTombstone struct {
 // ListSyncMetadata returns lightweight metadata for documents in a vault,
 // optionally filtered by updated_at > since. Used for incremental sync.
 func (c *Client) ListSyncMetadata(ctx context.Context, vaultID string, since *string, limit, offset int) ([]SyncMeta, error) {
+	defer c.logOp(ctx, "document.list_sync_metadata", time.Now())
 	if limit <= 0 {
 		limit = 500
 	}
@@ -62,6 +63,7 @@ func (c *Client) ListSyncMetadata(ctx context.Context, vaultID string, since *st
 
 // ListTombstones returns tombstones for deleted documents in a vault since the given time.
 func (c *Client) ListTombstones(ctx context.Context, vaultID string, since string, limit, offset int) ([]SyncTombstone, error) {
+	defer c.logOp(ctx, "document.list_tombstones", time.Now())
 	if limit <= 0 {
 		limit = 500
 	}
@@ -86,6 +88,7 @@ func (c *Client) ListTombstones(ctx context.Context, vaultID string, since strin
 }
 
 func (c *Client) CreateDocument(ctx context.Context, input models.DocumentInput) (*models.Document, error) {
+	defer c.logOp(ctx, "document.create", time.Now())
 	labels := input.Labels
 	if labels == nil {
 		labels = []string{}
@@ -132,6 +135,7 @@ func (c *Client) CreateDocument(ctx context.Context, input models.DocumentInput)
 }
 
 func (c *Client) GetDocumentByPath(ctx context.Context, vaultID, path string) (*models.Document, error) {
+	defer c.logOp(ctx, "document.get_by_path", time.Now())
 	sql := `SELECT * FROM document WHERE vault = type::record("vault", $vault_id) AND path = $path LIMIT 1`
 	results, err := surrealdb.Query[[]models.Document](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
@@ -147,6 +151,7 @@ func (c *Client) GetDocumentByPath(ctx context.Context, vaultID, path string) (*
 }
 
 func (c *Client) GetDocumentByID(ctx context.Context, id string) (*models.Document, error) {
+	defer c.logOp(ctx, "document.get_by_id", time.Now())
 	sql := `SELECT * FROM type::record("document", $id)`
 	results, err := surrealdb.Query[[]models.Document](ctx, c.DB(), sql, map[string]any{
 		"id": id,
@@ -229,6 +234,7 @@ func buildDocumentFilter(filter ListDocumentsFilter) (whereClause string, vars m
 }
 
 func (c *Client) ListDocuments(ctx context.Context, filter ListDocumentsFilter) ([]models.Document, error) {
+	defer c.logOp(ctx, "document.list", time.Now())
 	where, vars, suffix, err := buildDocumentFilter(filter)
 	if err != nil {
 		return nil, fmt.Errorf("list documents: %w", err)
@@ -246,6 +252,7 @@ func (c *Client) ListDocuments(ctx context.Context, filter ListDocumentsFilter) 
 }
 
 func (c *Client) UpdateDocument(ctx context.Context, id string, content, contentBody, title string, source models.DocumentSource, labels []string, contentHash *string, metadata map[string]any) (*models.Document, error) {
+	defer c.logOp(ctx, "document.update", time.Now())
 	if labels == nil {
 		labels = []string{}
 	}
@@ -284,6 +291,7 @@ func (c *Client) UpdateDocument(ctx context.Context, id string, content, content
 }
 
 func (c *Client) DeleteDocument(ctx context.Context, id string) error {
+	defer c.logOp(ctx, "document.delete", time.Now())
 	sql := `DELETE type::record("document", $id)`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"id": id}); err != nil {
 		return fmt.Errorf("delete document: %w", err)
@@ -294,6 +302,7 @@ func (c *Client) DeleteDocument(ctx context.Context, id string) error {
 // DeleteDocumentsByPrefix deletes all documents in a vault whose path starts with the given prefix.
 // Returns the number of deleted documents.
 func (c *Client) DeleteDocumentsByPrefix(ctx context.Context, vaultID, pathPrefix string) (int, error) {
+	defer c.logOp(ctx, "document.delete_by_prefix", time.Now())
 	sql := `DELETE FROM document WHERE vault = type::record("vault", $vault_id) AND string::starts_with(path, $prefix) RETURN BEFORE`
 	results, err := surrealdb.Query[[]models.Document](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
@@ -311,6 +320,7 @@ func (c *Client) DeleteDocumentsByPrefix(ctx context.Context, vaultID, pathPrefi
 // MoveDocumentsByPrefix updates all documents in a vault whose path starts with oldPrefix,
 // replacing oldPrefix with newPrefix. Returns the count of moved documents.
 func (c *Client) MoveDocumentsByPrefix(ctx context.Context, vaultID, oldPrefix, newPrefix string) (int, error) {
+	defer c.logOp(ctx, "document.move_by_prefix", time.Now())
 	sql := `
 		UPDATE document
 		SET path = string::concat($new_prefix, string::slice(path, string::len($old_prefix)))
@@ -333,6 +343,7 @@ func (c *Client) MoveDocumentsByPrefix(ctx context.Context, vaultID, oldPrefix, 
 }
 
 func (c *Client) MoveDocument(ctx context.Context, id, newPath string) (*models.Document, error) {
+	defer c.logOp(ctx, "document.move", time.Now())
 	sql := `
 		UPDATE type::record("document", $id) SET
 			path = $new_path
@@ -353,6 +364,7 @@ func (c *Client) MoveDocument(ctx context.Context, id, newPath string) (*models.
 
 // ListUnprocessedDocuments returns documents that have not yet been processed by the async worker.
 func (c *Client) ListUnprocessedDocuments(ctx context.Context, limit int) ([]models.Document, error) {
+	defer c.logOp(ctx, "document.list_unprocessed", time.Now())
 	if limit <= 0 {
 		limit = 20
 	}
@@ -371,6 +383,7 @@ func (c *Client) ListUnprocessedDocuments(ctx context.Context, limit int) ([]mod
 
 // MarkDocumentProcessed sets processed = true on a document.
 func (c *Client) MarkDocumentProcessed(ctx context.Context, docID string) error {
+	defer c.logOp(ctx, "document.mark_processed", time.Now())
 	sql := `UPDATE type::record("document", $id) SET processed = true`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"id": docID}); err != nil {
 		return fmt.Errorf("mark processed: %w", err)
@@ -380,6 +393,7 @@ func (c *Client) MarkDocumentProcessed(ctx context.Context, docID string) error 
 
 // ListLabels returns all distinct labels used by documents in the given vault.
 func (c *Client) ListLabels(ctx context.Context, vaultID string) ([]string, error) {
+	defer c.logOp(ctx, "document.list_labels", time.Now())
 	sql := `RETURN array::distinct(array::flatten(
 		(SELECT labels FROM document WHERE vault = type::record("vault", $vault_id)).labels
 	))`
@@ -401,6 +415,7 @@ func (c *Client) ListLabels(ctx context.Context, vaultID string) ([]string, erro
 
 // ListLabelsWithCounts returns labels with their document counts for the given vault.
 func (c *Client) ListLabelsWithCounts(ctx context.Context, vaultID string) ([]models.LabelCount, error) {
+	defer c.logOp(ctx, "document.list_labels_with_counts", time.Now())
 	sql := `SELECT label, count() AS count FROM (SELECT labels AS label FROM document WHERE vault = type::record("vault", $vault_id) SPLIT labels) GROUP BY label ORDER BY count DESC`
 	results, err := surrealdb.Query[[]models.LabelCount](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
@@ -421,6 +436,7 @@ func (c *Client) ListLabelsWithCounts(ctx context.Context, vaultID string) ([]mo
 // GetDocumentMetaByPath returns lightweight metadata for a document (no content).
 // Returns nil if the document doesn't exist.
 func (c *Client) GetDocumentMetaByPath(ctx context.Context, vaultID, path string) (*models.DocumentMeta, error) {
+	defer c.logOp(ctx, "document.get_meta_by_path", time.Now())
 	sql := `SELECT path, content_length, content_hash ?? null AS content_hash, updated_at FROM document WHERE vault = type::record("vault", $vault_id) AND path = $path LIMIT 1`
 	results, err := surrealdb.Query[[]models.DocumentMeta](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
@@ -437,6 +453,7 @@ func (c *Client) GetDocumentMetaByPath(ctx context.Context, vaultID, path string
 
 // ListDocumentMetas returns lightweight metadata (no content) for documents matching the filter.
 func (c *Client) ListDocumentMetas(ctx context.Context, filter ListDocumentsFilter) ([]models.DocumentMeta, error) {
+	defer c.logOp(ctx, "document.list_metas", time.Now())
 	where, vars, suffix, err := buildDocumentFilter(filter)
 	if err != nil {
 		return nil, fmt.Errorf("list document metas: %w", err)
@@ -459,6 +476,7 @@ func (c *Client) ListDocumentMetas(ctx context.Context, filter ListDocumentsFilt
 // violation (another request created the same path between our check and insert),
 // we retry as an update.
 func (c *Client) UpsertDocument(ctx context.Context, input models.DocumentInput) (doc *models.Document, created bool, previousDoc *models.Document, err error) {
+	defer c.logOp(ctx, "document.upsert", time.Now())
 	const maxRetries = 3
 
 	for attempt := range maxRetries {

--- a/internal/db/queries_folder.go
+++ b/internal/db/queries_folder.go
@@ -13,6 +13,7 @@ import (
 
 // CreateFolder creates a single folder record. Returns the created folder.
 func (c *Client) CreateFolder(ctx context.Context, vaultID, folderPath string) (*models.Folder, error) {
+	defer c.logOp(ctx, "folder.create", time.Now())
 	name := path.Base(folderPath)
 
 	sql := `
@@ -41,6 +42,7 @@ func (c *Client) CreateFolder(ctx context.Context, vaultID, folderPath string) (
 // caching recent calls to skip redundant DB round-trips (60s TTL).
 // For example, given "/guides/sub/file.md", it creates "/guides" and "/guides/sub".
 func (c *Client) EnsureFolders(ctx context.Context, vaultID, docPath string) error {
+	defer c.logOp(ctx, "folder.ensure", time.Now())
 	docPath = models.NormalizePath(docPath)
 	dir := path.Dir(docPath)
 	if dir == "/" || dir == "." {
@@ -69,6 +71,7 @@ func (c *Client) EnsureFolders(ctx context.Context, vaultID, docPath string) err
 // For example, given "/guides/sub", it creates "/guides" and "/guides/sub".
 // All folders are inserted in a single batched query to avoid N+1 round-trips.
 func (c *Client) EnsureFolderPath(ctx context.Context, vaultID, folderPath string) error {
+	defer c.logOp(ctx, "folder.ensure_path", time.Now())
 	folderPath = models.NormalizePath(folderPath)
 	if folderPath == "/" || folderPath == "." {
 		return nil
@@ -103,6 +106,7 @@ func (c *Client) EnsureFolderPath(ctx context.Context, vaultID, folderPath strin
 
 // ListFolders returns all folders in a vault, ordered by path.
 func (c *Client) ListFolders(ctx context.Context, vaultID string) ([]models.Folder, error) {
+	defer c.logOp(ctx, "folder.list", time.Now())
 	sql := `SELECT * FROM folder WHERE vault = type::record("vault", $vault_id) ORDER BY path ASC`
 	results, err := surrealdb.Query[[]models.Folder](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
@@ -120,6 +124,7 @@ func (c *Client) ListFolders(ctx context.Context, vaultID string) ([]models.Fold
 // Only folders whose path starts with parentPath+"/" are fetched from the DB,
 // then filtered in Go to exclude nested descendants (much faster than loading all folders).
 func (c *Client) ListChildFolders(ctx context.Context, vaultID, parentPath string) ([]models.Folder, error) {
+	defer c.logOp(ctx, "folder.list_children", time.Now())
 	prefix := parentPath
 	if !strings.HasSuffix(prefix, "/") {
 		prefix += "/"
@@ -150,6 +155,7 @@ func (c *Client) ListChildFolders(ctx context.Context, vaultID, parentPath strin
 
 // GetFolderByPath returns a single folder by vault and path, or nil if not found.
 func (c *Client) GetFolderByPath(ctx context.Context, vaultID, folderPath string) (*models.Folder, error) {
+	defer c.logOp(ctx, "folder.get_by_path", time.Now())
 	sql := `SELECT * FROM folder WHERE vault = type::record("vault", $vault_id) AND path = $path LIMIT 1`
 	results, err := surrealdb.Query[[]models.Folder](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
@@ -166,6 +172,7 @@ func (c *Client) GetFolderByPath(ctx context.Context, vaultID, folderPath string
 
 // DeleteFolder deletes a single folder and all its children (paths starting with folderPath + "/").
 func (c *Client) DeleteFolder(ctx context.Context, vaultID, folderPath string) error {
+	defer c.logOp(ctx, "folder.delete", time.Now())
 	if _, err := c.deleteFolderTree(ctx, vaultID, folderPath); err != nil {
 		return fmt.Errorf("delete folder: %w", err)
 	}
@@ -175,6 +182,7 @@ func (c *Client) DeleteFolder(ctx context.Context, vaultID, folderPath string) e
 // DeleteFoldersByPrefix deletes all folders whose path starts with the given prefix
 // or matches the prefix itself (without trailing slash). Returns the number of deleted folders.
 func (c *Client) DeleteFoldersByPrefix(ctx context.Context, vaultID, prefix string) (int, error) {
+	defer c.logOp(ctx, "folder.delete_by_prefix", time.Now())
 	folderPath := strings.TrimSuffix(prefix, "/")
 	return c.deleteFolderTree(ctx, vaultID, folderPath)
 }
@@ -199,6 +207,7 @@ func (c *Client) InvalidateFolderCache(vaultID, folderPath string) {
 // Two statements are needed because SurrealDB v3 doesn't support parenthesized OR in WHERE.
 // Returns the total number of deleted folders.
 func (c *Client) deleteFolderTree(ctx context.Context, vaultID, folderPath string) (int, error) {
+	defer c.logOp(ctx, "folder.delete_tree", time.Now())
 	c.InvalidateFolderCache(vaultID, folderPath)
 	prefix := folderPath + "/"
 	vars := map[string]any{
@@ -236,6 +245,7 @@ func (c *Client) deleteFolderTree(ctx context.Context, vaultID, folderPath strin
 // Accepts folder paths (e.g. "/guides", "/docs") — trailing slashes are handled internally.
 // Returns the number of moved folders.
 func (c *Client) MoveFoldersByPrefix(ctx context.Context, vaultID, oldPath, newPath string) (int, error) {
+	defer c.logOp(ctx, "folder.move_by_prefix", time.Now())
 	oldFolderPath := strings.TrimSuffix(oldPath, "/")
 	newFolderPath := strings.TrimSuffix(newPath, "/")
 

--- a/internal/db/queries_label.go
+++ b/internal/db/queries_label.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/surrealdb/surrealdb.go"
@@ -13,6 +14,7 @@ import (
 // Uses check-then-create/update to work around SurrealDB v3's UPSERT ... WHERE
 // not creating new records when no match exists.
 func (c *Client) EnsureLabel(ctx context.Context, vaultID, name string) (string, error) {
+	defer c.logOp(ctx, "label.ensure", time.Now())
 	name = strings.ToLower(strings.TrimSpace(name))
 	if name == "" {
 		return "", fmt.Errorf("ensure label: name must not be empty")
@@ -67,6 +69,7 @@ func (c *Client) EnsureLabel(ctx context.Context, vaultID, name string) (string,
 // SyncDocumentLabels replaces all has_label edges for a document with edges
 // to the given labels. Labels are upserted as needed.
 func (c *Client) SyncDocumentLabels(ctx context.Context, docID, vaultID string, labels []string) error {
+	defer c.logOp(ctx, "label.sync", time.Now())
 	// Delete existing edges from this document
 	sql := `DELETE FROM has_label WHERE in = type::record("document", $doc_id)`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
@@ -100,6 +103,7 @@ func (c *Client) SyncDocumentLabels(ctx context.Context, docID, vaultID string, 
 // GetDocumentsByLabel returns all documents in a vault that have a specific label,
 // using graph traversal through has_label edges.
 func (c *Client) GetDocumentsByLabel(ctx context.Context, vaultID, labelName string) ([]models.Document, error) {
+	defer c.logOp(ctx, "label.get_documents", time.Now())
 	sql := `
 		SELECT * FROM document WHERE
 			vault = type::record("vault", $vault_id)
@@ -120,6 +124,7 @@ func (c *Client) GetDocumentsByLabel(ctx context.Context, vaultID, labelName str
 
 // GetLabelsForDocument returns all label names for a document using graph traversal.
 func (c *Client) GetLabelsForDocument(ctx context.Context, docID string) ([]string, error) {
+	defer c.logOp(ctx, "label.get_for_document", time.Now())
 	sql := `SELECT VALUE ->has_label->label.name FROM type::record("document", $doc_id)`
 	results, err := surrealdb.Query[[][]string](ctx, c.DB(), sql, map[string]any{
 		"doc_id": bareID("document", docID),

--- a/internal/db/queries_relation.go
+++ b/internal/db/queries_relation.go
@@ -3,12 +3,14 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/surrealdb/surrealdb.go"
 )
 
 func (c *Client) CreateRelation(ctx context.Context, input models.DocRelationInput) (*models.DocRelation, error) {
+	defer c.logOp(ctx, "relation.create", time.Now())
 	sql := `
 		LET $from = type::record("document", $from_id);
 		LET $to = type::record("document", $to_id);
@@ -34,6 +36,7 @@ func (c *Client) CreateRelation(ctx context.Context, input models.DocRelationInp
 }
 
 func (c *Client) GetRelations(ctx context.Context, documentID string) ([]models.DocRelation, error) {
+	defer c.logOp(ctx, "relation.get", time.Now())
 	sql := `SELECT * FROM doc_relation WHERE in = type::record("document", $doc_id) OR out = type::record("document", $doc_id)`
 	results, err := surrealdb.Query[[]models.DocRelation](ctx, c.DB(), sql, map[string]any{
 		"doc_id": documentID,
@@ -48,6 +51,7 @@ func (c *Client) GetRelations(ctx context.Context, documentID string) ([]models.
 }
 
 func (c *Client) GetRelationByID(ctx context.Context, id string) (*models.DocRelation, error) {
+	defer c.logOp(ctx, "relation.get_by_id", time.Now())
 	sql := `SELECT * FROM type::record("doc_relation", $id)`
 	results, err := surrealdb.Query[[]models.DocRelation](ctx, c.DB(), sql, map[string]any{
 		"id": id,
@@ -64,6 +68,7 @@ func (c *Client) GetRelationByID(ctx context.Context, id string) (*models.DocRel
 // DeleteRelationsBySource removes all doc_relations originating from a document with the given source.
 // Used to implement delete-then-recreate for frontmatter-derived relations.
 func (c *Client) DeleteRelationsBySource(ctx context.Context, docID, source string) error {
+	defer c.logOp(ctx, "relation.delete_by_source", time.Now())
 	sql := `DELETE FROM doc_relation WHERE in = type::record("document", $doc_id) AND source = $source`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
 		"doc_id": bareID("document", docID),
@@ -75,6 +80,7 @@ func (c *Client) DeleteRelationsBySource(ctx context.Context, docID, source stri
 }
 
 func (c *Client) DeleteRelation(ctx context.Context, id string) error {
+	defer c.logOp(ctx, "relation.delete", time.Now())
 	sql := `DELETE type::record("doc_relation", $id)`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"id": id}); err != nil {
 		return fmt.Errorf("delete relation: %w", err)

--- a/internal/db/queries_search.go
+++ b/internal/db/queries_search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/surrealdb/surrealdb.go"
@@ -52,6 +53,7 @@ func buildChunkFilterConditions(filter SearchFilter) ([]string, map[string]any) 
 // BM25ChunkSearch performs fulltext search on chunk content via BM25,
 // filtering by the parent document's vault, labels, doc_type and folder.
 func (c *Client) BM25ChunkSearch(ctx context.Context, query string, filter SearchFilter) ([]ChunkWithScore, error) {
+	defer c.logOp(ctx, "search.bm25", time.Now())
 	limit := filter.Limit
 	if limit <= 0 {
 		limit = 20
@@ -82,6 +84,7 @@ func (c *Client) BM25ChunkSearch(ctx context.Context, query string, filter Searc
 // ChunkVectorSearch performs HNSW vector similarity search on chunk embeddings,
 // applying the same filters (labels, docType, folder) as BM25 via the parent document.
 func (c *Client) ChunkVectorSearch(ctx context.Context, embedding []float32, filter SearchFilter) ([]ChunkWithScore, error) {
+	defer c.logOp(ctx, "search.vector", time.Now())
 	limit := filter.Limit
 	if limit <= 0 {
 		limit = 20
@@ -111,11 +114,10 @@ func (c *Client) ChunkVectorSearch(ctx context.Context, embedding []float32, fil
 
 // GetDocumentsByIDs fetches multiple documents by ID in a single query.
 func (c *Client) GetDocumentsByIDs(ctx context.Context, ids []string) ([]models.Document, error) {
+	defer c.logOp(ctx, "search.get_docs_by_ids", time.Now())
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	start := c.startOp()
-	defer c.recordTiming("db.get_documents_by_ids", start)
 
 	sql := `SELECT * FROM document WHERE id INSIDE $ids`
 	recordIDs := make([]surrealmodels.RecordID, len(ids))

--- a/internal/db/queries_search_query.go
+++ b/internal/db/queries_search_query.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/surrealdb/surrealdb.go"
@@ -11,8 +12,7 @@ import (
 // LookupQueryEmbedding looks up a cached embedding for the given normalized query.
 // Returns nil if not found.
 func (c *Client) LookupQueryEmbedding(ctx context.Context, normalizedQuery string) (*models.SearchQuery, error) {
-	start := c.startOp()
-	defer c.recordTiming("db.lookup_query_embedding", start)
+	defer c.logOp(ctx, "search_query.lookup", time.Now())
 
 	sql := `SELECT * FROM search_query WHERE query = $query LIMIT 1`
 	results, err := surrealdb.Query[[]models.SearchQuery](ctx, c.DB(), sql, map[string]any{
@@ -30,8 +30,7 @@ func (c *Client) LookupQueryEmbedding(ctx context.Context, normalizedQuery strin
 // UpsertQueryEmbedding inserts a new search query cache entry or updates hit_count
 // and last_searched_at if the query already exists.
 func (c *Client) UpsertQueryEmbedding(ctx context.Context, normalizedQuery string, embedding []float32) error {
-	start := c.startOp()
-	defer c.recordTiming("db.upsert_query_embedding", start)
+	defer c.logOp(ctx, "search_query.upsert", time.Now())
 
 	sql := `
 		UPSERT search_query

--- a/internal/db/queries_share_link.go
+++ b/internal/db/queries_share_link.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/surrealdb/surrealdb.go"
@@ -11,6 +12,7 @@ import (
 
 // CreateShareLink creates a new share link for a doc/folder path.
 func (c *Client) CreateShareLink(ctx context.Context, vaultID, tokenHash, path string, isFolder bool, createdBy string, expiresAt *string) (*models.ShareLink, error) {
+	defer c.logOp(ctx, "share_link.create", time.Now())
 	var expiry any = surrealmodels.None
 	if expiresAt != nil {
 		expiry = *expiresAt
@@ -45,6 +47,7 @@ func (c *Client) CreateShareLink(ctx context.Context, vaultID, tokenHash, path s
 
 // GetShareLinkByHash looks up a share link by its token hash.
 func (c *Client) GetShareLinkByHash(ctx context.Context, hash string) (*models.ShareLink, error) {
+	defer c.logOp(ctx, "share_link.get_by_hash", time.Now())
 	sql := `SELECT * FROM share_link WHERE token_hash = $hash LIMIT 1`
 	results, err := surrealdb.Query[[]models.ShareLink](ctx, c.DB(), sql, map[string]any{
 		"hash": hash,
@@ -60,6 +63,7 @@ func (c *Client) GetShareLinkByHash(ctx context.Context, hash string) (*models.S
 
 // GetShareLink looks up a share link by ID.
 func (c *Client) GetShareLink(ctx context.Context, id string) (*models.ShareLink, error) {
+	defer c.logOp(ctx, "share_link.get", time.Now())
 	sql := `SELECT * FROM type::record("share_link", $id)`
 	results, err := surrealdb.Query[[]models.ShareLink](ctx, c.DB(), sql, map[string]any{
 		"id": bareID("share_link", id),
@@ -75,6 +79,7 @@ func (c *Client) GetShareLink(ctx context.Context, id string) (*models.ShareLink
 
 // ListShareLinks returns all share links for a vault.
 func (c *Client) ListShareLinks(ctx context.Context, vaultID string) ([]models.ShareLink, error) {
+	defer c.logOp(ctx, "share_link.list", time.Now())
 	sql := `SELECT * FROM share_link WHERE vault = type::record("vault", $vault_id) ORDER BY created_at DESC`
 	results, err := surrealdb.Query[[]models.ShareLink](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
@@ -90,6 +95,7 @@ func (c *Client) ListShareLinks(ctx context.Context, vaultID string) ([]models.S
 
 // DeleteShareLink removes a share link by ID.
 func (c *Client) DeleteShareLink(ctx context.Context, id string) error {
+	defer c.logOp(ctx, "share_link.delete", time.Now())
 	sql := `DELETE type::record("share_link", $id)`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"id": bareID("share_link", id)}); err != nil {
 		return fmt.Errorf("delete share link: %w", err)

--- a/internal/db/queries_template.go
+++ b/internal/db/queries_template.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/surrealdb/surrealdb.go"
@@ -10,6 +11,7 @@ import (
 )
 
 func (c *Client) CreateTemplate(ctx context.Context, input models.TemplateInput) (*models.Template, error) {
+	defer c.logOp(ctx, "template.create", time.Now())
 	var vaultVal any
 	if input.VaultID != nil {
 		vaultVal = newRecordID("vault", *input.VaultID)
@@ -43,6 +45,7 @@ func (c *Client) CreateTemplate(ctx context.Context, input models.TemplateInput)
 }
 
 func (c *Client) GetTemplate(ctx context.Context, id string) (*models.Template, error) {
+	defer c.logOp(ctx, "template.get", time.Now())
 	sql := `SELECT * FROM type::record("template", $id)`
 	results, err := surrealdb.Query[[]models.Template](ctx, c.DB(), sql, map[string]any{
 		"id": id,
@@ -57,6 +60,7 @@ func (c *Client) GetTemplate(ctx context.Context, id string) (*models.Template, 
 }
 
 func (c *Client) ListTemplates(ctx context.Context, vaultID *string) ([]models.Template, error) {
+	defer c.logOp(ctx, "template.list", time.Now())
 	var sql string
 	vars := map[string]any{}
 
@@ -78,6 +82,7 @@ func (c *Client) ListTemplates(ctx context.Context, vaultID *string) ([]models.T
 }
 
 func (c *Client) DeleteTemplate(ctx context.Context, id string) error {
+	defer c.logOp(ctx, "template.delete", time.Now())
 	sql := `DELETE type::record("template", $id)`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"id": id}); err != nil {
 		return fmt.Errorf("delete template: %w", err)

--- a/internal/db/queries_token.go
+++ b/internal/db/queries_token.go
@@ -3,12 +3,14 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/surrealdb/surrealdb.go"
 )
 
 func (c *Client) CreateToken(ctx context.Context, userID, tokenHash, name string) (*models.APIToken, error) {
+	defer c.logOp(ctx, "token.create", time.Now())
 	sql := `
 		CREATE api_token SET
 			user = type::record("user", $user_id),
@@ -31,6 +33,7 @@ func (c *Client) CreateToken(ctx context.Context, userID, tokenHash, name string
 }
 
 func (c *Client) GetTokenByHash(ctx context.Context, hash string) (*models.APIToken, error) {
+	defer c.logOp(ctx, "token.get_by_hash", time.Now())
 	sql := `SELECT * FROM api_token WHERE token_hash = $hash LIMIT 1`
 	results, err := surrealdb.Query[[]models.APIToken](ctx, c.DB(), sql, map[string]any{
 		"hash": hash,
@@ -45,6 +48,7 @@ func (c *Client) GetTokenByHash(ctx context.Context, hash string) (*models.APITo
 }
 
 func (c *Client) UpdateTokenLastUsed(ctx context.Context, tokenID string) error {
+	defer c.logOp(ctx, "token.update_last_used", time.Now())
 	sql := `UPDATE type::record("api_token", $id) SET last_used = time::now()`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"id": tokenID}); err != nil {
 		return fmt.Errorf("update token last used: %w", err)
@@ -53,6 +57,7 @@ func (c *Client) UpdateTokenLastUsed(ctx context.Context, tokenID string) error 
 }
 
 func (c *Client) ListTokens(ctx context.Context, userID string) ([]models.APIToken, error) {
+	defer c.logOp(ctx, "token.list", time.Now())
 	sql := `SELECT * FROM api_token WHERE user = type::record("user", $user_id) ORDER BY created_at DESC`
 	results, err := surrealdb.Query[[]models.APIToken](ctx, c.DB(), sql, map[string]any{
 		"user_id": userID,
@@ -67,6 +72,7 @@ func (c *Client) ListTokens(ctx context.Context, userID string) ([]models.APITok
 }
 
 func (c *Client) DeleteToken(ctx context.Context, id string) error {
+	defer c.logOp(ctx, "token.delete", time.Now())
 	sql := `DELETE type::record("api_token", $id)`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"id": id}); err != nil {
 		return fmt.Errorf("delete token: %w", err)

--- a/internal/db/queries_user.go
+++ b/internal/db/queries_user.go
@@ -3,12 +3,14 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/surrealdb/surrealdb.go"
 )
 
 func (c *Client) CreateUser(ctx context.Context, input models.UserInput) (*models.User, error) {
+	defer c.logOp(ctx, "user.create", time.Now())
 	sql := `
 		CREATE user SET
 			name = $name,
@@ -29,6 +31,7 @@ func (c *Client) CreateUser(ctx context.Context, input models.UserInput) (*model
 }
 
 func (c *Client) CreateUserWithID(ctx context.Context, userID string, input models.UserInput) (*models.User, error) {
+	defer c.logOp(ctx, "user.create_with_id", time.Now())
 	sql := `
 		CREATE type::record("user", $user_id) SET
 			name = $name,
@@ -50,6 +53,7 @@ func (c *Client) CreateUserWithID(ctx context.Context, userID string, input mode
 }
 
 func (c *Client) GetUser(ctx context.Context, id string) (*models.User, error) {
+	defer c.logOp(ctx, "user.get", time.Now())
 	sql := `SELECT * FROM type::record("user", $id)`
 	results, err := surrealdb.Query[[]models.User](ctx, c.DB(), sql, map[string]any{
 		"id": id,
@@ -64,6 +68,7 @@ func (c *Client) GetUser(ctx context.Context, id string) (*models.User, error) {
 }
 
 func (c *Client) GetUserByName(ctx context.Context, name string) (*models.User, error) {
+	defer c.logOp(ctx, "user.get_by_name", time.Now())
 	sql := `SELECT * FROM user WHERE name = $name LIMIT 1`
 	results, err := surrealdb.Query[[]models.User](ctx, c.DB(), sql, map[string]any{
 		"name": name,
@@ -79,6 +84,7 @@ func (c *Client) GetUserByName(ctx context.Context, name string) (*models.User, 
 
 // UpdateUserSystemAdmin sets the is_system_admin flag on a user.
 func (c *Client) UpdateUserSystemAdmin(ctx context.Context, userID string, isAdmin bool) error {
+	defer c.logOp(ctx, "user.update_system_admin", time.Now())
 	sql := `UPDATE type::record("user", $id) SET is_system_admin = $is_admin`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
 		"id":       bareID("user", userID),

--- a/internal/db/queries_vault.go
+++ b/internal/db/queries_vault.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/surrealdb/surrealdb.go"
@@ -10,6 +11,7 @@ import (
 )
 
 func (c *Client) CreateVault(ctx context.Context, userID string, input models.VaultInput) (*models.Vault, error) {
+	defer c.logOp(ctx, "vault.create", time.Now())
 	sql := `
 		CREATE vault SET
 			name = $name,
@@ -32,6 +34,7 @@ func (c *Client) CreateVault(ctx context.Context, userID string, input models.Va
 }
 
 func (c *Client) CreateVaultWithID(ctx context.Context, vaultID string, userID string, input models.VaultInput) (*models.Vault, error) {
+	defer c.logOp(ctx, "vault.create_with_id", time.Now())
 	sql := `
 		CREATE type::record("vault", $vault_id) SET
 			name = $name,
@@ -55,6 +58,7 @@ func (c *Client) CreateVaultWithID(ctx context.Context, vaultID string, userID s
 }
 
 func (c *Client) GetVault(ctx context.Context, id string) (*models.Vault, error) {
+	defer c.logOp(ctx, "vault.get", time.Now())
 	sql := `SELECT * FROM type::record("vault", $id)`
 	results, err := surrealdb.Query[[]models.Vault](ctx, c.DB(), sql, map[string]any{
 		"id": id,
@@ -69,6 +73,7 @@ func (c *Client) GetVault(ctx context.Context, id string) (*models.Vault, error)
 }
 
 func (c *Client) GetVaultByName(ctx context.Context, name string) (*models.Vault, error) {
+	defer c.logOp(ctx, "vault.get_by_name", time.Now())
 	sql := `SELECT * FROM vault WHERE name = $name LIMIT 1`
 	results, err := surrealdb.Query[[]models.Vault](ctx, c.DB(), sql, map[string]any{
 		"name": name,
@@ -83,6 +88,7 @@ func (c *Client) GetVaultByName(ctx context.Context, name string) (*models.Vault
 }
 
 func (c *Client) ListVaults(ctx context.Context) ([]models.Vault, error) {
+	defer c.logOp(ctx, "vault.list", time.Now())
 	sql := `SELECT * FROM vault ORDER BY name ASC`
 	results, err := surrealdb.Query[[]models.Vault](ctx, c.DB(), sql, nil)
 	if err != nil {
@@ -95,6 +101,7 @@ func (c *Client) ListVaults(ctx context.Context) ([]models.Vault, error) {
 }
 
 func (c *Client) DeleteVault(ctx context.Context, id string) error {
+	defer c.logOp(ctx, "vault.delete", time.Now())
 	tx, err := c.db.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("delete vault begin tx: %w", err)
@@ -126,6 +133,7 @@ func (c *Client) DeleteVault(ctx context.Context, id string) error {
 
 // ListDocumentPaths returns all document paths in a vault (for folder derivation).
 func (c *Client) ListDocumentPaths(ctx context.Context, vaultID string) ([]string, error) {
+	defer c.logOp(ctx, "vault.list_document_paths", time.Now())
 	sql := `SELECT path FROM document WHERE vault = type::record("vault", $vault_id)`
 	results, err := surrealdb.Query[[]struct {
 		Path string `json:"path"`

--- a/internal/db/queries_vault_member.go
+++ b/internal/db/queries_vault_member.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/surrealdb/surrealdb.go"
@@ -10,6 +11,7 @@ import (
 
 // CreateVaultMember creates a new vault membership for a user.
 func (c *Client) CreateVaultMember(ctx context.Context, userID, vaultID string, role models.VaultRole) (*models.VaultMember, error) {
+	defer c.logOp(ctx, "vault_member.create", time.Now())
 	sql := `
 		CREATE vault_member SET
 			user = type::record("user", $user_id),
@@ -33,6 +35,7 @@ func (c *Client) CreateVaultMember(ctx context.Context, userID, vaultID string, 
 
 // GetVaultMemberships returns all vault memberships for a user.
 func (c *Client) GetVaultMemberships(ctx context.Context, userID string) ([]models.VaultMember, error) {
+	defer c.logOp(ctx, "vault_member.get_memberships", time.Now())
 	sql := `SELECT * FROM vault_member WHERE user = type::record("user", $user_id)`
 	results, err := surrealdb.Query[[]models.VaultMember](ctx, c.DB(), sql, map[string]any{
 		"user_id": bareID("user", userID),
@@ -48,6 +51,7 @@ func (c *Client) GetVaultMemberships(ctx context.Context, userID string) ([]mode
 
 // GetVaultMembers returns all members of a vault.
 func (c *Client) GetVaultMembers(ctx context.Context, vaultID string) ([]models.VaultMember, error) {
+	defer c.logOp(ctx, "vault_member.get_members", time.Now())
 	sql := `SELECT * FROM vault_member WHERE vault = type::record("vault", $vault_id)`
 	results, err := surrealdb.Query[[]models.VaultMember](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
@@ -63,6 +67,7 @@ func (c *Client) GetVaultMembers(ctx context.Context, vaultID string) ([]models.
 
 // UpdateVaultMemberRole updates the role of a vault member.
 func (c *Client) UpdateVaultMemberRole(ctx context.Context, userID, vaultID string, role models.VaultRole) error {
+	defer c.logOp(ctx, "vault_member.update_role", time.Now())
 	sql := `UPDATE vault_member SET role = $role WHERE user = type::record("user", $user_id) AND vault = type::record("vault", $vault_id)`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
 		"user_id":  bareID("user", userID),
@@ -76,6 +81,7 @@ func (c *Client) UpdateVaultMemberRole(ctx context.Context, userID, vaultID stri
 
 // DeleteVaultMember removes a user's membership from a vault.
 func (c *Client) DeleteVaultMember(ctx context.Context, userID, vaultID string) error {
+	defer c.logOp(ctx, "vault_member.delete", time.Now())
 	sql := `DELETE FROM vault_member WHERE user = type::record("user", $user_id) AND vault = type::record("vault", $vault_id)`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
 		"user_id":  bareID("user", userID),

--- a/internal/db/queries_version.go
+++ b/internal/db/queries_version.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/surrealdb/surrealdb.go"
@@ -10,8 +11,7 @@ import (
 
 // CreateVersion stores a new version snapshot of a document's content.
 func (c *Client) CreateVersion(ctx context.Context, input models.DocumentVersionInput, version int) (*models.DocumentVersion, error) {
-	start := c.startOp()
-	defer c.recordTiming("db.create_version", start)
+	defer c.logOp(ctx, "version.create", time.Now())
 
 	sql := `
 		CREATE document_version SET
@@ -44,8 +44,7 @@ func (c *Client) CreateVersion(ctx context.Context, input models.DocumentVersion
 
 // GetVersion retrieves a single version by its ID.
 func (c *Client) GetVersion(ctx context.Context, id string) (*models.DocumentVersion, error) {
-	start := c.startOp()
-	defer c.recordTiming("db.get_version", start)
+	defer c.logOp(ctx, "version.get", time.Now())
 
 	sql := `SELECT * FROM type::record("document_version", $id)`
 	results, err := surrealdb.Query[[]models.DocumentVersion](ctx, c.DB(), sql, map[string]any{
@@ -62,8 +61,7 @@ func (c *Client) GetVersion(ctx context.Context, id string) (*models.DocumentVer
 
 // GetVersionByNumber retrieves a specific version by document ID and version number.
 func (c *Client) GetVersionByNumber(ctx context.Context, documentID string, version int) (*models.DocumentVersion, error) {
-	start := c.startOp()
-	defer c.recordTiming("db.get_version_by_number", start)
+	defer c.logOp(ctx, "version.get_by_number", time.Now())
 
 	sql := `SELECT * FROM document_version WHERE document = type::record("document", $document_id) AND version = $version LIMIT 1`
 	results, err := surrealdb.Query[[]models.DocumentVersion](ctx, c.DB(), sql, map[string]any{
@@ -81,8 +79,7 @@ func (c *Client) GetVersionByNumber(ctx context.Context, documentID string, vers
 
 // ListVersions returns versions for a document, paginated, newest first.
 func (c *Client) ListVersions(ctx context.Context, documentID string, limit, offset int) ([]models.DocumentVersion, error) {
-	start := c.startOp()
-	defer c.recordTiming("db.list_versions", start)
+	defer c.logOp(ctx, "version.list", time.Now())
 
 	if limit <= 0 {
 		limit = 20
@@ -106,8 +103,7 @@ func (c *Client) ListVersions(ctx context.Context, documentID string, limit, off
 
 // GetLatestVersion returns the most recent version for a document.
 func (c *Client) GetLatestVersion(ctx context.Context, documentID string) (*models.DocumentVersion, error) {
-	start := c.startOp()
-	defer c.recordTiming("db.get_latest_version", start)
+	defer c.logOp(ctx, "version.get_latest", time.Now())
 
 	sql := `SELECT * FROM document_version WHERE document = type::record("document", $document_id) ORDER BY version DESC LIMIT 1`
 	results, err := surrealdb.Query[[]models.DocumentVersion](ctx, c.DB(), sql, map[string]any{
@@ -124,8 +120,7 @@ func (c *Client) GetLatestVersion(ctx context.Context, documentID string) (*mode
 
 // CountVersions returns the total number of versions for a document.
 func (c *Client) CountVersions(ctx context.Context, documentID string) (int, error) {
-	start := c.startOp()
-	defer c.recordTiming("db.count_versions", start)
+	defer c.logOp(ctx, "version.count", time.Now())
 
 	sql := `SELECT count() AS total FROM document_version WHERE document = type::record("document", $document_id) GROUP ALL`
 	type countResult struct {
@@ -146,8 +141,7 @@ func (c *Client) CountVersions(ctx context.Context, documentID string) (int, err
 // DeleteOldestVersions deletes versions beyond the retention cap, keeping the newest keepCount.
 // Returns the number of deleted versions.
 func (c *Client) DeleteOldestVersions(ctx context.Context, documentID string, keepCount int) (int, error) {
-	start := c.startOp()
-	defer c.recordTiming("db.delete_oldest_versions", start)
+	defer c.logOp(ctx, "version.delete_oldest", time.Now())
 
 	sql := `
 		DELETE FROM document_version
@@ -175,8 +169,7 @@ func (c *Client) DeleteOldestVersions(ctx context.Context, documentID string, ke
 // NextVersionNumber returns the next version number for a document.
 // Uses max(version) instead of count() to avoid collisions after retention pruning.
 func (c *Client) NextVersionNumber(ctx context.Context, documentID string) (int, error) {
-	start := c.startOp()
-	defer c.recordTiming("db.next_version_number", start)
+	defer c.logOp(ctx, "version.next_number", time.Now())
 
 	sql := `SELECT version FROM document_version WHERE document = type::record("document", $document_id) ORDER BY version DESC LIMIT 1`
 	type versionResult struct {

--- a/internal/db/queries_wikilink.go
+++ b/internal/db/queries_wikilink.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/surrealdb/surrealdb.go"
@@ -11,6 +12,7 @@ import (
 
 // CreateWikiLinks creates wiki-link records for a document in a single batch INSERT.
 func (c *Client) CreateWikiLinks(ctx context.Context, fromDocID, vaultID string, links []WikiLinkInput) error {
+	defer c.logOp(ctx, "wikilink.create", time.Now())
 	if len(links) == 0 {
 		return nil
 	}
@@ -51,6 +53,7 @@ type WikiLinkInput struct {
 
 // GetWikiLinks returns outgoing wiki-links from a document.
 func (c *Client) GetWikiLinks(ctx context.Context, fromDocID string) ([]models.WikiLink, error) {
+	defer c.logOp(ctx, "wikilink.get", time.Now())
 	sql := `SELECT * FROM wiki_link WHERE from_doc = type::record("document", $doc_id)`
 	results, err := surrealdb.Query[[]models.WikiLink](ctx, c.DB(), sql, map[string]any{
 		"doc_id": fromDocID,
@@ -66,6 +69,7 @@ func (c *Client) GetWikiLinks(ctx context.Context, fromDocID string) ([]models.W
 
 // GetBacklinks returns wiki-links pointing to a document.
 func (c *Client) GetBacklinks(ctx context.Context, toDocID string) ([]models.WikiLink, error) {
+	defer c.logOp(ctx, "wikilink.get_backlinks", time.Now())
 	sql := `SELECT * FROM wiki_link WHERE to_doc = type::record("document", $doc_id)`
 	results, err := surrealdb.Query[[]models.WikiLink](ctx, c.DB(), sql, map[string]any{
 		"doc_id": toDocID,
@@ -81,6 +85,7 @@ func (c *Client) GetBacklinks(ctx context.Context, toDocID string) ([]models.Wik
 
 // DeleteWikiLinks removes all wiki-links originating from a document.
 func (c *Client) DeleteWikiLinks(ctx context.Context, fromDocID string) error {
+	defer c.logOp(ctx, "wikilink.delete", time.Now())
 	sql := `DELETE FROM wiki_link WHERE from_doc = type::record("document", $doc_id)`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
 		"doc_id": fromDocID,
@@ -93,6 +98,7 @@ func (c *Client) DeleteWikiLinks(ctx context.Context, fromDocID string) error {
 // UnresolveWikiLinksToDoc sets to_doc = NONE on all wiki_links pointing to the given document,
 // making them dangling. Used during document deletion to preserve backlink references.
 func (c *Client) UnresolveWikiLinksToDoc(ctx context.Context, docID string) (int, error) {
+	defer c.logOp(ctx, "wikilink.unresolve", time.Now())
 	sql := `UPDATE wiki_link SET to_doc = NONE WHERE to_doc = type::record("document", $doc_id)`
 	results, err := surrealdb.Query[[]models.WikiLink](ctx, c.DB(), sql, map[string]any{
 		"doc_id": bareID("document", docID),
@@ -109,6 +115,7 @@ func (c *Client) UnresolveWikiLinksToDoc(ctx context.Context, docID string) (int
 // UpdateWikiLinkRawTargets updates raw_target for all wiki_links in a vault matching oldTarget.
 // Used when a document is moved to keep raw_targets consistent with the new path/title.
 func (c *Client) UpdateWikiLinkRawTargets(ctx context.Context, vaultID, oldTarget, newTarget string) (int, error) {
+	defer c.logOp(ctx, "wikilink.update_raw_targets", time.Now())
 	sql := `UPDATE wiki_link SET raw_target = $new_target WHERE vault = type::record("vault", $vault_id) AND raw_target = $old_target`
 	results, err := surrealdb.Query[[]models.WikiLink](ctx, c.DB(), sql, map[string]any{
 		"vault_id":   bareID("vault", vaultID),
@@ -128,6 +135,7 @@ func (c *Client) UpdateWikiLinkRawTargets(ctx context.Context, vaultID, oldTarge
 // where raw_target starts with oldPrefix, replacing the prefix with newPrefix.
 // Used when documents are moved by prefix (folder rename).
 func (c *Client) UpdateWikiLinkRawTargetsByPrefix(ctx context.Context, vaultID, oldPrefix, newPrefix string) (int, error) {
+	defer c.logOp(ctx, "wikilink.update_raw_targets_by_prefix", time.Now())
 	sql := `UPDATE wiki_link SET raw_target = string::concat($new_prefix, string::slice(raw_target, string::len($old_prefix))) WHERE vault = type::record("vault", $vault_id) AND string::starts_with(raw_target, $old_prefix)`
 	results, err := surrealdb.Query[[]models.WikiLink](ctx, c.DB(), sql, map[string]any{
 		"vault_id":   bareID("vault", vaultID),
@@ -146,6 +154,7 @@ func (c *Client) UpdateWikiLinkRawTargetsByPrefix(ctx context.Context, vaultID, 
 // ResolveDanglingLinks finds dangling wiki-links in a vault matching a target
 // and resolves them to point to the given document.
 func (c *Client) ResolveDanglingLinks(ctx context.Context, vaultID, rawTarget, toDocID string) (int, error) {
+	defer c.logOp(ctx, "wikilink.resolve_dangling", time.Now())
 	sql := `
 		UPDATE wiki_link SET to_doc = type::record("document", $to_doc_id)
 		WHERE vault = type::record("vault", $vault_id)

--- a/internal/llm/embedder.go
+++ b/internal/llm/embedder.go
@@ -20,6 +20,7 @@ import (
 	ollamaembed "github.com/cloudwego/eino-ext/components/embedding/ollama"
 	openaiembed "github.com/cloudwego/eino-ext/components/embedding/openai"
 	"github.com/raphi011/knowhow/internal/config"
+	"github.com/raphi011/knowhow/internal/logutil"
 	"github.com/raphi011/knowhow/internal/metrics"
 	bedrockembed "github.com/tmc/langchaingo/embeddings/bedrock"
 	"google.golang.org/genai"
@@ -132,15 +133,16 @@ func float64sToFloat32s(in []float64) []float32 {
 
 // Embed generates an embedding vector for text.
 func (e *Embedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	logger := logutil.FromCtx(ctx).With("model", e.modelName)
 	textLen := len(text)
-	slog.Debug("embedding text", "model", e.modelName, "text_len", textLen)
+	logger.Debug("embedding text", "text_len", textLen)
 
 	start := time.Now()
 	vectors, err := e.model.EmbedStrings(ctx, []string{text})
 	duration := time.Since(start)
 
 	if err != nil {
-		slog.Warn("embedding failed", "model", e.modelName, "text_len", textLen, "duration_ms", duration.Milliseconds(), "error", err)
+		logger.Warn("embedding failed", "text_len", textLen, "duration_ms", duration.Milliseconds(), "error", err)
 		return nil, fmt.Errorf("embed: %w", err)
 	}
 
@@ -153,7 +155,7 @@ func (e *Embedder) Embed(ctx context.Context, text string) ([]float32, error) {
 		return nil, fmt.Errorf("dimension mismatch: got %d, want %d", len(vec), e.dimension)
 	}
 
-	slog.Debug("embedding complete", "model", e.modelName, "text_len", textLen, "duration_ms", duration.Milliseconds())
+	logger.Debug("embedding complete", "text_len", textLen, "duration_ms", duration.Milliseconds())
 
 	if e.metrics != nil {
 		e.metrics.RecordTiming(metrics.OpEmbedding, duration)
@@ -168,13 +170,19 @@ func (e *Embedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32,
 		return [][]float32{}, nil
 	}
 
+	logger := logutil.FromCtx(ctx).With("model", e.modelName)
+	logger.Debug("embedding batch starting", "batch_size", len(texts))
+
 	start := time.Now()
 	vectors, err := e.model.EmbedStrings(ctx, texts)
 	duration := time.Since(start)
 
 	if err != nil {
+		logger.Warn("embedding batch failed", "batch_size", len(texts), "duration_ms", duration.Milliseconds(), "error", err)
 		return nil, fmt.Errorf("embed batch: %w", err)
 	}
+
+	logger.Debug("embedding batch complete", "batch_size", len(texts), "duration_ms", duration.Milliseconds())
 
 	if len(vectors) != len(texts) {
 		return nil, fmt.Errorf("count mismatch: got %d, want %d", len(vectors), len(texts))
@@ -292,12 +300,13 @@ func float32sToFloat64s(in []float32) []float64 {
 
 // EmbedStrings implements einoEmbedder.
 func (b *bedrockEmbedder) EmbedStrings(ctx context.Context, texts []string, _ ...embedding.Option) ([][]float64, error) {
+	logger := logutil.FromCtx(ctx)
 	start := time.Now()
 	totalChars := 0
 	for _, t := range texts {
 		totalChars += len(t)
 	}
-	slog.Debug("bedrock embedding starting", "provider", b.provider, "texts", len(texts), "total_chars", totalChars)
+	logger.Debug("bedrock embedding starting", "provider", b.provider, "texts", len(texts), "total_chars", totalChars)
 
 	var vecs [][]float32
 	var err error
@@ -313,10 +322,10 @@ func (b *bedrockEmbedder) EmbedStrings(ctx context.Context, texts []string, _ ..
 
 	duration := time.Since(start)
 	if err != nil {
-		slog.Warn("bedrock embedding failed", "provider", b.provider, "duration_ms", duration.Milliseconds(), "error", err)
+		logger.Warn("bedrock embedding failed", "provider", b.provider, "duration_ms", duration.Milliseconds(), "error", err)
 		return nil, fmt.Errorf("bedrock %s embedding: %w", b.provider, err)
 	}
-	slog.Debug("bedrock embedding complete", "provider", b.provider, "texts", len(texts), "duration_ms", duration.Milliseconds())
+	logger.Debug("bedrock embedding complete", "provider", b.provider, "texts", len(texts), "duration_ms", duration.Milliseconds())
 
 	// Convert float32→float64 for einoEmbedder interface. The Embedder wrapper
 	// converts back to float32 for storage. This round-trip is lossless but

--- a/internal/llm/model.go
+++ b/internal/llm/model.go
@@ -21,6 +21,7 @@ import (
 	einoollama "github.com/cloudwego/eino-ext/components/model/ollama"
 	einoopenai "github.com/cloudwego/eino-ext/components/model/openai"
 	"github.com/raphi011/knowhow/internal/config"
+	"github.com/raphi011/knowhow/internal/logutil"
 	"github.com/raphi011/knowhow/internal/metrics"
 	"google.golang.org/genai"
 )
@@ -292,7 +293,8 @@ func (m *Model) GenerateWithSystem(ctx context.Context, systemPrompt, userPrompt
 	userLen := len(userPrompt)
 	totalLen := systemLen + userLen
 
-	slog.Debug("LLM generate starting", "model", m.modelName, "system_len", systemLen, "user_len", userLen, "total_len", totalLen)
+	logger := logutil.FromCtx(ctx).With("model", m.modelName)
+	logger.Debug("LLM generate starting", "system_len", systemLen, "user_len", userLen, "total_len", totalLen)
 
 	messages := []*schema.Message{
 		{Role: schema.System, Content: systemPrompt},
@@ -304,17 +306,17 @@ func (m *Model) GenerateWithSystem(ctx context.Context, systemPrompt, userPrompt
 	duration := time.Since(start)
 
 	if err != nil {
-		slog.Warn("LLM generate failed", "model", m.modelName, "total_len", totalLen, "duration_ms", duration.Milliseconds(), "error", err)
+		logger.Warn("LLM generate failed", "total_len", totalLen, "duration_ms", duration.Milliseconds(), "error", err)
 		return "", wrapFatalError(fmt.Errorf("generate with system: %w", err))
 	}
 
 	if resp.Content == "" {
-		slog.Warn("LLM returned empty response", "model", m.modelName, "total_len", totalLen, "duration_ms", duration.Milliseconds())
+		logger.Warn("LLM returned empty response", "total_len", totalLen, "duration_ms", duration.Milliseconds())
 		return "", fmt.Errorf("empty response from model")
 	}
 
 	responseLen := len(resp.Content)
-	slog.Debug("LLM generate complete", "model", m.modelName, "total_len", totalLen, "response_len", responseLen, "duration_ms", duration.Milliseconds())
+	logger.Debug("LLM generate complete", "total_len", totalLen, "response_len", responseLen, "duration_ms", duration.Milliseconds())
 
 	if m.metrics != nil {
 		inputTokens, outputTokens := extractTokenCounts(resp.ResponseMeta, totalLen, responseLen)
@@ -375,7 +377,8 @@ func (m *Model) GenerateWithSystemStream(
 	userLen := len(userPrompt)
 	totalLen := systemLen + userLen
 
-	slog.Debug("LLM streaming generate starting", "model", m.modelName, "system_len", systemLen, "user_len", userLen, "total_len", totalLen)
+	logger := logutil.FromCtx(ctx).With("model", m.modelName)
+	logger.Debug("LLM streaming generate starting", "system_len", systemLen, "user_len", userLen, "total_len", totalLen)
 
 	messages := []*schema.Message{
 		{Role: schema.System, Content: systemPrompt},
@@ -386,7 +389,7 @@ func (m *Model) GenerateWithSystemStream(
 
 	sr, err := m.chatModel.Stream(ctx, messages, model.WithMaxTokens(8192))
 	if err != nil {
-		slog.Warn("LLM streaming generate failed to start", "model", m.modelName, "total_len", totalLen, "error", err)
+		logger.Warn("LLM streaming generate failed to start", "total_len", totalLen, "error", err)
 		return wrapFatalError(fmt.Errorf("generate with system stream: %w", err))
 	}
 	defer sr.Close()
@@ -401,7 +404,7 @@ func (m *Model) GenerateWithSystemStream(
 		}
 		if recvErr != nil {
 			duration := time.Since(start)
-			slog.Warn("LLM streaming generate failed", "model", m.modelName, "total_len", totalLen, "duration_ms", duration.Milliseconds(), "error", recvErr)
+			logger.Warn("LLM streaming generate failed", "total_len", totalLen, "duration_ms", duration.Milliseconds(), "error", recvErr)
 			return wrapFatalError(fmt.Errorf("generate with system stream: %w", recvErr))
 		}
 		if msg.Content != "" {
@@ -416,7 +419,7 @@ func (m *Model) GenerateWithSystemStream(
 	}
 
 	duration := time.Since(start)
-	slog.Debug("LLM streaming generate complete", "model", m.modelName, "total_len", totalLen, "output_len", outputLen, "duration_ms", duration.Milliseconds())
+	logger.Debug("LLM streaming generate complete", "total_len", totalLen, "output_len", outputLen, "duration_ms", duration.Milliseconds())
 
 	if m.metrics != nil {
 		inputTokens, outputTokens := extractTokenCounts(lastMeta, totalLen, outputLen)
@@ -461,6 +464,8 @@ func (m *Model) GenerateWithSystemStreamMultiTurn(
 	messages := make([]*schema.Message, 0, 2+len(history))
 	messages = append(messages, &schema.Message{Role: schema.System, Content: systemPrompt})
 
+	logger := logutil.FromCtx(ctx).With("model", m.modelName)
+
 	for i, msg := range history {
 		switch msg.Role {
 		case "user":
@@ -468,7 +473,7 @@ func (m *Model) GenerateWithSystemStreamMultiTurn(
 		case "assistant":
 			messages = append(messages, &schema.Message{Role: schema.Assistant, Content: msg.Content})
 		default:
-			slog.Warn("unknown chat message role, skipping", "role", msg.Role, "index", i)
+			logger.Warn("unknown chat message role, skipping", "role", msg.Role, "index", i)
 		}
 	}
 
@@ -480,13 +485,13 @@ func (m *Model) GenerateWithSystemStreamMultiTurn(
 		totalLen += len(msg.Content)
 	}
 
-	slog.Debug("LLM multi-turn streaming starting", "model", m.modelName, "history_len", len(history), "total_len", totalLen)
+	logger.Debug("LLM multi-turn streaming starting", "history_len", len(history), "total_len", totalLen)
 
 	start := time.Now()
 
 	sr, err := m.chatModel.Stream(ctx, messages, model.WithMaxTokens(8192))
 	if err != nil {
-		slog.Warn("LLM multi-turn streaming failed to start", "model", m.modelName, "total_len", totalLen, "error", err)
+		logger.Warn("LLM multi-turn streaming failed to start", "total_len", totalLen, "error", err)
 		return wrapFatalError(fmt.Errorf("generate multi-turn stream: %w", err))
 	}
 	defer sr.Close()
@@ -501,7 +506,7 @@ func (m *Model) GenerateWithSystemStreamMultiTurn(
 		}
 		if recvErr != nil {
 			duration := time.Since(start)
-			slog.Warn("LLM multi-turn streaming failed", "model", m.modelName, "total_len", totalLen, "duration_ms", duration.Milliseconds(), "error", recvErr)
+			logger.Warn("LLM multi-turn streaming failed", "total_len", totalLen, "duration_ms", duration.Milliseconds(), "error", recvErr)
 			return wrapFatalError(fmt.Errorf("generate multi-turn stream: %w", recvErr))
 		}
 		if msg.Content != "" {
@@ -516,7 +521,7 @@ func (m *Model) GenerateWithSystemStreamMultiTurn(
 	}
 
 	duration := time.Since(start)
-	slog.Debug("LLM multi-turn streaming complete", "model", m.modelName, "total_len", totalLen, "output_len", outputLen, "duration_ms", duration.Milliseconds())
+	logger.Debug("LLM multi-turn streaming complete", "total_len", totalLen, "output_len", outputLen, "duration_ms", duration.Milliseconds())
 
 	if m.metrics != nil {
 		inputTokens, outputTokens := extractTokenCounts(lastMeta, totalLen, outputLen)
@@ -621,8 +626,9 @@ func (m *Model) GenerateStreamWithTools(
 		}
 
 		// Append assistant turn with the tool calls.
+		logger := logutil.FromCtx(ctx)
 		for _, tc := range merged.ToolCalls {
-			slog.Info("tool call ID before sending back", "iteration", i, "id", tc.ID, "name", tc.Function.Name, "index", tc.Index)
+			logger.Debug("tool call", "iteration", i, "id", tc.ID, "name", tc.Function.Name, "index", tc.Index)
 		}
 		msgs = append(msgs, schema.AssistantMessage(merged.Content, merged.ToolCalls))
 

--- a/internal/logutil/logutil.go
+++ b/internal/logutil/logutil.go
@@ -1,0 +1,22 @@
+// Package logutil provides context-carried slog loggers for structured request-scoped logging.
+package logutil
+
+import (
+	"context"
+	"log/slog"
+)
+
+type ctxKey struct{}
+
+// WithLogger stores an *slog.Logger in the context.
+func WithLogger(ctx context.Context, l *slog.Logger) context.Context {
+	return context.WithValue(ctx, ctxKey{}, l)
+}
+
+// FromCtx extracts the logger from ctx, falling back to slog.Default().
+func FromCtx(ctx context.Context) *slog.Logger {
+	if l, ok := ctx.Value(ctxKey{}).(*slog.Logger); ok && l != nil {
+		return l
+	}
+	return slog.Default()
+}

--- a/internal/logutil/logutil_test.go
+++ b/internal/logutil/logutil_test.go
@@ -1,0 +1,53 @@
+package logutil
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+)
+
+func TestFromCtx_fallsBackToDefault(t *testing.T) {
+	ctx := context.Background()
+	got := FromCtx(ctx)
+	if got != slog.Default() {
+		t.Error("expected slog.Default() when no logger in context")
+	}
+}
+
+func TestWithLogger_roundTrips(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	ctx := WithLogger(context.Background(), logger)
+	got := FromCtx(ctx)
+
+	if got != logger {
+		t.Error("expected stored logger to be returned")
+	}
+}
+
+func TestFromCtx_nilLoggerFallsBackToDefault(t *testing.T) {
+	ctx := WithLogger(context.Background(), nil)
+	got := FromCtx(ctx)
+	if got != slog.Default() {
+		t.Error("expected slog.Default() when nil logger stored in context")
+	}
+}
+
+func TestFromCtx_propagatesAttributes(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	enriched := logger.With("request_id", "abc-123")
+
+	ctx := WithLogger(context.Background(), enriched)
+	FromCtx(ctx).Debug("test message", "extra", "val")
+
+	output := buf.String()
+	if !bytes.Contains([]byte(output), []byte("request_id=abc-123")) {
+		t.Errorf("expected request_id in output, got: %s", output)
+	}
+	if !bytes.Contains([]byte(output), []byte("extra=val")) {
+		t.Errorf("expected extra in output, got: %s", output)
+	}
+}

--- a/internal/webdav/handler.go
+++ b/internal/webdav/handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/raphi011/knowhow/internal/auth"
 	"github.com/raphi011/knowhow/internal/db"
 	"github.com/raphi011/knowhow/internal/document"
+	"github.com/raphi011/knowhow/internal/logutil"
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/raphi011/knowhow/internal/vault"
 )
@@ -145,7 +146,7 @@ func NewHandler(
 
 		ac, err := auth.Authenticate(r.Context(), dbClient, rawToken, noAuth)
 		if err != nil {
-			slog.Warn("webdav: auth failed", "error", err)
+			logutil.FromCtx(r.Context()).Warn("webdav: auth failed", "error", err)
 			http.Error(w, "invalid credentials", http.StatusUnauthorized)
 			return
 		}
@@ -153,7 +154,7 @@ func NewHandler(
 		// Resolve vault + check access
 		vaultID, err := auth.ResolveVault(r.Context(), ac, vaultSvc, vaultName)
 		if err != nil {
-			slog.Warn("webdav: vault resolution failed", "vault", vaultName, "error", err)
+			logutil.FromCtx(r.Context()).Warn("webdav: vault resolution failed", "vault", vaultName, "error", err)
 			http.Error(w, "vault not found or access denied", http.StatusForbidden)
 			return
 		}
@@ -187,6 +188,7 @@ func NewHandler(
 
 		// Create per-request WebDAV handler with the resolved vault
 		davFS := NewFS(vaultID, dbClient, docService, assetSvc, vaultSvc, pendingSets.Get(vaultID))
+		reqLogger := logutil.FromCtx(r.Context())
 		davHandler := &webdav.Handler{
 			FileSystem: davFS,
 			LockSystem: lockSystems.Get(vaultID),
@@ -196,12 +198,12 @@ func NewHandler(
 					return
 				}
 				if errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrPermission) {
-					slog.Debug("webdav request",
+					reqLogger.Debug("webdav request",
 						"method", r.Method,
 						"path", r.URL.Path,
 						"error", err)
 				} else {
-					slog.Warn("webdav request failed",
+					reqLogger.Warn("webdav request failed",
 						"method", r.Method,
 						"path", r.URL.Path,
 						"error", err)
@@ -209,7 +211,12 @@ func NewHandler(
 			},
 		}
 
-		davHandler.ServeHTTP(&singleWriteResponseWriter{ResponseWriter: w}, r)
+		davStart := time.Now()
+		wrec := &singleWriteResponseWriter{ResponseWriter: w}
+		davHandler.ServeHTTP(wrec, r)
+		reqLogger.Debug("webdav request",
+			"method", r.Method, "vault", vaultName, "path", filePath,
+			"status", wrec.statusCode, "duration_ms", time.Since(davStart).Milliseconds())
 	})
 }
 


### PR DESCRIPTION
Add structured debug logging across all subsystems using context-carried slog loggers. Request-scoped attributes (request_id, user_id, conversation_id, vault_id) propagate automatically to all downstream logs. SIGHUP-based LOG_LEVEL reload enables runtime level switching without restart.

Closes #79

## New Features
- `internal/logutil` package: `WithLogger(ctx, logger)` / `FromCtx(ctx)` for context-carried loggers
- `RequestLogMiddleware`: generates request_id (UUID), logs method/path/status/duration at Debug level
- Dynamic log level: `*slog.LevelVar` shared across text+JSON handlers, reloadable via SIGHUP
- Auth middleware enriches context logger with `user_id`
- Agent chat handler enriches context logger with `conversation_id` and `vault_id`
- LLM/embedder: all `slog.*` calls replaced with `logutil.FromCtx(ctx).*` for attribute propagation
- DB: `logOp` helper adds `defer c.logOp(ctx, "table.verb", time.Now())` to ~118 query methods
- WebDAV: request timing with vault name, path, status, and duration
- `cmd_serve.go` now uses `config.SetupLogger` for dual-output (stderr text + JSON file) instead of stderr-only

## Breaking Changes
- None