### PR TITLE
feat: server federation for cross-server vault access

### DIFF
--- a/cmd/knowhow/cmd_remote.go
+++ b/cmd/knowhow/cmd_remote.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var remoteCmd = &cobra.Command{
+	Use:   "remote",
+	Short: "Manage remote knowhow server connections",
+}
+
+var remoteListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List configured remotes",
+	RunE:  runRemoteList,
+}
+
+var remoteAddCmd = &cobra.Command{
+	Use:   "add <name> <url>",
+	Short: "Add a remote knowhow server",
+	Long:  `Add a remote knowhow server. Token can be passed via --token flag or KNOWHOW_REMOTE_TOKEN env var. If neither is set, you will be prompted.`,
+	Args:  cobra.ExactArgs(2),
+	RunE:  runRemoteAdd,
+}
+
+var remoteRemoveCmd = &cobra.Command{
+	Use:   "remove <name>",
+	Short: "Remove a remote knowhow server",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runRemoteRemove,
+}
+
+var remoteAPIFlags *apiFlags
+var remoteToken string
+
+func init() {
+	remoteAPIFlags = addAPIFlags(remoteCmd)
+	remoteAddCmd.Flags().StringVar(&remoteToken, "token", os.Getenv("KNOWHOW_REMOTE_TOKEN"), "API token for the remote server")
+	remoteCmd.AddCommand(remoteListCmd)
+	remoteCmd.AddCommand(remoteAddCmd)
+	remoteCmd.AddCommand(remoteRemoveCmd)
+}
+
+type remoteListResponse struct {
+	Name      string    `json:"name"`
+	URL       string    `json:"url"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+func runRemoteList(_ *cobra.Command, _ []string) error {
+	client := remoteAPIFlags.newClient()
+
+	var remotes []remoteListResponse
+	if err := client.Get(context.Background(), "/api/remotes", &remotes); err != nil {
+		return fmt.Errorf("list remotes: %w", err)
+	}
+
+	if len(remotes) == 0 {
+		fmt.Println("No remotes configured.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tURL\tCREATED")
+	for _, r := range remotes {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", r.Name, r.URL, r.CreatedAt.Format("2006-01-02"))
+	}
+	return w.Flush()
+}
+
+func runRemoteAdd(_ *cobra.Command, args []string) error {
+	name := args[0]
+	url := args[1]
+
+	if remoteToken == "" {
+		return fmt.Errorf("--token or KNOWHOW_REMOTE_TOKEN required")
+	}
+
+	client := remoteAPIFlags.newClient()
+
+	body := map[string]string{
+		"name":  name,
+		"url":   url,
+		"token": remoteToken,
+	}
+
+	var result json.RawMessage
+	if err := client.Post(context.Background(), "/api/remotes", body, &result); err != nil {
+		return fmt.Errorf("add remote: %w", err)
+	}
+
+	fmt.Printf("Remote %q added (%s)\n", name, url)
+	return nil
+}
+
+func runRemoteRemove(_ *cobra.Command, args []string) error {
+	name := args[0]
+	client := remoteAPIFlags.newClient()
+
+	if err := client.Delete(context.Background(), "/api/remotes/"+name); err != nil {
+		return fmt.Errorf("remove remote: %w", err)
+	}
+
+	fmt.Printf("Remote %q removed\n", name)
+	return nil
+}

--- a/cmd/knowhow/cmd_serve.go
+++ b/cmd/knowhow/cmd_serve.go
@@ -171,6 +171,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 			},
 			app.DBClient(),
 			app.VaultService(),
+			app.RemoteService(),
 		)
 		mux.Handle("/mcp", authMw(mcpHandler))
 		slog.Info("MCP endpoint enabled", "path", "/mcp")

--- a/cmd/knowhow/main.go
+++ b/cmd/knowhow/main.go
@@ -71,6 +71,7 @@ func main() {
 	rootCmd.AddCommand(catCmd)
 	rootCmd.AddCommand(rmCmd)
 	rootCmd.AddCommand(vaultCmd)
+	rootCmd.AddCommand(remoteCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/internal/api/folders.go
+++ b/internal/api/folders.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/raphi011/knowhow/internal/auth"
+	"github.com/raphi011/knowhow/internal/logutil"
+	"github.com/raphi011/knowhow/internal/models"
+	"github.com/raphi011/knowhow/internal/pathutil"
+)
+
+func (s *Server) listFolders(w http.ResponseWriter, r *http.Request) {
+	vaultID := r.URL.Query().Get("vault")
+	if vaultID == "" {
+		writeError(w, http.StatusBadRequest, "vault query parameter required")
+		return
+	}
+
+	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	ctx := r.Context()
+	logger := logutil.FromCtx(ctx)
+
+	folders, err := s.app.DBClient().ListFolders(ctx, vaultID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list folders")
+		logger.Error("list folders", "vault_id", vaultID, "error", err)
+		return
+	}
+
+	parent := r.URL.Query().Get("parent")
+	if parent != "" {
+		parent = pathutil.NormalizeFolderPath(parent)
+		var filtered []models.Folder
+		for _, f := range folders {
+			if pathutil.IsImmediateChildFolder(parent, f.Path) {
+				filtered = append(filtered, f)
+			}
+		}
+		folders = filtered
+	}
+
+	resp := make([]FolderResponse, len(folders))
+	for i, f := range folders {
+		resp[i] = FolderResponse{
+			Path: f.Path,
+			Name: f.Name,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/api/remotes.go
+++ b/internal/api/remotes.go
@@ -1,0 +1,181 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/raphi011/knowhow/internal/auth"
+	"github.com/raphi011/knowhow/internal/db"
+	"github.com/raphi011/knowhow/internal/logutil"
+	"github.com/raphi011/knowhow/internal/models"
+)
+
+type remoteResponse struct {
+	Name      string    `json:"name"`
+	URL       string    `json:"url"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+func (s *Server) listRemotes(w http.ResponseWriter, r *http.Request) {
+	if err := auth.RequireSystemAdmin(r.Context()); err != nil {
+		writeError(w, http.StatusForbidden, "system admin required")
+		return
+	}
+
+	remoteSvc := s.app.RemoteService()
+	if remoteSvc == nil {
+		writeJSON(w, http.StatusOK, []remoteResponse{})
+		return
+	}
+
+	remotes, err := remoteSvc.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list remotes")
+		logutil.FromCtx(r.Context()).Error("list remotes", "error", err)
+		return
+	}
+
+	resp := make([]remoteResponse, len(remotes))
+	for i, r := range remotes {
+		resp[i] = remoteResponse{
+			Name:      r.Name,
+			URL:       r.URL,
+			CreatedAt: r.CreatedAt,
+			UpdatedAt: r.UpdatedAt,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+type addRemoteRequest struct {
+	Name  string `json:"name"`
+	URL   string `json:"url"`
+	Token string `json:"token"`
+}
+
+func (s *Server) addRemote(w http.ResponseWriter, r *http.Request) {
+	if err := auth.RequireSystemAdmin(r.Context()); err != nil {
+		writeError(w, http.StatusForbidden, "system admin required")
+		return
+	}
+
+	var body addRemoteRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if body.Name == "" || body.URL == "" || body.Token == "" {
+		writeError(w, http.StatusBadRequest, "name, url, and token are required")
+		return
+	}
+	if strings.Contains(body.Name, "/") || strings.Contains(body.Name, " ") {
+		writeError(w, http.StatusBadRequest, "remote name must not contain '/' or spaces")
+		return
+	}
+
+	remoteSvc := s.app.RemoteService()
+	if remoteSvc == nil {
+		writeError(w, http.StatusServiceUnavailable, "remote service not available")
+		return
+	}
+
+	ctx := r.Context()
+	logger := logutil.FromCtx(ctx)
+
+	// Validate connectivity by calling /health on the remote
+	if err := checkRemoteHealth(ctx, body.URL); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("cannot reach remote: %v", err))
+		return
+	}
+
+	ac, err := auth.FromContext(ctx)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	remote, err := remoteSvc.Add(ctx, ac.UserID, models.RemoteInput{
+		Name:  body.Name,
+		URL:   body.URL,
+		Token: body.Token,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to add remote")
+		logger.Error("add remote", "name", body.Name, "error", err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, remoteResponse{
+		Name:      remote.Name,
+		URL:       remote.URL,
+		CreatedAt: remote.CreatedAt,
+		UpdatedAt: remote.UpdatedAt,
+	})
+}
+
+func (s *Server) removeRemote(w http.ResponseWriter, r *http.Request) {
+	if err := auth.RequireSystemAdmin(r.Context()); err != nil {
+		writeError(w, http.StatusForbidden, "system admin required")
+		return
+	}
+
+	name := r.PathValue("name")
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "remote name required")
+		return
+	}
+
+	remoteSvc := s.app.RemoteService()
+	if remoteSvc == nil {
+		writeError(w, http.StatusServiceUnavailable, "remote service not available")
+		return
+	}
+
+	logger := logutil.FromCtx(r.Context())
+
+	if err := remoteSvc.Remove(r.Context(), name); err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			writeError(w, http.StatusNotFound, fmt.Sprintf("remote not found: %s", name))
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to remove remote")
+		logger.Error("remove remote", "name", name, "error", err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// checkRemoteHealth performs a GET /health on the remote URL to verify connectivity.
+func checkRemoteHealth(ctx context.Context, remoteURL string) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, remoteURL+"/health", nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("health check returned %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/raphi011/knowhow/internal/auth"
+	"github.com/raphi011/knowhow/internal/logutil"
+	"github.com/raphi011/knowhow/internal/models"
+	"github.com/raphi011/knowhow/internal/search"
+)
+
+func (s *Server) searchDocuments(w http.ResponseWriter, r *http.Request) {
+	vaultID := r.URL.Query().Get("vault")
+	query := r.URL.Query().Get("query")
+
+	if vaultID == "" || query == "" {
+		writeError(w, http.StatusBadRequest, "vault and query parameters required")
+		return
+	}
+
+	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	limit := 20
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+
+	var labels []string
+	if l := r.URL.Query().Get("labels"); l != "" {
+		labels = strings.Split(l, ",")
+	}
+
+	ctx := r.Context()
+	logger := logutil.FromCtx(ctx)
+
+	results, err := s.app.SearchService().Search(ctx, search.SearchInput{
+		VaultID: vaultID,
+		Query:   query,
+		Labels:  labels,
+		Limit:   limit,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "search failed")
+		logger.Error("search documents", "vault_id", vaultID, "error", err)
+		return
+	}
+
+	resp := make([]SearchResultResponse, len(results))
+	for i, r := range results {
+		chunks := make([]ChunkMatchResponse, len(r.MatchedChunks))
+		for j, c := range r.MatchedChunks {
+			chunks[j] = ChunkMatchResponse{
+				Snippet:     c.Snippet,
+				HeadingPath: c.HeadingPath,
+				Position:    c.Position,
+				Score:       c.Score,
+			}
+		}
+		resp[i] = SearchResultResponse{
+			Path:          r.Path,
+			Title:         r.Title,
+			Score:         r.Score,
+			MatchedChunks: chunks,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -46,8 +46,22 @@ func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Han
 	// Bulk upload
 	mux.Handle("POST /api/bulk", authMw(http.HandlerFunc(s.bulkUpload)))
 
+	// Search
+	mux.Handle("GET /api/search", authMw(http.HandlerFunc(s.searchDocuments)))
+
+	// Folders
+	mux.Handle("GET /api/folders", authMw(http.HandlerFunc(s.listFolders)))
+
+	// Versions
+	mux.Handle("GET /api/versions", authMw(http.HandlerFunc(s.listVersions)))
+
 	// Labels
 	mux.Handle("GET /api/labels", authMw(http.HandlerFunc(s.listLabels)))
+
+	// Remotes (federation)
+	mux.Handle("GET /api/remotes", authMw(http.HandlerFunc(s.listRemotes)))
+	mux.Handle("POST /api/remotes", authMw(http.HandlerFunc(s.addRemote)))
+	mux.Handle("DELETE /api/remotes/{name}", authMw(http.HandlerFunc(s.removeRemote)))
 
 	// Backup
 	mux.Handle("GET /api/backup", authMw(http.HandlerFunc(s.backup)))

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -15,6 +15,7 @@ type Vault struct {
 	CreatedBy   string    `json:"createdBy"`
 	CreatedAt   time.Time `json:"createdAt"`
 	UpdatedAt   time.Time `json:"updatedAt"`
+	Remote      *string   `json:"remote,omitempty"`
 }
 
 // Document is the JSON representation of a document.
@@ -101,6 +102,37 @@ type VaultInfo struct {
 	ConversationCount int   `json:"conversationCount"`
 	TokenInput        int64 `json:"tokenInput"`
 	TokenOutput       int64 `json:"tokenOutput"`
+}
+
+// SearchResultResponse is the JSON representation of a search result.
+type SearchResultResponse struct {
+	Path          string               `json:"path"`
+	Title         string               `json:"title"`
+	Score         float64              `json:"score"`
+	MatchedChunks []ChunkMatchResponse `json:"matchedChunks"`
+}
+
+// ChunkMatchResponse is the JSON representation of a matched chunk.
+type ChunkMatchResponse struct {
+	Snippet     string  `json:"snippet"`
+	HeadingPath *string `json:"headingPath,omitempty"`
+	Position    int     `json:"position"`
+	Score       float64 `json:"score"`
+}
+
+// FolderResponse is the JSON representation of a folder.
+type FolderResponse struct {
+	Path string `json:"path"`
+	Name string `json:"name"`
+}
+
+// VersionResponse is the JSON representation of a document version.
+type VersionResponse struct {
+	Version     int       `json:"version"`
+	Title       string    `json:"title"`
+	Source      string    `json:"source"`
+	ContentHash string    `json:"contentHash"`
+	CreatedAt   time.Time `json:"createdAt"`
 }
 
 // ServerConfig holds the server's effective configuration.

--- a/internal/api/vaults.go
+++ b/internal/api/vaults.go
@@ -24,43 +24,63 @@ func (s *Server) listVaults(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var result []Vault
+
 	// System admin or wildcard → return all vaults
 	if ac.IsSystemAdmin {
-		result := make([]Vault, len(all))
+		result = make([]Vault, len(all))
 		for i := range all {
 			result[i] = vaultFromModel(&all[i])
 		}
-		writeJSON(w, http.StatusOK, result)
-		return
-	}
+	} else {
+		// Filter to vaults the user has access to
+		accessSet := make(map[string]bool, len(ac.Vaults))
+		hasWildcard := false
+		for _, vp := range ac.Vaults {
+			if vp.VaultID == auth.WildcardVaultAccess {
+				hasWildcard = true
+				break
+			}
+			accessSet[vp.VaultID] = true
+		}
 
-	// Filter to vaults the user has access to
-	accessSet := make(map[string]bool, len(ac.Vaults))
-	for _, vp := range ac.Vaults {
-		if vp.VaultID == auth.WildcardVaultAccess {
-			result := make([]Vault, len(all))
+		if hasWildcard {
+			result = make([]Vault, len(all))
 			for i := range all {
 				result[i] = vaultFromModel(&all[i])
 			}
-			writeJSON(w, http.StatusOK, result)
-			return
+		} else {
+			logger := logutil.FromCtx(r.Context())
+			for i := range all {
+				id, err := models.RecordIDString(all[i].ID)
+				if err != nil {
+					logger.Warn("failed to extract vault ID, skipping", "vault_name", all[i].Name, "error", err)
+					continue
+				}
+				if accessSet[id] {
+					result = append(result, vaultFromModel(&all[i]))
+				}
+			}
 		}
-		accessSet[vp.VaultID] = true
 	}
 
-	logger := logutil.FromCtx(r.Context())
-
-	var result []Vault
-	for i := range all {
-		id, err := models.RecordIDString(all[i].ID)
+	// Append remote vaults if remote service is configured
+	if remoteSvc := s.app.RemoteService(); remoteSvc != nil {
+		remoteVaults, err := remoteSvc.ListRemoteVaults(r.Context())
 		if err != nil {
-			logger.Warn("failed to extract vault ID, skipping", "vault_name", all[i].Name, "error", err)
-			continue
-		}
-		if accessSet[id] {
-			result = append(result, vaultFromModel(&all[i]))
+			logutil.FromCtx(r.Context()).Warn("failed to list remote vaults", "error", err)
+		} else {
+			for _, rv := range remoteVaults {
+				remoteName := rv.RemoteName
+				result = append(result, Vault{
+					ID:     rv.VaultID,
+					Name:   rv.Namespace,
+					Remote: &remoteName,
+				})
+			}
 		}
 	}
+
 	if result == nil {
 		result = []Vault{}
 	}

--- a/internal/api/versions.go
+++ b/internal/api/versions.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/raphi011/knowhow/internal/auth"
+	"github.com/raphi011/knowhow/internal/logutil"
+	"github.com/raphi011/knowhow/internal/models"
+)
+
+func (s *Server) listVersions(w http.ResponseWriter, r *http.Request) {
+	vaultID := r.URL.Query().Get("vault")
+	path := r.URL.Query().Get("path")
+
+	if vaultID == "" || path == "" {
+		writeError(w, http.StatusBadRequest, "vault and path parameters required")
+		return
+	}
+
+	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	limit := 20
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+
+	ctx := r.Context()
+	logger := logutil.FromCtx(ctx)
+
+	doc, err := s.app.DBClient().GetDocumentByPath(ctx, vaultID, path)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get document")
+		logger.Error("list versions: get document", "vault_id", vaultID, "path", path, "error", err)
+		return
+	}
+	if doc == nil {
+		writeError(w, http.StatusNotFound, "document not found")
+		return
+	}
+
+	docID, err := models.RecordIDString(doc.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "invalid document ID")
+		logger.Error("list versions: extract doc ID", "path", path, "error", err)
+		return
+	}
+
+	versions, err := s.app.DBClient().ListVersions(ctx, docID, limit, 0)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list versions")
+		logger.Error("list versions", "doc_id", docID, "error", err)
+		return
+	}
+
+	resp := make([]VersionResponse, len(versions))
+	for i, v := range versions {
+		resp[i] = VersionResponse{
+			Version:     v.Version,
+			Title:       v.Title,
+			Source:      string(v.Source),
+			ContentHash: v.ContentHash,
+			CreatedAt:   v.CreatedAt,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -17,6 +17,16 @@ import (
 	"github.com/raphi011/knowhow/internal/models"
 )
 
+// HTTPError is returned when the server responds with a 4xx/5xx status code.
+type HTTPError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Message)
+}
+
 // Client is a REST API client for the Knowhow server.
 type Client struct {
 	baseURL string
@@ -187,6 +197,123 @@ func (c *Client) do(ctx context.Context, method, path string, body, target any) 
 	return c.handleResponse(req, target)
 }
 
+// Vault is the JSON representation of a vault from the REST API.
+type Vault struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Description *string `json:"description,omitempty"`
+	Remote      *string `json:"remote,omitempty"`
+}
+
+// ListVaults returns all accessible vaults.
+func (c *Client) ListVaults(ctx context.Context) ([]Vault, error) {
+	var vaults []Vault
+	if err := c.Get(ctx, "/api/vaults", &vaults); err != nil {
+		return nil, fmt.Errorf("list vaults: %w", err)
+	}
+	return vaults, nil
+}
+
+// SearchResult is the JSON representation of a search result from the REST API.
+type SearchResult struct {
+	Path          string       `json:"path"`
+	Title         string       `json:"title"`
+	Score         float64      `json:"score"`
+	MatchedChunks []ChunkMatch `json:"matchedChunks"`
+}
+
+// ChunkMatch is a matched chunk within a search result.
+type ChunkMatch struct {
+	Snippet     string  `json:"snippet"`
+	HeadingPath *string `json:"headingPath,omitempty"`
+	Position    int     `json:"position"`
+	Score       float64 `json:"score"`
+}
+
+// SearchDocuments searches documents on the remote server.
+func (c *Client) SearchDocuments(ctx context.Context, vaultID, query string, limit int) ([]SearchResult, error) {
+	q := url.Values{"vault": {vaultID}, "query": {query}}
+	if limit > 0 {
+		q.Set("limit", fmt.Sprintf("%d", limit))
+	}
+	var results []SearchResult
+	if err := c.Get(ctx, "/api/search?"+q.Encode(), &results); err != nil {
+		return nil, fmt.Errorf("search documents: %w", err)
+	}
+	return results, nil
+}
+
+// Folder is the JSON representation of a folder from the REST API.
+type Folder struct {
+	Path string `json:"path"`
+	Name string `json:"name"`
+}
+
+// ListFolders lists folders in a vault, optionally under a parent path.
+func (c *Client) ListFolders(ctx context.Context, vaultID string, parent *string) ([]Folder, error) {
+	q := url.Values{"vault": {vaultID}}
+	if parent != nil {
+		q.Set("parent", *parent)
+	}
+	var folders []Folder
+	if err := c.Get(ctx, "/api/folders?"+q.Encode(), &folders); err != nil {
+		return nil, fmt.Errorf("list folders: %w", err)
+	}
+	return folders, nil
+}
+
+// CreateDocumentRequest is the body for creating a document via REST API.
+type CreateDocumentRequest struct {
+	VaultID string `json:"vaultId"`
+	Path    string `json:"path"`
+	Content string `json:"content"`
+	Source  string `json:"source"`
+}
+
+// CreateDocument creates a new document on the remote server.
+func (c *Client) CreateDocument(ctx context.Context, req CreateDocumentRequest) (*Document, error) {
+	var doc Document
+	if err := c.Post(ctx, "/api/documents", req, &doc); err != nil {
+		return nil, fmt.Errorf("create document: %w", err)
+	}
+	return &doc, nil
+}
+
+// EditDocumentRequest is the body for editing a document via REST API.
+// Uses the same endpoint as create (upsert semantics).
+type EditDocumentRequest = CreateDocumentRequest
+
+// EditDocument updates an existing document on the remote server.
+func (c *Client) EditDocument(ctx context.Context, req EditDocumentRequest) (*Document, error) {
+	var doc Document
+	if err := c.Post(ctx, "/api/documents", req, &doc); err != nil {
+		return nil, fmt.Errorf("edit document: %w", err)
+	}
+	return &doc, nil
+}
+
+// Version is the JSON representation of a document version from the REST API.
+type Version struct {
+	Version     int       `json:"version"`
+	Title       string    `json:"title"`
+	Source      string    `json:"source"`
+	ContentHash string    `json:"contentHash"`
+	CreatedAt   time.Time `json:"createdAt"`
+}
+
+// ListVersions returns version history for a document.
+func (c *Client) ListVersions(ctx context.Context, vaultID, path string, limit int) ([]Version, error) {
+	q := url.Values{"vault": {vaultID}, "path": {path}}
+	if limit > 0 {
+		q.Set("limit", fmt.Sprintf("%d", limit))
+	}
+	var versions []Version
+	if err := c.Get(ctx, "/api/versions?"+q.Encode(), &versions); err != nil {
+		return nil, fmt.Errorf("list versions: %w", err)
+	}
+	return versions, nil
+}
+
 // Document is the JSON representation of a document returned by the REST API.
 type Document struct {
 	ID          string  `json:"id"`
@@ -331,9 +458,9 @@ func (c *Client) DownloadBackup(ctx context.Context, vaultID, outputPath string)
 			Error string `json:"error"`
 		}
 		if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
-			return 0, fmt.Errorf("HTTP %d: %s", resp.StatusCode, errResp.Error)
+			return 0, &HTTPError{StatusCode: resp.StatusCode, Message: errResp.Error}
 		}
-		return 0, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+		return 0, &HTTPError{StatusCode: resp.StatusCode, Message: string(body)}
 	}
 
 	f, err := os.Create(outputPath)
@@ -373,9 +500,9 @@ func (c *Client) handleResponse(req *http.Request, target any) error {
 			Error string `json:"error"`
 		}
 		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error != "" {
-			return fmt.Errorf("HTTP %d: %s", resp.StatusCode, errResp.Error)
+			return &HTTPError{StatusCode: resp.StatusCode, Message: errResp.Error}
 		}
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+		return &HTTPError{StatusCode: resp.StatusCode, Message: string(respBody)}
 	}
 
 	if target != nil && len(respBody) > 0 {

--- a/internal/db/client.go
+++ b/internal/db/client.go
@@ -285,7 +285,7 @@ func (c *Client) WipeData(ctx context.Context) error {
 
 	// Delete all records from each table
 	// Order matters due to foreign key references
-	tables := []string{"doc_relation", "wiki_link", "chunk", "document", "template", "share_link", "vault_member", "api_token", "vault", "user"}
+	tables := []string{"doc_relation", "wiki_link", "chunk", "document", "template", "share_link", "vault_member", "api_token", "remote", "vault", "user"}
 
 	for _, table := range tables {
 		query := fmt.Sprintf("DELETE %s", table)

--- a/internal/db/queries_remote.go
+++ b/internal/db/queries_remote.go
@@ -1,0 +1,86 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/raphi011/knowhow/internal/models"
+	"github.com/surrealdb/surrealdb.go"
+)
+
+// CreateRemote creates a new remote server configuration.
+func (c *Client) CreateRemote(ctx context.Context, userID string, input models.RemoteInput) (*models.Remote, error) {
+	defer c.logOp(ctx, "remote.create", time.Now())
+
+	sql := `
+		CREATE remote SET
+			name = $name,
+			url = $url,
+			token = $token,
+			created_by = type::record("user", $user_id)
+		RETURN AFTER
+	`
+	results, err := surrealdb.Query[[]models.Remote](ctx, c.DB(), sql, map[string]any{
+		"name":    input.Name,
+		"url":     input.URL,
+		"token":   input.Token,
+		"user_id": bareID("user", userID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create remote: %w", err)
+	}
+	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
+		return nil, fmt.Errorf("create remote: no result returned")
+	}
+	return &(*results)[0].Result[0], nil
+}
+
+// GetRemoteByName returns a remote by its unique name.
+func (c *Client) GetRemoteByName(ctx context.Context, name string) (*models.Remote, error) {
+	defer c.logOp(ctx, "remote.get_by_name", time.Now())
+
+	sql := `SELECT * FROM remote WHERE name = $name LIMIT 1`
+	results, err := surrealdb.Query[[]models.Remote](ctx, c.DB(), sql, map[string]any{
+		"name": name,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get remote by name: %w", err)
+	}
+	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
+		return nil, nil
+	}
+	return &(*results)[0].Result[0], nil
+}
+
+// ListRemotes returns all configured remotes.
+func (c *Client) ListRemotes(ctx context.Context) ([]models.Remote, error) {
+	defer c.logOp(ctx, "remote.list", time.Now())
+
+	sql := `SELECT * FROM remote ORDER BY name ASC`
+	results, err := surrealdb.Query[[]models.Remote](ctx, c.DB(), sql, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list remotes: %w", err)
+	}
+	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
+		return []models.Remote{}, nil
+	}
+	return (*results)[0].Result, nil
+}
+
+// DeleteRemote deletes a remote by name. Returns true if a record was deleted.
+func (c *Client) DeleteRemote(ctx context.Context, name string) (bool, error) {
+	defer c.logOp(ctx, "remote.delete", time.Now())
+
+	sql := `DELETE FROM remote WHERE name = $name RETURN BEFORE`
+	results, err := surrealdb.Query[[]models.Remote](ctx, c.DB(), sql, map[string]any{
+		"name": name,
+	})
+	if err != nil {
+		return false, fmt.Errorf("delete remote: %w", err)
+	}
+	if results == nil || len(*results) == 0 {
+		return false, nil
+	}
+	return len((*results)[0].Result) > 0, nil
+}

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -347,6 +347,20 @@ func SchemaSQL(dimension int) string {
     };
 
     -- ==========================================================================
+    -- REMOTE TABLE (federation: connections to other knowhow servers)
+    -- ==========================================================================
+    DEFINE TABLE IF NOT EXISTS remote SCHEMAFULL;
+
+    DEFINE FIELD IF NOT EXISTS name       ON remote TYPE string;
+    DEFINE FIELD IF NOT EXISTS url        ON remote TYPE string;
+    DEFINE FIELD IF NOT EXISTS token      ON remote TYPE string;
+    DEFINE FIELD IF NOT EXISTS created_by ON remote TYPE record<user>;
+    DEFINE FIELD IF NOT EXISTS created_at ON remote TYPE datetime DEFAULT time::now();
+    DEFINE FIELD IF NOT EXISTS updated_at ON remote TYPE datetime VALUE time::now();
+
+    DEFINE INDEX IF NOT EXISTS idx_remote_name ON remote FIELDS name UNIQUE;
+
+    -- ==========================================================================
     -- ASSET TABLE (binary image storage)
     -- ==========================================================================
     DEFINE TABLE IF NOT EXISTS asset SCHEMAFULL;

--- a/internal/integration/mcp_http_test.go
+++ b/internal/integration/mcp_http_test.go
@@ -34,7 +34,7 @@ func setupMCPServer(t *testing.T, suffix string) (*httptest.Server, string, *doc
 		DocService: docSvc,
 	}
 
-	handler := mcptools.NewHandler(executor, testDB, vaultSvc)
+	handler := mcptools.NewHandler(executor, testDB, vaultSvc, nil)
 	wrappedHandler := auth.NoAuthMiddleware(handler)
 
 	srv := httptest.NewServer(wrappedHandler)

--- a/internal/mcptools/auth.go
+++ b/internal/mcptools/auth.go
@@ -3,12 +3,23 @@ package mcptools
 import (
 	"context"
 	"fmt"
-	"log/slog"
+	"strings"
 
 	"github.com/raphi011/knowhow/internal/auth"
+	"github.com/raphi011/knowhow/internal/logutil"
 	"github.com/raphi011/knowhow/internal/models"
+	"github.com/raphi011/knowhow/internal/remote"
+	"github.com/raphi011/knowhow/internal/tools"
 	"github.com/raphi011/knowhow/internal/vault"
 )
+
+// VaultRef is a resolved vault reference with its executor and namespace.
+type VaultRef struct {
+	VaultID   string             // vault ID (local bare ID or remote server vault ID)
+	Executor  tools.ToolExecutor // local or remote executor
+	Namespace string             // "" for local, "home" for remote
+	IsRemote  bool
+}
 
 // resolveVaultIDs returns the list of vault IDs the caller has access to.
 // In no-auth mode (wildcard access), it fetches all vault IDs from the DB.
@@ -44,10 +55,104 @@ func resolveVaultIDs(ctx context.Context, vaultService *vault.Service) ([]string
 	for _, v := range vaults {
 		id, err := models.RecordIDString(v.ID)
 		if err != nil {
-			slog.Warn("failed to extract vault ID, skipping", "vault_name", v.Name, "error", err)
+			logutil.FromCtx(ctx).Warn("failed to extract vault ID, skipping", "vault_name", v.Name, "error", err)
 			continue
 		}
 		ids = append(ids, id)
 	}
 	return ids, nil
+}
+
+// resolveAllVaults returns VaultRefs for both local and remote vaults.
+// Each ref carries the appropriate executor. Remote vaults are skipped
+// if remoteService is nil or unreachable.
+func (t *mcpTools) resolveAllVaults(ctx context.Context) ([]VaultRef, error) {
+	localIDs, err := resolveVaultIDs(ctx, t.vaultService)
+	if err != nil {
+		return nil, err
+	}
+
+	refs := make([]VaultRef, 0, len(localIDs))
+	for _, id := range localIDs {
+		refs = append(refs, VaultRef{
+			VaultID:  id,
+			Executor: t.executor,
+		})
+	}
+
+	if t.remoteService == nil {
+		return refs, nil
+	}
+
+	remoteVaults, err := t.remoteService.ListRemoteVaults(ctx)
+	if err != nil {
+		logutil.FromCtx(ctx).Warn("failed to list remote vaults, using local only", "error", err)
+		return refs, nil
+	}
+	for _, rv := range remoteVaults {
+		client, err := t.remoteService.ClientFor(ctx, rv.RemoteName)
+		if err != nil {
+			logutil.FromCtx(ctx).Warn("failed to get client for remote, skipping", "remote", rv.RemoteName, "error", err)
+			continue
+		}
+		refs = append(refs, VaultRef{
+			VaultID:   rv.VaultID,
+			Executor:  remote.NewExecutor(client, rv.RemoteName),
+			Namespace: rv.Namespace,
+			IsRemote:  true,
+		})
+	}
+
+	return refs, nil
+}
+
+// resolveWriteVault resolves the target vault for a write operation.
+// If vaultName contains "/" it routes to a remote vault.
+// Otherwise, it uses the first local vault.
+func (t *mcpTools) resolveWriteVault(ctx context.Context, vaultName string) (*VaultRef, error) {
+	if vaultName != "" && strings.Contains(vaultName, "/") {
+		// Remote vault: "home/default" → remote="home", vaultName="default"
+		parts := strings.SplitN(vaultName, "/", 2)
+		remoteName := parts[0]
+
+		if t.remoteService == nil {
+			return nil, fmt.Errorf("remote vaults not configured")
+		}
+
+		client, err := t.remoteService.ClientFor(ctx, remoteName)
+		if err != nil {
+			return nil, fmt.Errorf("resolve remote %q: %w", remoteName, err)
+		}
+
+		// Find the vault ID on the remote by name
+		remoteVaults, err := t.remoteService.ListRemoteVaults(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list remote vaults: %w", err)
+		}
+		for _, rv := range remoteVaults {
+			if rv.Namespace == vaultName {
+				return &VaultRef{
+					VaultID:   rv.VaultID,
+					Executor:  remote.NewExecutor(client, remoteName),
+					Namespace: rv.Namespace,
+					IsRemote:  true,
+				}, nil
+			}
+		}
+		return nil, fmt.Errorf("remote vault %q not found", vaultName)
+	}
+
+	// Local vault
+	vaultIDs, err := resolveVaultIDs(ctx, t.vaultService)
+	if err != nil {
+		return nil, err
+	}
+	if len(vaultIDs) == 0 {
+		return nil, fmt.Errorf("no vaults accessible")
+	}
+
+	return &VaultRef{
+		VaultID:  vaultIDs[0],
+		Executor: t.executor,
+	}, nil
 }

--- a/internal/mcptools/server.go
+++ b/internal/mcptools/server.go
@@ -8,18 +8,21 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/raphi011/knowhow/internal/db"
+	"github.com/raphi011/knowhow/internal/remote"
 	"github.com/raphi011/knowhow/internal/tools"
 	"github.com/raphi011/knowhow/internal/vault"
 )
 
 // NewHandler creates the MCP HTTP handler that serves knowhow tools at the
 // given path. Auth is handled externally via auth.Middleware wrapping this handler.
-func NewHandler(executor *tools.Executor, dbClient *db.Client, vaultService *vault.Service) http.Handler {
+// remoteService may be nil if federation is not configured.
+func NewHandler(executor tools.ToolExecutor, dbClient *db.Client, vaultService *vault.Service, remoteService *remote.Service) http.Handler {
 	t := &mcpTools{
-		executor:     executor,
-		db:           dbClient,
-		vaultService: vaultService,
-		cache:        newCache(60 * time.Second),
+		executor:      executor,
+		db:            dbClient,
+		vaultService:  vaultService,
+		remoteService: remoteService,
+		cache:         newCache(60 * time.Second),
 	}
 
 	server := mcp.NewServer(&mcp.Implementation{

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -5,21 +5,23 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"sort"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/raphi011/knowhow/internal/db"
+	"github.com/raphi011/knowhow/internal/logutil"
+	"github.com/raphi011/knowhow/internal/remote"
 	"github.com/raphi011/knowhow/internal/tools"
 	"github.com/raphi011/knowhow/internal/vault"
 )
 
 type mcpTools struct {
-	executor     *tools.Executor
-	db           *db.Client
-	vaultService *vault.Service
-	cache        *cache
+	executor      tools.ToolExecutor
+	db            *db.Client
+	vaultService  *vault.Service
+	remoteService *remote.Service
+	cache         *cache
 }
 
 func (t *mcpTools) register(server *mcp.Server) {
@@ -117,7 +119,7 @@ func (t *mcpTools) searchDocuments(ctx context.Context, req *mcp.CallToolRequest
 		return errorResult("limit must be positive"), nil, nil
 	}
 
-	vaultIDs, err := resolveVaultIDs(ctx, t.vaultService)
+	refs, err := t.resolveAllVaults(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("search documents: %w", err)
 	}
@@ -128,13 +130,16 @@ func (t *mcpTools) searchDocuments(ctx context.Context, req *mcp.CallToolRequest
 	}
 
 	var sb strings.Builder
-	for _, vaultID := range vaultIDs {
-		result, _, execErr := t.executor.ExecuteTool(ctx, vaultID, "search", string(argsJSON))
+	for _, ref := range refs {
+		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "search", string(argsJSON))
 		if execErr != nil {
-			slog.Warn("search failed", "vault", vaultID, "error", execErr)
+			logutil.FromCtx(ctx).Warn("search failed", "vault", ref.VaultID, "namespace", ref.Namespace, "error", execErr)
 			continue
 		}
 		if result != "" && result != "No results found." {
+			if ref.IsRemote {
+				fmt.Fprintf(&sb, "[%s]\n", ref.Namespace)
+			}
 			sb.WriteString(result)
 		}
 	}
@@ -155,7 +160,7 @@ func (t *mcpTools) getDocument(ctx context.Context, req *mcp.CallToolRequest, in
 		return errorResult("path is required"), nil, nil
 	}
 
-	vaultIDs, err := resolveVaultIDs(ctx, t.vaultService)
+	refs, err := t.resolveAllVaults(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get document: %w", err)
 	}
@@ -165,13 +170,16 @@ func (t *mcpTools) getDocument(ctx context.Context, req *mcp.CallToolRequest, in
 		return nil, nil, fmt.Errorf("marshal args: %w", err)
 	}
 
-	for _, vaultID := range vaultIDs {
-		result, _, execErr := t.executor.ExecuteTool(ctx, vaultID, "read_document", string(argsJSON))
+	for _, ref := range refs {
+		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "read_document", string(argsJSON))
 		if execErr != nil {
-			slog.Warn("get document failed", "vault", vaultID, "path", input.Path, "error", execErr)
+			logutil.FromCtx(ctx).Warn("get document failed", "vault", ref.VaultID, "namespace", ref.Namespace, "path", input.Path, "error", execErr)
 			continue
 		}
 		if !strings.HasPrefix(result, "Document not found:") {
+			if ref.IsRemote {
+				result = fmt.Sprintf("[%s]\n%s", ref.Namespace, result)
+			}
 			return textResult(result), nil, nil
 		}
 	}
@@ -182,19 +190,20 @@ func (t *mcpTools) getDocument(ctx context.Context, req *mcp.CallToolRequest, in
 type listLabelsInput struct{}
 
 func (t *mcpTools) listLabels(ctx context.Context, req *mcp.CallToolRequest, input listLabelsInput) (*mcp.CallToolResult, any, error) {
-	vaultIDs, err := resolveVaultIDs(ctx, t.vaultService)
+	refs, err := t.resolveAllVaults(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list labels: %w", err)
 	}
 
 	labelSet := map[string]bool{}
-	for _, vaultID := range vaultIDs {
-		result, err := t.cache.GetOrFetch("list_labels:"+vaultID, func() (string, error) {
-			r, _, execErr := t.executor.ExecuteTool(ctx, vaultID, "list_labels", "{}")
+	for _, ref := range refs {
+		cacheKey := "list_labels:" + ref.Namespace + ":" + ref.VaultID
+		result, err := t.cache.GetOrFetch(cacheKey, func() (string, error) {
+			r, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "list_labels", "{}")
 			return r, execErr
 		})
 		if err != nil {
-			slog.Warn("list labels failed", "vault", vaultID, "error", err)
+			logutil.FromCtx(ctx).Warn("list labels failed", "vault", ref.VaultID, "namespace", ref.Namespace, "error", err)
 			continue
 		}
 		if result != "No labels found." {
@@ -219,22 +228,26 @@ func (t *mcpTools) listLabels(ctx context.Context, req *mcp.CallToolRequest, inp
 type listFoldersInput struct{}
 
 func (t *mcpTools) listFolders(ctx context.Context, req *mcp.CallToolRequest, input listFoldersInput) (*mcp.CallToolResult, any, error) {
-	vaultIDs, err := resolveVaultIDs(ctx, t.vaultService)
+	refs, err := t.resolveAllVaults(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list folders: %w", err)
 	}
 
 	var sb strings.Builder
-	for _, vaultID := range vaultIDs {
-		result, err := t.cache.GetOrFetch("list_folders:"+vaultID, func() (string, error) {
-			r, _, execErr := t.executor.ExecuteTool(ctx, vaultID, "list_folders", "{}")
+	for _, ref := range refs {
+		cacheKey := "list_folders:" + ref.Namespace + ":" + ref.VaultID
+		result, err := t.cache.GetOrFetch(cacheKey, func() (string, error) {
+			r, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "list_folders", "{}")
 			return r, execErr
 		})
 		if err != nil {
-			slog.Warn("list folders failed", "vault", vaultID, "error", err)
+			logutil.FromCtx(ctx).Warn("list folders failed", "vault", ref.VaultID, "namespace", ref.Namespace, "error", err)
 			continue
 		}
 		if result != "No folders found." {
+			if ref.IsRemote {
+				fmt.Fprintf(&sb, "[%s]\n", ref.Namespace)
+			}
 			sb.WriteString(result)
 		}
 	}
@@ -254,7 +267,7 @@ func (t *mcpTools) listFolderContents(ctx context.Context, req *mcp.CallToolRequ
 		return errorResult("folder is required"), nil, nil
 	}
 
-	vaultIDs, err := resolveVaultIDs(ctx, t.vaultService)
+	refs, err := t.resolveAllVaults(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list folder contents: %w", err)
 	}
@@ -265,13 +278,16 @@ func (t *mcpTools) listFolderContents(ctx context.Context, req *mcp.CallToolRequ
 	}
 
 	var sb strings.Builder
-	for _, vaultID := range vaultIDs {
-		result, _, execErr := t.executor.ExecuteTool(ctx, vaultID, "list_folder_contents", string(argsJSON))
+	for _, ref := range refs {
+		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "list_folder_contents", string(argsJSON))
 		if execErr != nil {
-			slog.Warn("list folder contents failed", "vault", vaultID, "error", execErr)
+			logutil.FromCtx(ctx).Warn("list folder contents failed", "vault", ref.VaultID, "namespace", ref.Namespace, "error", execErr)
 			continue
 		}
 		if !strings.HasPrefix(result, "No contents found") {
+			if ref.IsRemote {
+				fmt.Fprintf(&sb, "[%s]\n", ref.Namespace)
+			}
 			sb.WriteString(result)
 		}
 	}
@@ -295,7 +311,7 @@ func (t *mcpTools) getDocumentVersions(ctx context.Context, req *mcp.CallToolReq
 		return errorResult("limit must be positive"), nil, nil
 	}
 
-	vaultIDs, err := resolveVaultIDs(ctx, t.vaultService)
+	refs, err := t.resolveAllVaults(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get document versions: %w", err)
 	}
@@ -305,13 +321,16 @@ func (t *mcpTools) getDocumentVersions(ctx context.Context, req *mcp.CallToolReq
 		return nil, nil, fmt.Errorf("marshal args: %w", err)
 	}
 
-	for _, vaultID := range vaultIDs {
-		result, _, execErr := t.executor.ExecuteTool(ctx, vaultID, "get_document_versions", string(argsJSON))
+	for _, ref := range refs {
+		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "get_document_versions", string(argsJSON))
 		if execErr != nil {
-			slog.Warn("get document versions failed", "vault", vaultID, "path", input.Path, "error", execErr)
+			logutil.FromCtx(ctx).Warn("get document versions failed", "vault", ref.VaultID, "namespace", ref.Namespace, "path", input.Path, "error", execErr)
 			continue
 		}
 		if !strings.HasPrefix(result, "Document not found:") {
+			if ref.IsRemote {
+				result = fmt.Sprintf("[%s]\n%s", ref.Namespace, result)
+			}
 			return textResult(result), nil, nil
 		}
 	}
@@ -322,14 +341,12 @@ func (t *mcpTools) getDocumentVersions(ctx context.Context, req *mcp.CallToolReq
 // ---------- Write tool handlers (use first vault) ----------
 
 // executeWriteTool resolves vault access, marshals input, and executes a
-// write tool on the first accessible vault.
-func (t *mcpTools) executeWriteTool(ctx context.Context, toolName string, input any) (*mcp.CallToolResult, any, error) {
-	vaultIDs, err := resolveVaultIDs(ctx, t.vaultService)
+// write tool on the target vault. If vaultName contains "/" it routes to
+// a remote vault; otherwise it uses the first local vault.
+func (t *mcpTools) executeWriteTool(ctx context.Context, toolName, vaultName string, input any) (*mcp.CallToolResult, any, error) {
+	ref, err := t.resolveWriteVault(ctx, vaultName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("execute write tool %s: %w", toolName, err)
-	}
-	if len(vaultIDs) == 0 {
-		return nil, nil, fmt.Errorf("no vaults accessible")
 	}
 
 	argsJSON, err := json.Marshal(input)
@@ -337,12 +354,15 @@ func (t *mcpTools) executeWriteTool(ctx context.Context, toolName string, input 
 		return nil, nil, fmt.Errorf("marshal args: %w", err)
 	}
 
-	result, _, execErr := t.executor.ExecuteTool(ctx, vaultIDs[0], toolName, string(argsJSON))
+	result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, toolName, string(argsJSON))
 	if execErr != nil {
 		if isToolLevelError(execErr) {
 			return errorResult(execErr.Error()), nil, nil
 		}
 		return nil, nil, fmt.Errorf("execute write tool %s: %w", toolName, execErr)
+	}
+	if ref.IsRemote {
+		result = fmt.Sprintf("[%s] %s", ref.Namespace, result)
 	}
 	return textResult(result), nil, nil
 }
@@ -351,6 +371,7 @@ type createMemoryInput struct {
 	Title   string   `json:"title" jsonschema:"Memory title"`
 	Content string   `json:"content" jsonschema:"Memory content (markdown)"`
 	Labels  []string `json:"labels,omitempty" jsonschema:"Additional labels (memory label is always added)"`
+	Vault   string   `json:"vault,omitempty" jsonschema:"Target vault (e.g. home/default for remote). Defaults to first local vault."`
 }
 
 func (t *mcpTools) createMemory(ctx context.Context, req *mcp.CallToolRequest, input createMemoryInput) (*mcp.CallToolResult, any, error) {
@@ -360,12 +381,13 @@ func (t *mcpTools) createMemory(ctx context.Context, req *mcp.CallToolRequest, i
 	if strings.TrimSpace(input.Content) == "" {
 		return errorResult("content is required"), nil, nil
 	}
-	return t.executeWriteTool(ctx, "create_memory", input)
+	return t.executeWriteTool(ctx, "create_memory", input.Vault, input)
 }
 
 type createDocumentInput struct {
 	Path    string `json:"path" jsonschema:"Document path (e.g. /guides/new-guide.md)"`
 	Content string `json:"content" jsonschema:"Full markdown content"`
+	Vault   string `json:"vault,omitempty" jsonschema:"Target vault (e.g. home/default for remote). Defaults to first local vault."`
 }
 
 func (t *mcpTools) createDocument(ctx context.Context, req *mcp.CallToolRequest, input createDocumentInput) (*mcp.CallToolResult, any, error) {
@@ -375,13 +397,14 @@ func (t *mcpTools) createDocument(ctx context.Context, req *mcp.CallToolRequest,
 	if strings.TrimSpace(input.Content) == "" {
 		return errorResult("content is required"), nil, nil
 	}
-	return t.executeWriteTool(ctx, "create_document", input)
+	return t.executeWriteTool(ctx, "create_document", input.Vault, input)
 }
 
 type editDocumentInput struct {
 	Path         string  `json:"path" jsonschema:"Document path of the existing document"`
 	Content      string  `json:"content" jsonschema:"Complete new markdown content (replaces existing)"`
 	ExpectedHash *string `json:"expected_hash,omitempty" jsonschema:"Content hash from get_document for optimistic concurrency check"`
+	Vault        string  `json:"vault,omitempty" jsonschema:"Target vault (e.g. home/default for remote). Defaults to first local vault."`
 }
 
 func (t *mcpTools) editDocument(ctx context.Context, req *mcp.CallToolRequest, input editDocumentInput) (*mcp.CallToolResult, any, error) {
@@ -391,7 +414,7 @@ func (t *mcpTools) editDocument(ctx context.Context, req *mcp.CallToolRequest, i
 	if strings.TrimSpace(input.Content) == "" {
 		return errorResult("content is required"), nil, nil
 	}
-	return t.executeWriteTool(ctx, "edit_document", input)
+	return t.executeWriteTool(ctx, "edit_document", input.Vault, input)
 }
 
 type editDocumentSectionInput struct {
@@ -403,6 +426,7 @@ type editDocumentSectionInput struct {
 	NewHeading   *string `json:"new_heading,omitempty" jsonschema:"Heading text for insert/append operations"`
 	NewLevel     *int    `json:"new_level,omitempty" jsonschema:"Heading level 1-6 for insert/append operations"`
 	ExpectedHash *string `json:"expected_hash,omitempty" jsonschema:"Content hash from get_document for optimistic concurrency check"`
+	Vault        string  `json:"vault,omitempty" jsonschema:"Target vault (e.g. home/default for remote). Defaults to first local vault."`
 }
 
 func (t *mcpTools) editDocumentSection(ctx context.Context, req *mcp.CallToolRequest, input editDocumentSectionInput) (*mcp.CallToolResult, any, error) {
@@ -412,7 +436,7 @@ func (t *mcpTools) editDocumentSection(ctx context.Context, req *mcp.CallToolReq
 	if strings.TrimSpace(input.Operation) == "" {
 		return errorResult("operation is required. Use one of: replace, insert_after, insert_before, delete, append"), nil, nil
 	}
-	return t.executeWriteTool(ctx, "edit_document_section", input)
+	return t.executeWriteTool(ctx, "edit_document_section", input.Vault, input)
 }
 
 // ---------- helpers ----------
@@ -429,9 +453,6 @@ func errorResult(text string) *mcp.CallToolResult {
 		IsError: true,
 	}
 }
-
-//go:fix inline
-func boolPtr(b bool) *bool { return new(b) }
 
 // isToolLevelError returns true for executor errors that are user-correctable
 // and should be returned as MCP tool errors (IsError=true) rather than

--- a/internal/models/remote.go
+++ b/internal/models/remote.go
@@ -1,0 +1,25 @@
+package models
+
+import (
+	"time"
+
+	surrealmodels "github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// Remote represents a connection to another knowhow server.
+type Remote struct {
+	ID        surrealmodels.RecordID `json:"id"`
+	Name      string                 `json:"name"`
+	URL       string                 `json:"url"`
+	Token     string                 `json:"token"`
+	CreatedBy surrealmodels.RecordID `json:"created_by"`
+	CreatedAt time.Time              `json:"created_at"`
+	UpdatedAt time.Time              `json:"updated_at"`
+}
+
+// RemoteInput holds the data needed to create or update a remote.
+type RemoteInput struct {
+	Name  string `json:"name"`
+	URL   string `json:"url"`
+	Token string `json:"token"`
+}

--- a/internal/remote/executor.go
+++ b/internal/remote/executor.go
@@ -1,0 +1,346 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/raphi011/knowhow/internal/apiclient"
+	"github.com/raphi011/knowhow/internal/tools"
+)
+
+// Executor implements tools.ToolExecutor by proxying tool calls to a remote
+// knowhow server via its REST API.
+type Executor struct {
+	client     *apiclient.Client
+	remoteName string
+}
+
+// NewExecutor creates a remote executor for the given remote.
+func NewExecutor(client *apiclient.Client, remoteName string) *Executor {
+	return &Executor{client: client, remoteName: remoteName}
+}
+
+// ExecuteTool routes a tool call to the appropriate REST API method on the remote server.
+func (e *Executor) ExecuteTool(ctx context.Context, vaultID, toolName, arguments string) (string, *tools.ToolResultMeta, error) {
+	switch toolName {
+	case "search":
+		return e.execSearch(ctx, vaultID, arguments)
+	case "read_document":
+		return e.execReadDocument(ctx, vaultID, arguments)
+	case "list_labels":
+		return e.execListLabels(ctx, vaultID)
+	case "list_folders":
+		return e.execListFolders(ctx, vaultID, arguments)
+	case "list_folder_contents":
+		return e.execListFolderContents(ctx, vaultID, arguments)
+	case "create_document":
+		return e.execCreateDocument(ctx, vaultID, arguments)
+	case "edit_document":
+		return e.execEditDocument(ctx, vaultID, arguments)
+	case "edit_document_section":
+		return "", nil, &tools.ToolError{
+			Message: "edit_document_section is not supported on remote vaults. Use get_document to read the full content, edit locally, then use edit_document to save.",
+		}
+	case "create_memory":
+		return e.execCreateMemory(ctx, vaultID, arguments)
+	case "get_document_versions":
+		return e.execGetDocumentVersions(ctx, vaultID, arguments)
+	default:
+		return "", nil, fmt.Errorf("unknown tool: %s", toolName)
+	}
+}
+
+func (e *Executor) execSearch(ctx context.Context, vaultID, arguments string) (string, *tools.ToolResultMeta, error) {
+	var input struct {
+		Query string `json:"query"`
+	}
+	if err := json.Unmarshal([]byte(arguments), &input); err != nil {
+		return "", nil, fmt.Errorf("parse search input: %w", err)
+	}
+
+	start := time.Now()
+	results, err := e.client.SearchDocuments(ctx, vaultID, input.Query, 20)
+	durationMs := time.Since(start).Milliseconds()
+	if err != nil {
+		return "", nil, fmt.Errorf("remote search: %w", err)
+	}
+
+	var sb strings.Builder
+	totalChunks := 0
+	for _, r := range results {
+		fmt.Fprintf(&sb, "## %s (%s)\n", r.Title, r.Path)
+		totalChunks += len(r.MatchedChunks)
+		for _, ch := range r.MatchedChunks {
+			sb.WriteString(ch.Snippet)
+			sb.WriteString("\n\n")
+		}
+	}
+
+	result := sb.String()
+	if result == "" {
+		result = "No results found."
+	}
+
+	resultCount := len(results)
+	meta := &tools.ToolResultMeta{
+		DurationMs:  durationMs,
+		ResultCount: &resultCount,
+		ChunkCount:  &totalChunks,
+	}
+	return result, meta, nil
+}
+
+func (e *Executor) execReadDocument(ctx context.Context, vaultID, arguments string) (string, *tools.ToolResultMeta, error) {
+	var input struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(arguments), &input); err != nil {
+		return "", nil, fmt.Errorf("parse read_document input: %w", err)
+	}
+
+	start := time.Now()
+	doc, err := e.client.GetDocument(ctx, vaultID, input.Path)
+	durationMs := time.Since(start).Milliseconds()
+	if err != nil {
+		var httpErr *apiclient.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return fmt.Sprintf("Document not found: %s", input.Path), &tools.ToolResultMeta{DurationMs: durationMs}, nil
+		}
+		return "", nil, fmt.Errorf("remote read document: %w", err)
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# %s\n\n", doc.Title)
+	if doc.ContentHash != nil {
+		fmt.Fprintf(&sb, "Content-Hash: %s\n\n", *doc.ContentHash)
+	}
+	sb.WriteString(doc.Content)
+
+	contentLen := len(doc.Content)
+	meta := &tools.ToolResultMeta{
+		DurationMs:    durationMs,
+		DocumentPath:  &doc.Path,
+		DocumentTitle: &doc.Title,
+		ContentLength: &contentLen,
+	}
+	return sb.String(), meta, nil
+}
+
+func (e *Executor) execListLabels(ctx context.Context, vaultID string) (string, *tools.ToolResultMeta, error) {
+	start := time.Now()
+	labels, err := e.client.ListLabels(ctx, vaultID)
+	durationMs := time.Since(start).Milliseconds()
+	if err != nil {
+		return "", nil, fmt.Errorf("remote list labels: %w", err)
+	}
+
+	result := "No labels found."
+	if len(labels) > 0 {
+		result = strings.Join(labels, ", ")
+	}
+	count := len(labels)
+	meta := &tools.ToolResultMeta{
+		DurationMs:  durationMs,
+		ResultCount: &count,
+	}
+	return result, meta, nil
+}
+
+func (e *Executor) execListFolders(ctx context.Context, vaultID, arguments string) (string, *tools.ToolResultMeta, error) {
+	var input struct {
+		Parent *string `json:"parent"`
+	}
+	if err := json.Unmarshal([]byte(arguments), &input); err != nil {
+		return "", nil, fmt.Errorf("parse list_folders input: %w", err)
+	}
+
+	start := time.Now()
+	folders, err := e.client.ListFolders(ctx, vaultID, input.Parent)
+	durationMs := time.Since(start).Milliseconds()
+	if err != nil {
+		return "", nil, fmt.Errorf("remote list folders: %w", err)
+	}
+
+	var sb strings.Builder
+	for _, f := range folders {
+		fmt.Fprintf(&sb, "%s (%s)\n", f.Path, f.Name)
+	}
+	result := sb.String()
+	if result == "" {
+		result = "No folders found."
+	}
+	count := len(folders)
+	meta := &tools.ToolResultMeta{
+		DurationMs:  durationMs,
+		ResultCount: &count,
+	}
+	return result, meta, nil
+}
+
+func (e *Executor) execListFolderContents(ctx context.Context, vaultID, arguments string) (string, *tools.ToolResultMeta, error) {
+	var input struct {
+		Folder string `json:"folder"`
+	}
+	if err := json.Unmarshal([]byte(arguments), &input); err != nil {
+		return "", nil, fmt.Errorf("parse list_folder_contents input: %w", err)
+	}
+	if input.Folder == "" {
+		return "", nil, fmt.Errorf("folder is required")
+	}
+
+	start := time.Now()
+	entries, err := e.client.ListFiles(ctx, vaultID, input.Folder, false)
+	durationMs := time.Since(start).Milliseconds()
+	if err != nil {
+		return "", nil, fmt.Errorf("remote list folder contents: %w", err)
+	}
+
+	var sb strings.Builder
+	count := 0
+	for _, entry := range entries {
+		if entry.IsDir {
+			fmt.Fprintf(&sb, "📁 %s/\n", entry.Name)
+		} else {
+			fmt.Fprintf(&sb, "📄 %s\n", entry.Path)
+		}
+		count++
+	}
+
+	result := sb.String()
+	if result == "" {
+		result = fmt.Sprintf("No contents found in folder %s", input.Folder)
+	}
+	meta := &tools.ToolResultMeta{
+		DurationMs:  durationMs,
+		ResultCount: &count,
+	}
+	return result, meta, nil
+}
+
+func (e *Executor) execCreateDocument(ctx context.Context, vaultID, arguments string) (string, *tools.ToolResultMeta, error) {
+	return e.execUpsertDocument(ctx, vaultID, arguments, "create")
+}
+
+func (e *Executor) execEditDocument(ctx context.Context, vaultID, arguments string) (string, *tools.ToolResultMeta, error) {
+	return e.execUpsertDocument(ctx, vaultID, arguments, "edit")
+}
+
+func (e *Executor) execUpsertDocument(ctx context.Context, vaultID, arguments, verb string) (string, *tools.ToolResultMeta, error) {
+	var input struct {
+		Path    string `json:"path"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal([]byte(arguments), &input); err != nil {
+		return "", nil, fmt.Errorf("parse %s_document input: %w", verb, err)
+	}
+
+	start := time.Now()
+	doc, err := e.client.CreateDocument(ctx, apiclient.CreateDocumentRequest{
+		VaultID: vaultID,
+		Path:    input.Path,
+		Content: input.Content,
+		Source:  "ai_generated",
+	})
+	durationMs := time.Since(start).Milliseconds()
+	if err != nil {
+		return "", nil, fmt.Errorf("remote %s document: %w", verb, err)
+	}
+
+	pastTense := "created"
+	if verb == "edit" {
+		pastTense = "updated"
+	}
+
+	meta := &tools.ToolResultMeta{
+		DurationMs:    durationMs,
+		DocumentPath:  &doc.Path,
+		DocumentTitle: &doc.Title,
+	}
+	return fmt.Sprintf("Document %s: %s (%s)", pastTense, doc.Title, doc.Path), meta, nil
+}
+
+func (e *Executor) execCreateMemory(ctx context.Context, vaultID, arguments string) (string, *tools.ToolResultMeta, error) {
+	var input struct {
+		Title   string   `json:"title"`
+		Content string   `json:"content"`
+		Labels  []string `json:"labels"`
+	}
+	if err := json.Unmarshal([]byte(arguments), &input); err != nil {
+		return "", nil, fmt.Errorf("parse create_memory input: %w", err)
+	}
+
+	path, fullContent := tools.BuildMemoryDocument(input.Title, input.Content, input.Labels)
+
+	start := time.Now()
+	doc, err := e.client.CreateDocument(ctx, apiclient.CreateDocumentRequest{
+		VaultID: vaultID,
+		Path:    path,
+		Content: fullContent,
+		Source:  "mcp",
+	})
+	durationMs := time.Since(start).Milliseconds()
+	if err != nil {
+		return "", nil, fmt.Errorf("remote create memory: %w", err)
+	}
+
+	meta := &tools.ToolResultMeta{
+		DurationMs:    durationMs,
+		DocumentPath:  &doc.Path,
+		DocumentTitle: &doc.Title,
+	}
+	return fmt.Sprintf("Memory created at %s", doc.Path), meta, nil
+}
+
+func (e *Executor) execGetDocumentVersions(ctx context.Context, vaultID, arguments string) (string, *tools.ToolResultMeta, error) {
+	var input struct {
+		Path  string `json:"path"`
+		Limit *int   `json:"limit"`
+	}
+	if err := json.Unmarshal([]byte(arguments), &input); err != nil {
+		return "", nil, fmt.Errorf("parse get_document_versions input: %w", err)
+	}
+
+	limit := 20
+	if input.Limit != nil && *input.Limit > 0 {
+		limit = *input.Limit
+	}
+
+	start := time.Now()
+	versions, err := e.client.ListVersions(ctx, vaultID, input.Path, limit)
+	durationMs := time.Since(start).Milliseconds()
+	if err != nil {
+		var httpErr *apiclient.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return fmt.Sprintf("Document not found: %s", input.Path), &tools.ToolResultMeta{DurationMs: durationMs}, nil
+		}
+		return "", nil, fmt.Errorf("remote get document versions: %w", err)
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Document: %s\n", input.Path)
+	fmt.Fprintf(&sb, "Total versions: %d\n\n", len(versions))
+
+	if len(versions) == 0 {
+		sb.WriteString("No previous versions.\n")
+	} else {
+		for _, v := range versions {
+			fmt.Fprintf(&sb, "### Version %d\n", v.Version)
+			fmt.Fprintf(&sb, "- Title: %s\n", v.Title)
+			fmt.Fprintf(&sb, "- Created: %s\n", v.CreatedAt.Format(time.RFC3339))
+			fmt.Fprintf(&sb, "- Source: %s\n", v.Source)
+			fmt.Fprintf(&sb, "- Hash: %s\n\n", v.ContentHash)
+		}
+	}
+
+	count := len(versions)
+	meta := &tools.ToolResultMeta{
+		DurationMs:  durationMs,
+		ResultCount: &count,
+	}
+	return sb.String(), meta, nil
+}

--- a/internal/remote/service.go
+++ b/internal/remote/service.go
@@ -1,0 +1,148 @@
+// Package remote manages connections to other knowhow servers for federation.
+package remote
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/raphi011/knowhow/internal/apiclient"
+	"github.com/raphi011/knowhow/internal/db"
+	"github.com/raphi011/knowhow/internal/logutil"
+	"github.com/raphi011/knowhow/internal/models"
+)
+
+// RemoteVault represents a vault on a remote server with its namespaced name.
+type RemoteVault struct {
+	RemoteName string // e.g. "home"
+	VaultID    string // vault ID on the remote server
+	VaultName  string // vault name on the remote server
+	Namespace  string // e.g. "home/default"
+}
+
+// Service manages remote server configurations and clients.
+type Service struct {
+	db      *db.Client
+	clients sync.Map // remoteName -> *apiclient.Client
+
+	cacheMu      sync.RWMutex
+	vaultCache   []RemoteVault
+	cacheExpires time.Time
+}
+
+const vaultCacheTTL = 60 * time.Second
+
+// NewService creates a new remote service.
+func NewService(db *db.Client) *Service {
+	return &Service{db: db}
+}
+
+// Add registers a new remote server.
+func (s *Service) Add(ctx context.Context, userID string, input models.RemoteInput) (*models.Remote, error) {
+	r, err := s.db.CreateRemote(ctx, userID, input)
+	if err != nil {
+		return nil, fmt.Errorf("add remote: %w", err)
+	}
+	// Pre-create the client
+	s.clients.Store(input.Name, apiclient.New(input.URL, input.Token))
+	// Invalidate vault cache
+	s.invalidateCache()
+	return r, nil
+}
+
+// Remove deletes a remote server configuration.
+func (s *Service) Remove(ctx context.Context, name string) error {
+	deleted, err := s.db.DeleteRemote(ctx, name)
+	if err != nil {
+		return fmt.Errorf("remove remote: %w", err)
+	}
+	if !deleted {
+		return fmt.Errorf("remote %q: %w", name, db.ErrNotFound)
+	}
+	s.clients.Delete(name)
+	s.invalidateCache()
+	return nil
+}
+
+// List returns all configured remotes.
+func (s *Service) List(ctx context.Context) ([]models.Remote, error) {
+	return s.db.ListRemotes(ctx)
+}
+
+// ListRemoteVaults discovers vaults on all configured remotes.
+// Results are cached for 60 seconds. Unreachable remotes are skipped with a warning.
+func (s *Service) ListRemoteVaults(ctx context.Context) ([]RemoteVault, error) {
+	s.cacheMu.RLock()
+	if time.Now().Before(s.cacheExpires) && s.vaultCache != nil {
+		cached := s.vaultCache
+		s.cacheMu.RUnlock()
+		return cached, nil
+	}
+	s.cacheMu.RUnlock()
+
+	logger := logutil.FromCtx(ctx)
+
+	remotes, err := s.db.ListRemotes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list remote vaults: %w", err)
+	}
+
+	var result []RemoteVault
+
+	for _, r := range remotes {
+		client := s.clientFor(r.Name, r.URL, r.Token)
+		vaults, err := client.ListVaults(ctx)
+		if err != nil {
+			logger.Warn("remote unreachable, skipping", "remote", r.Name, "url", r.URL, "error", err)
+			continue
+		}
+		for _, v := range vaults {
+			result = append(result, RemoteVault{
+				RemoteName: r.Name,
+				VaultID:    v.ID,
+				VaultName:  v.Name,
+				Namespace:  r.Name + "/" + v.Name,
+			})
+		}
+	}
+
+	s.cacheMu.Lock()
+	s.vaultCache = result
+	s.cacheExpires = time.Now().Add(vaultCacheTTL)
+	s.cacheMu.Unlock()
+
+	return result, nil
+}
+
+// ClientFor returns an apiclient for the named remote.
+// Returns an error if the remote is not configured.
+func (s *Service) ClientFor(ctx context.Context, remoteName string) (*apiclient.Client, error) {
+	if c, ok := s.clients.Load(remoteName); ok {
+		return c.(*apiclient.Client), nil
+	}
+
+	// Lazy-load from DB
+	r, err := s.db.GetRemoteByName(ctx, remoteName)
+	if err != nil {
+		return nil, fmt.Errorf("client for %q: %w", remoteName, err)
+	}
+	if r == nil {
+		return nil, fmt.Errorf("remote %q not found", remoteName)
+	}
+
+	client := s.clientFor(r.Name, r.URL, r.Token)
+	return client, nil
+}
+
+func (s *Service) clientFor(name, url, token string) *apiclient.Client {
+	c, _ := s.clients.LoadOrStore(name, apiclient.New(url, token))
+	return c.(*apiclient.Client)
+}
+
+func (s *Service) invalidateCache() {
+	s.cacheMu.Lock()
+	s.vaultCache = nil
+	s.cacheExpires = time.Time{}
+	s.cacheMu.Unlock()
+}

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -21,6 +21,7 @@ import (
 	"github.com/raphi011/knowhow/internal/event"
 	"github.com/raphi011/knowhow/internal/llm"
 	"github.com/raphi011/knowhow/internal/models"
+	"github.com/raphi011/knowhow/internal/remote"
 	"github.com/raphi011/knowhow/internal/search"
 	"github.com/raphi011/knowhow/internal/template"
 	"github.com/raphi011/knowhow/internal/vault"
@@ -56,6 +57,7 @@ type App struct {
 	searchService            *search.Service
 	templateService          *template.Service
 	agentService             *agent.Service
+	remoteService            *remote.Service
 	bus                      *event.Bus
 	workerCancel             context.CancelFunc // guarded by mu
 	workerDone               chan struct{}      // guarded by mu
@@ -164,9 +166,12 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 
 	assetSvc := asset.NewService(dbClient, bus)
 
+	remoteSvc := remote.NewService(dbClient)
+
 	app := &App{
 		db:                       dbClient,
 		vaultService:             vault.NewService(dbClient),
+		remoteService:            remoteSvc,
 		assetService:             assetSvc,
 		processingWorkerInterval: time.Duration(cfg.ProcessingWorkerInterval) * time.Second,
 		processingWorkerBatch:    cfg.ProcessingWorkerBatch,
@@ -243,6 +248,11 @@ func (a *App) TemplateService() *template.Service {
 // AssetService returns the asset service.
 func (a *App) AssetService() *asset.Service {
 	return a.assetService
+}
+
+// RemoteService returns the remote federation service.
+func (a *App) RemoteService() *remote.Service {
+	return a.remoteService
 }
 
 // NewForTest creates a minimal App for integration tests — no background workers,

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -16,6 +16,12 @@ import (
 	"github.com/raphi011/knowhow/internal/search"
 )
 
+// ToolExecutor defines the interface for executing tools against a vault.
+// Both the local Executor and the remote proxy implement this.
+type ToolExecutor interface {
+	ExecuteTool(ctx context.Context, vaultID, toolName, arguments string) (string, *ToolResultMeta, error)
+}
+
 // Executor runs named tools against a single vault. It is the shared
 // implementation used by both the agent chat and the embedded MCP server.
 type Executor struct {
@@ -458,6 +464,34 @@ func (e *Executor) execEditDocumentSection(ctx context.Context, vaultID, argumen
 	return fmt.Sprintf("Section %s: %q in %s (%s)", opDesc, headingDesc, doc.Title, doc.Path), meta, nil
 }
 
+// BuildMemoryDocument builds a memory document's path and full content (with frontmatter)
+// from a title, body content, and optional labels. The "memory" label is always included.
+func BuildMemoryDocument(title, content string, labels []string) (path, fullContent string) {
+	// Deduplicate and always include "memory"
+	deduped := []string{"memory"}
+	for _, l := range labels {
+		if l != "memory" {
+			deduped = append(deduped, l)
+		}
+	}
+
+	// Build frontmatter
+	var sb strings.Builder
+	sb.WriteString("---\nlabels:\n")
+	for _, l := range deduped {
+		fmt.Fprintf(&sb, "  - %q\n", l)
+	}
+	sb.WriteString("---\n\n")
+	sb.WriteString(content)
+
+	// Generate date-prefixed path
+	slug := Slugify(title)
+	date := time.Now().Format("2006-01-02")
+	path = fmt.Sprintf("/memories/%s-%s.md", date, slug)
+
+	return path, sb.String()
+}
+
 func (e *Executor) execCreateMemory(ctx context.Context, vaultID, arguments string) (string, *ToolResultMeta, error) {
 	var input struct {
 		Title   string   `json:"title"`
@@ -474,33 +508,13 @@ func (e *Executor) execCreateMemory(ctx context.Context, vaultID, arguments stri
 		return "", nil, fmt.Errorf("content is required")
 	}
 
-	// Build labels — always include "memory"
-	labels := []string{"memory"}
-	for _, l := range input.Labels {
-		if l != "memory" {
-			labels = append(labels, l)
-		}
-	}
-
-	// Build frontmatter
-	var content strings.Builder
-	content.WriteString("---\nlabels:\n")
-	for _, l := range labels {
-		fmt.Fprintf(&content, "  - %q\n", l)
-	}
-	content.WriteString("---\n\n")
-	content.WriteString(input.Content)
-
-	// Generate date-prefixed path
-	slug := Slugify(input.Title)
-	date := time.Now().Format("2006-01-02")
-	path := fmt.Sprintf("/memories/%s-%s.md", date, slug)
+	path, fullContent := BuildMemoryDocument(input.Title, input.Content, input.Labels)
 
 	start := time.Now()
 	doc, err := e.DocService.Create(ctx, models.DocumentInput{
 		VaultID: vaultID,
 		Path:    path,
-		Content: content.String(),
+		Content: fullContent,
 		Source:  models.SourceMCP,
 	})
 	durationMs := time.Since(start).Milliseconds()


### PR DESCRIPTION
Allow a local knowhow server to proxy tool operations to remote servers via their REST API. An agent connected to the work server can seamlessly query and edit vaults on the home server as if they were local.

## New Features
- **Remote management**: `knowhow remote add/remove/list` CLI + `POST/GET/DELETE /api/remotes` REST API
- **Namespaced vaults**: remote vaults appear as `home/default`, `home/personal` in vault listings
- **Full read + write**: all MCP tools (search, read, create, edit, versions, labels, folders) work on remote vaults
- **REST API proxy**: local server uses `apiclient` to call remote REST API — remote server needs zero changes
- **Silent degradation**: unreachable remotes are logged and skipped, local results still returned
- **New REST endpoints**: `GET /api/search`, `GET /api/folders`, `GET /api/versions` (benefit local clients too)
- **`vault` field on write tools**: agents can target `home/default` for remote writes

## Breaking Changes
- `mcptools.NewHandler` signature changed (added `*remote.Service` param) — pass `nil` to preserve old behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)