### PR TITLE
[CORE-92] feat: @-reference file attachments in TUI

### DIFF
--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -10,12 +10,22 @@ import (
 	"github.com/raphi011/knowhow/internal/models"
 )
 
+// ChatAttachment represents a local file attached to a chat message.
+type ChatAttachment struct {
+	Path     string `json:"path"`
+	Content  string `json:"content"`
+	MimeType string `json:"mimeType"`
+	Language string `json:"language,omitempty"`
+	Type     string `json:"type"` // "text" or "image"
+}
+
 type chatRequestBody struct {
-	ConversationID string   `json:"conversationId"`
-	VaultID        string   `json:"vaultId"`
-	Content        string   `json:"content"`
-	DocRefs        []string `json:"docRefs"`
-	AutoApprove    bool     `json:"autoApprove"`
+	ConversationID string           `json:"conversationId"`
+	VaultID        string           `json:"vaultId"`
+	Content        string           `json:"content"`
+	DocRefs        []string         `json:"docRefs"`
+	Attachments    []ChatAttachment `json:"attachments,omitempty"`
+	AutoApprove    bool             `json:"autoApprove"`
 }
 
 // HandleChat returns an HTTP handler for POST /agent/chat that streams SSE events back to the client.
@@ -32,7 +42,7 @@ func (s *Service) HandleChat() http.HandlerFunc {
 			return
 		}
 
-		r.Body = http.MaxBytesReader(w, r.Body, 64*1024) // 64KB max
+		r.Body = http.MaxBytesReader(w, r.Body, 5*1024*1024) // 5MB max (text file attachments)
 		var body chatRequestBody
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			http.Error(w, "invalid request body", http.StatusBadRequest)
@@ -90,6 +100,7 @@ func (s *Service) HandleChat() http.HandlerFunc {
 			UserID:         ac.UserID,
 			Content:        body.Content,
 			DocRefs:        body.DocRefs,
+			Attachments:    body.Attachments,
 			AutoApprove:    body.AutoApprove,
 		}
 

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -316,6 +316,7 @@ type ChatRequest struct {
 	UserID         string
 	Content        string
 	DocRefs        []string
+	Attachments    []ChatAttachment
 	AutoApprove    bool              // true = skip approval for write tools
 	Approvals      *approvalRegistry // nil if auto-approve
 }
@@ -397,6 +398,22 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest, emit func(StreamEve
 			messages = append(messages,
 				&schema.Message{Role: schema.User, Content: "Referenced documents:\n" + refContext.String()},
 				&schema.Message{Role: schema.Assistant, Content: "I'll use these referenced documents to help answer your question."},
+			)
+		}
+	}
+
+	// Inject local file attachments as context
+	if len(req.Attachments) > 0 {
+		var fileContext strings.Builder
+		for _, att := range req.Attachments {
+			if att.Type == "text" {
+				fmt.Fprintf(&fileContext, "\n--- File: %s ---\n```%s\n%s\n```\n", att.Path, att.Language, att.Content)
+			}
+		}
+		if fileContext.Len() > 0 {
+			messages = append(messages,
+				&schema.Message{Role: schema.User, Content: "Attached local files:\n" + fileContext.String()},
+				&schema.Message{Role: schema.Assistant, Content: "I'll use these attached files to help answer your question."},
 			)
 		}
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -267,6 +267,44 @@ func (m *Model) sendMessage() tea.Cmd {
 		return nil
 	}
 
+	// Parse @-references and resolve local files
+	refs := parseAtRefs(content)
+	var chatAttachments []ChatAttachment
+	var resolved []Attachment
+
+	if len(refs) > 0 {
+		resolved = resolveAttachments(refs)
+
+		// Check for errors
+		var errs []string
+		for _, att := range resolved {
+			if att.Error != "" {
+				errs = append(errs, att.Error)
+			}
+		}
+		if len(errs) > 0 {
+			m.errMsg = strings.Join(errs, "; ")
+			return nil
+		}
+
+		// Build wire-format attachments
+		for _, att := range resolved {
+			chatAttachments = append(chatAttachments, ChatAttachment{
+				Path:     att.Path,
+				Content:  att.Content,
+				MimeType: att.MimeType,
+				Language: att.Language,
+				Type:     "text",
+			})
+		}
+
+		content = stripAtRefs(content, refs)
+		if content == "" {
+			m.errMsg = "message is empty after removing @-references"
+			return nil
+		}
+	}
+
 	m.input.SetValue("")
 	m.streaming = true
 	m.streamParts = nil
@@ -275,9 +313,10 @@ func (m *Model) sendMessage() tea.Cmd {
 	ctx := m.ctx
 	convID := m.conversationID
 	vaultID := m.vaultID
+	attachments := chatAttachments
 
 	startStreamCmd := func() tea.Msg {
-		ch, err := client.Chat(ctx, convID, vaultID, content, false)
+		ch, err := client.Chat(ctx, convID, vaultID, content, attachments, false)
 		if err != nil {
 			return streamEventMsg{event: StreamEvent{Type: "error", Content: err.Error()}, done: true}
 		}
@@ -292,7 +331,7 @@ func (m *Model) sendMessage() tea.Cmd {
 
 	// Print user message to scrollback, then start streaming + spinner
 	return tea.Sequence(
-		tea.Println(renderUserMessage(content)),
+		tea.Println(renderUserMessage(content, resolved)),
 		tea.Batch(startStreamCmd, m.spinner.Tick),
 	)
 }

--- a/internal/tui/attachment.go
+++ b/internal/tui/attachment.go
@@ -1,0 +1,250 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// FileType classifies an attachment by content kind.
+type FileType int
+
+const (
+	FileTypeText   FileType = iota
+	FileTypeImage
+	FileTypeBinary
+)
+
+const maxAttachmentSize = 1 << 20 // 1MB
+
+// Attachment holds a resolved @-reference with its file content.
+type Attachment struct {
+	Path     string   // original path from @-reference
+	AbsPath  string   // resolved absolute path
+	Name     string   // basename
+	Content  string   // file text content (only for text files)
+	MimeType string
+	Language string   // code fence language hint (e.g. "go", "python")
+	Type     FileType
+	Size     int64
+	Error    string   // non-empty if file couldn't be read
+}
+
+// LineCount returns the number of lines in the attachment content.
+func (a Attachment) LineCount() int {
+	if a.Content == "" {
+		return 0
+	}
+	return strings.Count(a.Content, "\n") + 1
+}
+
+// atRefRegex matches @-prefixed file paths. Supports:
+// - relative: @./foo.go, @../bar/baz.py
+// - absolute: @/usr/local/file.txt
+// - tilde: @~/Documents/notes.md
+// - bare: @file.go (must contain a dot to avoid matching @mentions)
+var atRefRegex = regexp.MustCompile(`@((?:\.\.?/[\w./_\-]+)|(?:~/[\w./_\-]+)|(?:/[\w./_\-]+)|(?:[\w.\-]+\.[\w]+))`)
+
+// parseAtRefs extracts @-prefixed file paths from input text.
+func parseAtRefs(input string) []string {
+	matches := atRefRegex.FindAllStringSubmatch(input, -1)
+	seen := make(map[string]struct{}, len(matches))
+	var refs []string
+	for _, m := range matches {
+		ref := m[1]
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+// resolveAttachments expands paths, reads files, and classifies them.
+func resolveAttachments(refs []string) []Attachment {
+	attachments := make([]Attachment, 0, len(refs))
+	for _, ref := range refs {
+		att := resolveOne(ref)
+		attachments = append(attachments, att)
+	}
+	return attachments
+}
+
+func resolveOne(ref string) Attachment {
+	expanded := expandPath(ref)
+
+	abs, err := filepath.Abs(expanded)
+	if err != nil {
+		return Attachment{Path: ref, Error: fmt.Sprintf("resolve path: %v", err)}
+	}
+
+	info, err := os.Stat(abs)
+	if err != nil {
+		return Attachment{Path: ref, AbsPath: abs, Error: fmt.Sprintf("file not found: %s", ref)}
+	}
+	if info.IsDir() {
+		return Attachment{Path: ref, AbsPath: abs, Error: fmt.Sprintf("path is a directory: %s", ref)}
+	}
+
+	ext := strings.ToLower(filepath.Ext(abs))
+	fileType := classifyFile(ext)
+	att := Attachment{
+		Path:    ref,
+		AbsPath: abs,
+		Name:    filepath.Base(abs),
+		Type:    fileType,
+		Size:    info.Size(),
+	}
+
+	if fileType == FileTypeBinary {
+		att.Error = fmt.Sprintf("binary file not supported: %s", ref)
+		return att
+	}
+	if fileType == FileTypeImage {
+		att.Error = fmt.Sprintf("image attachments not yet supported: %s", ref)
+		return att
+	}
+
+	if info.Size() > maxAttachmentSize {
+		att.Error = fmt.Sprintf("file too large (%d bytes, max %d): %s", info.Size(), maxAttachmentSize, ref)
+		return att
+	}
+
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		att.Error = fmt.Sprintf("read file: %v", err)
+		return att
+	}
+
+	att.Content = string(data)
+	att.Language = langForExt(ext)
+	att.MimeType = mimeForExt(ext)
+	return att
+}
+
+// expandPath expands ~ to the user's home directory.
+func expandPath(p string) string {
+	if strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return p
+		}
+		return filepath.Join(home, p[2:])
+	}
+	return p
+}
+
+// classifyFile returns the file type based on extension.
+func classifyFile(ext string) FileType {
+	switch ext {
+	case ".go", ".py", ".js", ".ts", ".tsx", ".jsx", ".rs", ".rb", ".java",
+		".kt", ".kts", ".c", ".h", ".cpp", ".hpp", ".cs", ".swift", ".scala",
+		".sh", ".bash", ".zsh", ".fish", ".ps1",
+		".md", ".txt", ".rst", ".adoc",
+		".json", ".yaml", ".yml", ".toml", ".xml", ".csv", ".tsv",
+		".html", ".css", ".scss", ".less", ".sass",
+		".sql", ".graphql", ".gql",
+		".proto", ".tf", ".hcl",
+		".env", ".ini", ".cfg", ".conf",
+		".dockerfile", ".makefile",
+		".lua", ".vim", ".el",
+		".r", ".jl", ".m", ".mm",
+		".zig", ".nim", ".v", ".d",
+		".gitignore", ".gitattributes", ".editorconfig",
+		".mod", ".sum", ".lock":
+		return FileTypeText
+	case ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".bmp", ".ico":
+		return FileTypeImage
+	default:
+		return FileTypeBinary
+	}
+}
+
+// langForExt maps file extensions to code fence language hints.
+func langForExt(ext string) string {
+	m := map[string]string{
+		".go":     "go",
+		".py":     "python",
+		".js":     "javascript",
+		".ts":     "typescript",
+		".tsx":    "tsx",
+		".jsx":    "jsx",
+		".rs":     "rust",
+		".rb":     "ruby",
+		".java":   "java",
+		".kt":     "kotlin",
+		".kts":    "kotlin",
+		".c":      "c",
+		".h":      "c",
+		".cpp":    "cpp",
+		".hpp":    "cpp",
+		".cs":     "csharp",
+		".swift":  "swift",
+		".scala":  "scala",
+		".sh":     "bash",
+		".bash":   "bash",
+		".zsh":    "zsh",
+		".fish":   "fish",
+		".ps1":    "powershell",
+		".md":     "markdown",
+		".json":   "json",
+		".yaml":   "yaml",
+		".yml":    "yaml",
+		".toml":   "toml",
+		".xml":    "xml",
+		".html":   "html",
+		".css":    "css",
+		".scss":   "scss",
+		".less":   "less",
+		".sql":    "sql",
+		".graphql": "graphql",
+		".gql":    "graphql",
+		".proto":  "protobuf",
+		".tf":     "terraform",
+		".hcl":    "hcl",
+		".lua":    "lua",
+		".vim":    "vim",
+		".r":      "r",
+		".jl":     "julia",
+		".zig":    "zig",
+		".nim":    "nim",
+	}
+	if lang, ok := m[ext]; ok {
+		return lang
+	}
+	return ""
+}
+
+// mimeForExt returns a MIME type for known text extensions.
+func mimeForExt(ext string) string {
+	switch ext {
+	case ".json":
+		return "application/json"
+	case ".xml":
+		return "application/xml"
+	case ".html":
+		return "text/html"
+	case ".css":
+		return "text/css"
+	case ".js":
+		return "text/javascript"
+	case ".md":
+		return "text/markdown"
+	default:
+		return "text/plain"
+	}
+}
+
+// stripAtRefs removes @path tokens from input, cleaning up extra whitespace.
+func stripAtRefs(input string, refs []string) string {
+	result := input
+	for _, ref := range refs {
+		result = strings.ReplaceAll(result, "@"+ref, "")
+	}
+	// Collapse multiple spaces into one and trim
+	result = strings.Join(strings.Fields(result), " ")
+	return result
+}

--- a/internal/tui/attachment_test.go
+++ b/internal/tui/attachment_test.go
@@ -1,0 +1,233 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseAtRefs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"no refs", "hello world", nil},
+		{"single relative", "explain @./main.go", []string{"./main.go"}},
+		{"single absolute", "read @/etc/hosts please", []string{"/etc/hosts"}},
+		{"tilde path", "check @~/Documents/notes.md", []string{"~/Documents/notes.md"}},
+		{"multiple refs", "@./a.go @./b.go compare", []string{"./a.go", "./b.go"}},
+		{"duplicate refs", "@./a.go @./a.go", []string{"./a.go"}},
+		{"bare file with dot", "review @main.go", []string{"main.go"}},
+		{"path with hyphens", "@./my-file.ts ok", []string{"./my-file.ts"}},
+		{"path with dots", "@./dir.name/file.ext", []string{"./dir.name/file.ext"}},
+		{"nested path", "@./internal/tui/app.go", []string{"./internal/tui/app.go"}},
+		{"parent path", "@../other/file.py", []string{"../other/file.py"}},
+		{"no match for @mention", "hey @john how are you", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAtRefs(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseAtRefs(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i, g := range got {
+				if g != tt.want[i] {
+					t.Errorf("parseAtRefs(%q)[%d] = %q, want %q", tt.input, i, g, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestStripAtRefs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		refs  []string
+		want  string
+	}{
+		{"single ref", "explain @./main.go please", []string{"./main.go"}, "explain please"},
+		{"multiple refs", "@./a.go @./b.go compare these", []string{"./a.go", "./b.go"}, "compare these"},
+		{"no refs", "hello world", nil, "hello world"},
+		{"ref at end", "review @./file.go", []string{"./file.go"}, "review"},
+		{"ref at start", "@./file.go explain", []string{"./file.go"}, "explain"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripAtRefs(tt.input, tt.refs)
+			if got != tt.want {
+				t.Errorf("stripAtRefs(%q, %v) = %q, want %q", tt.input, tt.refs, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyFile(t *testing.T) {
+	tests := []struct {
+		ext  string
+		want FileType
+	}{
+		{".go", FileTypeText},
+		{".py", FileTypeText},
+		{".ts", FileTypeText},
+		{".md", FileTypeText},
+		{".json", FileTypeText},
+		{".yaml", FileTypeText},
+		{".toml", FileTypeText},
+		{".sql", FileTypeText},
+		{".sh", FileTypeText},
+		{".png", FileTypeImage},
+		{".jpg", FileTypeImage},
+		{".jpeg", FileTypeImage},
+		{".gif", FileTypeImage},
+		{".svg", FileTypeImage},
+		{".exe", FileTypeBinary},
+		{".zip", FileTypeBinary},
+		{".pdf", FileTypeBinary},
+		{"", FileTypeBinary},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ext, func(t *testing.T) {
+			got := classifyFile(tt.ext)
+			if got != tt.want {
+				t.Errorf("classifyFile(%q) = %d, want %d", tt.ext, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLangForExt(t *testing.T) {
+	tests := []struct {
+		ext  string
+		want string
+	}{
+		{".go", "go"},
+		{".py", "python"},
+		{".ts", "typescript"},
+		{".tsx", "tsx"},
+		{".rs", "rust"},
+		{".java", "java"},
+		{".md", "markdown"},
+		{".json", "json"},
+		{".yaml", "yaml"},
+		{".yml", "yaml"},
+		{".sql", "sql"},
+		{".unknown", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ext, func(t *testing.T) {
+			got := langForExt(tt.ext)
+			if got != tt.want {
+				t.Errorf("langForExt(%q) = %q, want %q", tt.ext, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveAttachments(t *testing.T) {
+	t.Run("reads real file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.go")
+		content := "package main\n\nfunc main() {}\n"
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		atts := resolveAttachments([]string{path})
+		if len(atts) != 1 {
+			t.Fatalf("got %d attachments, want 1", len(atts))
+		}
+		att := atts[0]
+		if att.Error != "" {
+			t.Fatalf("unexpected error: %s", att.Error)
+		}
+		if att.Content != content {
+			t.Errorf("content = %q, want %q", att.Content, content)
+		}
+		if att.Language != "go" {
+			t.Errorf("language = %q, want %q", att.Language, "go")
+		}
+		if att.Name != "test.go" {
+			t.Errorf("name = %q, want %q", att.Name, "test.go")
+		}
+		if att.Type != FileTypeText {
+			t.Errorf("type = %d, want %d", att.Type, FileTypeText)
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		atts := resolveAttachments([]string{"/nonexistent/file.go"})
+		if len(atts) != 1 {
+			t.Fatalf("got %d attachments, want 1", len(atts))
+		}
+		if atts[0].Error == "" {
+			t.Error("expected error for missing file")
+		}
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		dir := t.TempDir()
+		atts := resolveAttachments([]string{dir})
+		if len(atts) != 1 {
+			t.Fatalf("got %d attachments, want 1", len(atts))
+		}
+		if !strings.Contains(atts[0].Error, "directory") {
+			t.Errorf("expected directory error, got: %s", atts[0].Error)
+		}
+	})
+
+	t.Run("oversized file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "big.txt")
+		// Create file just over 1MB
+		data := make([]byte, maxAttachmentSize+1)
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		atts := resolveAttachments([]string{path})
+		if len(atts) != 1 {
+			t.Fatalf("got %d attachments, want 1", len(atts))
+		}
+		if !strings.Contains(atts[0].Error, "too large") {
+			t.Errorf("expected size error, got: %s", atts[0].Error)
+		}
+	})
+
+	t.Run("binary file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "data.zip")
+		if err := os.WriteFile(path, []byte("PK\x03\x04"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		atts := resolveAttachments([]string{path})
+		if len(atts) != 1 {
+			t.Fatalf("got %d attachments, want 1", len(atts))
+		}
+		if !strings.Contains(atts[0].Error, "binary") {
+			t.Errorf("expected binary error, got: %s", atts[0].Error)
+		}
+	})
+
+	t.Run("line count", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "lines.go")
+		content := "line1\nline2\nline3\n"
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		atts := resolveAttachments([]string{path})
+		if atts[0].LineCount() != 4 {
+			t.Errorf("LineCount() = %d, want 4", atts[0].LineCount())
+		}
+	})
+}

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -49,13 +49,25 @@ type StreamEvent struct {
 	OutputTokens int64  `json:"outputTokens,omitempty"`
 }
 
+// ChatAttachment is the wire format for file attachments sent to the agent.
+type ChatAttachment struct {
+	Path     string `json:"path"`
+	Content  string `json:"content"`
+	MimeType string `json:"mimeType"`
+	Language string `json:"language,omitempty"`
+	Type     string `json:"type"` // "text" or "image"
+}
+
 // Chat sends a message and returns a channel of SSE events.
-func (c *Client) Chat(ctx context.Context, conversationID, vaultID, content string, autoApprove bool) (<-chan StreamEvent, error) {
+func (c *Client) Chat(ctx context.Context, conversationID, vaultID, content string, attachments []ChatAttachment, autoApprove bool) (<-chan StreamEvent, error) {
 	body := map[string]any{
 		"conversationId": conversationID,
 		"vaultId":        vaultID,
 		"content":        content,
 		"autoApprove":    autoApprove,
+	}
+	if len(attachments) > 0 {
+		body["attachments"] = attachments
 	}
 
 	data, err := json.Marshal(body)

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -107,9 +107,22 @@ func renderStreamParts(renderer *glamour.TermRenderer, parts []ContentPart, pend
 	return sb.String()
 }
 
-// renderUserMessage renders a user message with role label for scrollback output.
-func renderUserMessage(content string) string {
-	return "\n" + userRoleStyle.Render("you") + "\n" + userMsgStyle.MaxWidth(maxTextWidth).Render(content) + "\n"
+// renderUserMessage renders a user message with role label and optional attachment indicators.
+func renderUserMessage(content string, attachments []Attachment) string {
+	var sb strings.Builder
+	sb.WriteString("\n")
+	sb.WriteString(userRoleStyle.Render("you"))
+	sb.WriteString("\n")
+	sb.WriteString(userMsgStyle.MaxWidth(maxTextWidth).Render(content))
+	sb.WriteString("\n")
+
+	for _, att := range attachments {
+		line := fmt.Sprintf("  %s (%s, %d lines)", att.Name, att.Path, att.LineCount())
+		sb.WriteString(attachmentStyle.Render(line))
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
 }
 
 // renderAssistantMessage renders a finalized assistant response for scrollback output.

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -63,4 +63,9 @@ var (
 	// Error message style
 	errorMsgStyle = lipgloss.NewStyle().
 			Foreground(errorColor)
+
+	// Attachment indicator style (shown below user messages)
+	attachmentStyle = lipgloss.NewStyle().
+			Foreground(mutedColor).
+			PaddingLeft(2)
 )


### PR DESCRIPTION
Add support for `@path` references in TUI chat input. Users can attach local text files as context for the agent by typing `@./file.go`, `@~/docs/notes.md`, or `@/absolute/path.ts`. Files are resolved, read, and sent as fenced code blocks to the LLM.

Closes #92

## New Features
- Parse `@path` tokens from TUI input (relative, absolute, tilde, bare `file.ext`)
- Resolve and read local text files with extension-based classification
- Send file content as fenced code blocks to the agent via new `attachments` field
- Show attachment indicators (filename, path, line count) below user messages
- Error handling: missing files, directories, binary files, oversized files (>1MB)

## Breaking Changes
- None