### PR TITLE
fix: security hardening and auth error handling

### DIFF
--- a/cmd/knowhow/cmd_serve.go
+++ b/cmd/knowhow/cmd_serve.go
@@ -79,10 +79,18 @@ func runServe(_ *cobra.Command, _ []string) error {
 	slog.SetDefault(logger)
 
 	port := fmt.Sprintf("%d", servePort)
-	slog.Info("starting knowhow server", "version", version, "port", port)
+
+	// In no-auth mode, bind to localhost only to prevent accidental public exposure.
+	listenHost := ""
+	if serveNoAuth {
+		listenHost = "127.0.0.1"
+		slog.Warn("no-auth mode: binding to localhost only")
+	}
+
+	slog.Info("starting knowhow server", "version", version, "port", port, "host", listenHost)
 
 	// Bind the port early so we fail fast if another instance is still running.
-	ln, err := net.Listen("tcp", ":"+port)
+	ln, err := net.Listen("tcp", listenHost+":"+port)
 	if err != nil {
 		return fmt.Errorf("bind port %s: %w", port, err)
 	}
@@ -207,7 +215,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 	// SSH/SFTP server (optional)
 	var sshSrv *sshd.Server
 	if cfg.SSHEnabled {
-		sshLn, listenErr := net.Listen("tcp", ":"+cfg.SSHPort)
+		sshLn, listenErr := net.Listen("tcp", listenHost+":"+cfg.SSHPort)
 		if listenErr != nil {
 			return fmt.Errorf("bind SSH port %s: %w", cfg.SSHPort, listenErr)
 		}
@@ -233,7 +241,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 	})
 
 	httpServer := &http.Server{
-		Addr:              ":" + port,
+		Addr:              listenHost + ":" + port,
 		Handler:           api.RequestLogMiddleware(mux),
 		ReadHeaderTimeout: 5 * time.Second,
 		IdleTimeout:       120 * time.Second,

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -35,6 +35,7 @@ type bulkResponse struct {
 }
 
 func (s *Server) bulkUpload(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 50*1024*1024) // 50 MB
 	// Use streaming multipart reader to avoid buffering the entire request in memory.
 	reader, err := r.MultipartReader()
 	if err != nil {

--- a/internal/api/conversations.go
+++ b/internal/api/conversations.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -89,8 +90,14 @@ type createConversationRequest struct {
 }
 
 func (s *Server) createConversation(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 64*1024) // 64 KB
 	var body createConversationRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -161,11 +168,17 @@ type renameConversationRequest struct {
 }
 
 func (s *Server) renameConversation(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 64*1024) // 64 KB
 	id := r.PathValue("id")
 	logger := logutil.FromCtx(r.Context())
 
 	var body renameConversationRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/internal/api/documents.go
+++ b/internal/api/documents.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -51,8 +52,14 @@ type upsertDocumentRequest struct {
 }
 
 func (s *Server) upsertDocument(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 5*1024*1024) // 5 MB
 	var body upsertDocumentRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -22,10 +22,19 @@ func GenerateToken() (raw string, hash string, err error) {
 	return raw, hash, nil
 }
 
+// ValidateTokenFormat checks that a raw token has the expected prefix.
+// Use this for fast-rejecting malformed tokens before DB lookups.
+func ValidateTokenFormat(raw string) error {
+	if !strings.HasPrefix(raw, tokenPrefix) {
+		return fmt.Errorf("token must start with %q", tokenPrefix)
+	}
+	return nil
+}
+
 // UseToken validates a caller-supplied raw token and returns its hash.
 func UseToken(raw string) (string, error) {
-	if !strings.HasPrefix(raw, tokenPrefix) {
-		return "", fmt.Errorf("token must start with %q", tokenPrefix)
+	if err := ValidateTokenFormat(raw); err != nil {
+		return "", err
 	}
 	return HashToken(raw), nil
 }

--- a/internal/auth/validate.go
+++ b/internal/auth/validate.go
@@ -2,13 +2,24 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/raphi011/knowhow/internal/db"
 	"github.com/raphi011/knowhow/internal/models"
+)
+
+var (
+	// ErrInvalidToken indicates the token was not found in the database.
+	ErrInvalidToken = errors.New("invalid token")
+	// ErrTokenExpired indicates the token was found but has expired.
+	ErrTokenExpired = errors.New("token expired")
+	// ErrInvalidShareLink indicates the share link was not found in the database.
+	ErrInvalidShareLink = errors.New("invalid share link")
+	// ErrShareLinkExpired indicates the share link was found but has expired.
+	ErrShareLinkExpired = errors.New("share link expired")
 )
 
 // Authenticate validates a raw API token and returns an AuthContext.
@@ -46,7 +57,7 @@ func Authenticate(ctx context.Context, dbClient *db.Client, rawToken string, noA
 
 	// Only fall through to share link if the token was genuinely not found.
 	// DB errors (connectivity, timeouts) should propagate immediately.
-	if !isNotFoundError(err) {
+	if !shouldFallThrough(err) {
 		return AuthContext{}, err
 	}
 
@@ -62,7 +73,12 @@ func Authenticate(ctx context.Context, dbClient *db.Client, rawToken string, noA
 		}, nil
 	}
 
-	// Return the original token error (more informative than share link error)
+	// If the share link was found but expired, that error is more actionable
+	// than the generic "invalid token" from the token lookup path.
+	if errors.Is(shareErr, ErrShareLinkExpired) {
+		return AuthContext{}, shareErr
+	}
+
 	return AuthContext{}, err
 }
 
@@ -85,11 +101,11 @@ func ValidateToken(ctx context.Context, dbClient *db.Client, rawToken string) (*
 		return nil, fmt.Errorf("token lookup: %w", err)
 	}
 	if token == nil {
-		return nil, fmt.Errorf("invalid token")
+		return nil, ErrInvalidToken
 	}
 
 	if token.IsExpired() {
-		return nil, fmt.Errorf("token expired")
+		return nil, ErrTokenExpired
 	}
 
 	tokenID, err := models.RecordIDString(token.ID)
@@ -160,11 +176,11 @@ func ValidateShareLink(ctx context.Context, dbClient *db.Client, rawToken string
 		return nil, fmt.Errorf("share link lookup: %w", err)
 	}
 	if link == nil {
-		return nil, fmt.Errorf("invalid share link")
+		return nil, ErrInvalidShareLink
 	}
 
 	if link.IsExpired() {
-		return nil, fmt.Errorf("share link expired")
+		return nil, ErrShareLinkExpired
 	}
 
 	vaultID, err := models.RecordIDString(link.Vault)
@@ -179,12 +195,10 @@ func ValidateShareLink(ctx context.Context, dbClient *db.Client, rawToken string
 	}, nil
 }
 
-// isNotFoundError returns true if the error indicates a token/link was not found
-// (as opposed to a DB infrastructure error).
-func isNotFoundError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "invalid token") || strings.Contains(msg, "token expired")
+// shouldFallThrough returns true if the token error indicates the token was
+// not found (as opposed to a DB infrastructure error). Used to decide
+// whether to fall through to share link lookup. Expired tokens are a hard
+// failure — the user should re-authenticate, not silently get share link access.
+func shouldFallThrough(err error) bool {
+	return errors.Is(err, ErrInvalidToken)
 }


### PR DESCRIPTION
Harden the server against common attack vectors and improve auth error semantics. No-auth mode now binds to localhost only, request bodies have size limits with proper 413 responses, and token validation uses sentinel errors instead of fragile string matching.

## New Features
- `ValidateTokenFormat` public function for fast-rejecting malformed tokens
- Sentinel errors: `ErrInvalidToken`, `ErrTokenExpired`, `ErrInvalidShareLink`, `ErrShareLinkExpired`
- MaxBytesReader limits: 50 MB (bulk upload), 5 MB (documents), 64 KB (conversations)
- No-auth mode binds to `127.0.0.1` (HTTP + SSH)

## Breaking Changes
- Expired API tokens no longer fall through to share link lookup (hard failure)
- Oversized request bodies now return 413 instead of 400
- `isNotFoundError` renamed to `shouldFallThrough` (internal, unexported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)