### PR TITLE
fix: SSE streaming through statusRecorder middleware

### DIFF
--- a/cmd/knowhow/cmd_serve.go
+++ b/cmd/knowhow/cmd_serve.go
@@ -236,8 +236,10 @@ func runServe(_ *cobra.Command, _ []string) error {
 		Addr:              ":" + port,
 		Handler:           api.RequestLogMiddleware(mux),
 		ReadHeaderTimeout: 5 * time.Second,
-		WriteTimeout:      120 * time.Second,
 		IdleTimeout:       120 * time.Second,
+		// WriteTimeout intentionally omitted: SSE endpoints are long-lived.
+		// Each handler manages its own lifecycle via context cancellation and
+		// write error checks.
 	}
 
 	quit := make(chan os.Signal, 1)
@@ -255,7 +257,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 
 	slog.Info("shutting down server...")
 
-	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	if sshSrv != nil {

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 
 	"github.com/raphi011/knowhow/internal/auth"
@@ -69,10 +68,12 @@ func (s *Service) HandleChat() http.HandlerFunc {
 		emit := func(event StreamEvent) {
 			data, err := json.Marshal(event)
 			if err != nil {
-				slog.Warn("failed to marshal SSE event", "error", err)
+				logutil.FromCtx(r.Context()).Warn("failed to marshal SSE event", "error", err)
 				return
 			}
-			fmt.Fprintf(w, "data: %s\n\n", data)
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+				return // client disconnected
+			}
 			flusher.Flush()
 		}
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -41,8 +41,18 @@ func (r *statusRecorder) WriteHeader(code int) {
 	r.ResponseWriter.WriteHeader(code)
 }
 
-// Unwrap returns the underlying ResponseWriter so http.Flusher and other
-// interfaces can be discovered via ResponseController.
+// Flush implements http.Flusher by delegating to the underlying writer.
+// This is required for SSE streaming — direct type assertions like
+// w.(http.Flusher) don't use Unwrap(), so the wrapper must implement
+// the interface explicitly.
+func (r *statusRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Unwrap returns the underlying ResponseWriter so other optional
+// interfaces (e.g. http.Hijacker) can be discovered via ResponseController.
 func (r *statusRecorder) Unwrap() http.ResponseWriter {
 	return r.ResponseWriter
 }

--- a/internal/db/queries_document.go
+++ b/internal/db/queries_document.go
@@ -416,7 +416,7 @@ func (c *Client) ListLabels(ctx context.Context, vaultID string) ([]string, erro
 // ListLabelsWithCounts returns labels with their document counts for the given vault.
 func (c *Client) ListLabelsWithCounts(ctx context.Context, vaultID string) ([]models.LabelCount, error) {
 	defer c.logOp(ctx, "document.list_labels_with_counts", time.Now())
-	sql := `SELECT label, count() AS count FROM (SELECT labels AS label FROM document WHERE vault = type::record("vault", $vault_id) SPLIT labels) GROUP BY label ORDER BY count DESC`
+	sql := `SELECT label, count() AS count FROM (SELECT labels AS label FROM document WHERE vault = type::record("vault", $vault_id) AND array::len(labels) > 0 SPLIT labels) GROUP BY label ORDER BY count DESC`
 	results, err := surrealdb.Query[[]models.LabelCount](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
 	})

--- a/internal/db/queries_document_test.go
+++ b/internal/db/queries_document_test.go
@@ -483,6 +483,8 @@ func TestListLabelsWithCounts(t *testing.T) {
 		{"/lc-" + suffix + "/a.md", []string{"go", "project"}},
 		{"/lc-" + suffix + "/b.md", []string{"go", "tutorial"}},
 		{"/lc-" + suffix + "/c.md", []string{"rust"}},
+		{"/lc-" + suffix + "/d.md", nil},   // no labels — must not produce phantom entries
+		{"/lc-" + suffix + "/e.md", []string{}}, // empty labels — must not produce phantom entries
 	} {
 		_, err := testDB.CreateDocument(ctx, models.DocumentInput{
 			VaultID:     vaultID,
@@ -504,8 +506,9 @@ func TestListLabelsWithCounts(t *testing.T) {
 	}
 
 	// Should be sorted by count desc: go(2), then project/tutorial/rust(1 each)
+	// Documents with nil or empty labels must NOT produce phantom entries
 	if len(counts) != 4 {
-		t.Fatalf("expected 4 label counts, got %d", len(counts))
+		t.Fatalf("expected 4 label counts, got %d: %v", len(counts), counts)
 	}
 	if counts[0].Label != "go" || counts[0].Count != 2 {
 		t.Errorf("expected first label to be go(2), got %s(%d)", counts[0].Label, counts[0].Count)

--- a/internal/event/handler.go
+++ b/internal/event/handler.go
@@ -3,11 +3,11 @@ package event
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"time"
 
 	"github.com/raphi011/knowhow/internal/auth"
+	"github.com/raphi011/knowhow/internal/logutil"
 	"github.com/raphi011/knowhow/internal/models"
 )
 
@@ -51,6 +51,8 @@ func HandleEvents(bus *Bus) http.HandlerFunc {
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
 
+		logger := logutil.FromCtx(r.Context())
+
 		for {
 			select {
 			case evt, ok := <-ch:
@@ -59,13 +61,17 @@ func HandleEvents(bus *Bus) http.HandlerFunc {
 				}
 				data, err := json.Marshal(evt)
 				if err != nil {
-					slog.Warn("failed to marshal change event", "error", err)
+					logger.Warn("failed to marshal change event", "error", err)
 					continue
 				}
-				fmt.Fprintf(w, "data: %s\n\n", data)
+				if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+					return // client disconnected
+				}
 				flusher.Flush()
 			case <-ticker.C:
-				fmt.Fprintf(w, ": ping\n\n")
+				if _, err := fmt.Fprintf(w, ": ping\n\n"); err != nil {
+					return // client disconnected
+				}
 				flusher.Flush()
 			case <-r.Context().Done():
 				return


### PR DESCRIPTION
## Summary

- **`statusRecorder.Flush()`**: The logging middleware wrapper didn't implement `http.Flusher`, causing SSE data to buffer. Direct type assertions (`w.(http.Flusher)`) don't traverse `Unwrap()` chains, so the wrapper must implement it explicitly.
- **Remove `WriteTimeout`**: The 120s server-level timeout silently killed long-lived SSE connections (event handler uses 30s keepalive pings). Handlers now manage their own lifecycle via context cancellation and write error checks.
- **Check write errors in SSE loops**: `fmt.Fprintf` to a disconnected client was silently ignored, causing handlers to keep looping for dead connections.
- **Use `logutil.FromCtx`**: SSE handlers now get request-scoped fields (`request_id`, `user_id`, `vault_id`) in log messages.
- **Filter empty labels**: `SPLIT labels` on `[]` produces phantom `NONE` rows in `ListLabelsWithCounts`. Added `array::len(labels) > 0` filter and regression test.

## Test plan

- [x] `just build` passes
- [x] `just test` passes (all tests green)
- [ ] Manual: start server, open SSE event stream, verify events stream in real-time
- [ ] Manual: disconnect SSE client, verify handler exits promptly

🤖 Generated with [Claude Code](https://claude.com/claude-code)