### PR TITLE
feat: add image attachment support for vision-capable LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,8 +451,16 @@ Attach local files to your chat messages using `@` followed by a file path. The 
 "What does @main.go do?"
 ```
 
-**Supported**: Text files up to 1MB (source code, markdown, config files, etc.)
-**Not yet supported**: Images, binary files, extensionless filenames (use `@./Makefile` instead of `@Makefile`)
+```bash
+# Attach an image for vision analysis
+"What's shown in this image? @./screenshot.png"
+
+# Mix text and image attachments
+"Explain the architecture in the diagram using the notes @./diagram.png @./notes.md"
+```
+
+**Supported**: Text files up to 1MB (source code, markdown, config files, etc.), images up to 10MB (PNG, JPG, GIF, WebP)
+**Not supported**: Binary files, extensionless filenames (use `@./Makefile` instead of `@Makefile`)
 
 ## Agent Tool Approval (Human-in-the-Loop)
 

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -35,9 +36,14 @@ func (s *Service) HandleChat() http.HandlerFunc {
 			return
 		}
 
-		r.Body = http.MaxBytesReader(w, r.Body, 5*1024*1024) // 5MB max (text file attachments)
+		r.Body = http.MaxBytesReader(w, r.Body, 50*1024*1024) // 50MB max (base64-encoded image attachments)
 		var body chatRequestBody
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				http.Error(w, "request body too large (max 50MB)", http.StatusRequestEntityTooLarge)
+				return
+			}
 			http.Error(w, "invalid request body", http.StatusBadRequest)
 			return
 		}
@@ -62,6 +68,15 @@ func (s *Service) HandleChat() http.HandlerFunc {
 			if att.Type != models.AttachmentTypeText && att.Type != models.AttachmentTypeImage {
 				http.Error(w, fmt.Sprintf("unsupported attachment type: %q", att.Type), http.StatusBadRequest)
 				return
+			}
+			if att.Type == models.AttachmentTypeImage {
+				switch att.MimeType {
+				case "image/png", "image/jpeg", "image/gif", "image/webp":
+					// valid
+				default:
+					http.Error(w, fmt.Sprintf("invalid mime type %q for image attachment %s", att.MimeType, att.Path), http.StatusBadRequest)
+					return
+				}
 			}
 		}
 

--- a/internal/agent/message_test.go
+++ b/internal/agent/message_test.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/cloudwego/eino/schema"
+	"github.com/raphi011/knowhow/internal/models"
+)
+
+func TestBuildUserMessage(t *testing.T) {
+	t.Run("no images returns plain text message", func(t *testing.T) {
+		msg := buildUserMessage("hello", nil)
+		if msg.Role != schema.User {
+			t.Errorf("Role = %v, want %v", msg.Role, schema.User)
+		}
+		if msg.Content != "hello" {
+			t.Errorf("Content = %q, want %q", msg.Content, "hello")
+		}
+		if msg.UserInputMultiContent != nil {
+			t.Error("expected nil UserInputMultiContent for text-only message")
+		}
+	})
+
+	t.Run("with images returns multimodal message", func(t *testing.T) {
+		images := []models.ChatAttachment{
+			{Path: "a.png", Content: "base64data1", MimeType: "image/png", Type: models.AttachmentTypeImage},
+			{Path: "b.jpg", Content: "base64data2", MimeType: "image/jpeg", Type: models.AttachmentTypeImage},
+		}
+		msg := buildUserMessage("describe these", images)
+		if msg.Role != schema.User {
+			t.Errorf("Role = %v, want %v", msg.Role, schema.User)
+		}
+		if msg.Content != "" {
+			t.Errorf("Content = %q, want empty for multimodal message", msg.Content)
+		}
+		parts := msg.UserInputMultiContent
+		if len(parts) != 3 {
+			t.Fatalf("got %d parts, want 3 (1 text + 2 images)", len(parts))
+		}
+
+		// First part is text
+		if parts[0].Type != schema.ChatMessagePartTypeText {
+			t.Errorf("parts[0].Type = %v, want Text", parts[0].Type)
+		}
+		if parts[0].Text != "describe these" {
+			t.Errorf("parts[0].Text = %q, want %q", parts[0].Text, "describe these")
+		}
+
+		// Image parts
+		for i, want := range []struct {
+			mime string
+			b64  string
+		}{
+			{"image/png", "base64data1"},
+			{"image/jpeg", "base64data2"},
+		} {
+			p := parts[i+1]
+			if p.Type != schema.ChatMessagePartTypeImageURL {
+				t.Errorf("parts[%d].Type = %v, want ImageURL", i+1, p.Type)
+			}
+			if p.Image == nil {
+				t.Fatalf("parts[%d].Image is nil", i+1)
+			}
+			if p.Image.MIMEType != want.mime {
+				t.Errorf("parts[%d].MIMEType = %q, want %q", i+1, p.Image.MIMEType, want.mime)
+			}
+			if p.Image.Base64Data == nil || *p.Image.Base64Data != want.b64 {
+				t.Errorf("parts[%d].Base64Data = %v, want %q", i+1, p.Image.Base64Data, want.b64)
+			}
+		}
+	})
+
+	t.Run("each image gets its own base64 pointer", func(t *testing.T) {
+		images := []models.ChatAttachment{
+			{Path: "a.png", Content: "AAA", MimeType: "image/png", Type: models.AttachmentTypeImage},
+			{Path: "b.png", Content: "BBB", MimeType: "image/png", Type: models.AttachmentTypeImage},
+		}
+		msg := buildUserMessage("test", images)
+		parts := msg.UserInputMultiContent
+		if len(parts) != 3 {
+			t.Fatalf("got %d parts, want 3", len(parts))
+		}
+		// Verify distinct pointers with correct values (not sharing the last loop iteration)
+		if *parts[1].Image.Base64Data != "AAA" {
+			t.Errorf("parts[1] base64 = %q, want %q", *parts[1].Image.Base64Data, "AAA")
+		}
+		if *parts[2].Image.Base64Data != "BBB" {
+			t.Errorf("parts[2] base64 = %q, want %q", *parts[2].Image.Base64Data, "BBB")
+		}
+		if parts[1].Image.Base64Data == parts[2].Image.Base64Data {
+			t.Error("image parts share the same Base64Data pointer — loop variable capture bug")
+		}
+	})
+}

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/raphi011/knowhow/internal/diff"
 	"github.com/raphi011/knowhow/internal/document"
 	"github.com/raphi011/knowhow/internal/llm"
+	"github.com/raphi011/knowhow/internal/logutil"
 	"github.com/raphi011/knowhow/internal/models"
 	"github.com/raphi011/knowhow/internal/parser"
 	"github.com/raphi011/knowhow/internal/search"
@@ -402,26 +403,34 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest, emit func(StreamEve
 		}
 	}
 
-	// Inject local file attachments as context
-	if len(req.Attachments) > 0 {
-		var fileContext strings.Builder
-		for _, att := range req.Attachments {
-			switch att.Type {
-			case models.AttachmentTypeText:
-				fmt.Fprintf(&fileContext, "\n--- File: %s ---\n```%s\n%s\n```\n", att.Path, att.Language, att.Content)
-			default:
-				slog.Warn("unsupported attachment type, skipping", "path", att.Path, "type", att.Type)
-			}
-		}
-		if fileContext.Len() > 0 {
-			messages = append(messages,
-				&schema.Message{Role: schema.User, Content: "Attached local files:\n" + fileContext.String()},
-				&schema.Message{Role: schema.Assistant, Content: "I'll use these attached files to help answer your question."},
-			)
+	// Separate text and image attachments
+	var textAtts, imageAtts []models.ChatAttachment
+	for _, att := range req.Attachments {
+		switch att.Type {
+		case models.AttachmentTypeText:
+			textAtts = append(textAtts, att)
+		case models.AttachmentTypeImage:
+			imageAtts = append(imageAtts, att)
+		default:
+			logutil.FromCtx(ctx).Warn("unsupported attachment type, skipping", "path", att.Path, "type", att.Type)
+			emit(StreamEvent{Type: "error", Content: fmt.Sprintf("unsupported attachment type %q for %s, skipping", att.Type, att.Path)})
 		}
 	}
 
-	messages = append(messages, &schema.Message{Role: schema.User, Content: req.Content})
+	// Inject text file attachments as fenced code blocks
+	if len(textAtts) > 0 {
+		var fileContext strings.Builder
+		for _, att := range textAtts {
+			fmt.Fprintf(&fileContext, "\n--- File: %s ---\n```%s\n%s\n```\n", att.Path, att.Language, att.Content)
+		}
+		messages = append(messages,
+			&schema.Message{Role: schema.User, Content: "Attached local files:\n" + fileContext.String()},
+			&schema.Message{Role: schema.Assistant, Content: "I'll use these attached files to help answer your question."},
+		)
+	}
+
+	// Build the final user message — multimodal if image attachments present
+	messages = append(messages, buildUserMessage(req.Content, imageAtts))
 
 	// Track tool calls and results for storage
 	type toolCallRecord struct {
@@ -606,6 +615,36 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest, emit func(StreamEve
 	}
 
 	return nil
+}
+
+// buildUserMessage constructs the final user message. If image attachments are
+// present, it returns a multimodal message with text + image parts; otherwise a
+// plain text message.
+func buildUserMessage(content string, imageAtts []models.ChatAttachment) *schema.Message {
+	if len(imageAtts) == 0 {
+		return &schema.Message{Role: schema.User, Content: content}
+	}
+
+	parts := []schema.MessageInputPart{
+		{Type: schema.ChatMessagePartTypeText, Text: content},
+	}
+	for _, img := range imageAtts {
+		// Copy to a loop-local variable so each part gets its own pointer.
+		b64 := img.Content
+		parts = append(parts, schema.MessageInputPart{
+			Type: schema.ChatMessagePartTypeImageURL,
+			Image: &schema.MessageInputImage{
+				MessagePartCommon: schema.MessagePartCommon{
+					Base64Data: &b64,
+					MIMEType:   img.MimeType,
+				},
+			},
+		})
+	}
+	return &schema.Message{
+		Role:                  schema.User,
+		UserInputMultiContent: parts,
+	}
 }
 
 // agentToolToCanonical maps agent-specific tool names to canonical executor names.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -295,7 +295,7 @@ func (m *Model) sendMessage() tea.Cmd {
 				Content:  att.Content,
 				MimeType: att.MimeType,
 				Language: att.Language,
-				Type:     models.AttachmentTypeText,
+				Type:     toAttachmentType(att.Type),
 			})
 		}
 

--- a/internal/tui/attachment.go
+++ b/internal/tui/attachment.go
@@ -1,11 +1,14 @@
 package tui
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/raphi011/knowhow/internal/models"
 )
 
 // FileType classifies an attachment by content kind.
@@ -32,14 +35,17 @@ func (ft FileType) String() string {
 	}
 }
 
-// 1MB per file. Server-side request limit is 5MB total (see agent/handler.go).
+// 1MB per text file. Server-side request limit is 50MB total (see agent/handler.go).
 const maxAttachmentSize = 1 << 20
+
+// 10MB per image file. Vision APIs accept larger payloads than text.
+const maxImageAttachmentSize = 10 << 20
 
 // Attachment holds a resolved @-reference with its file content.
 type Attachment struct {
 	Path     string   // original path from @-reference
 	AbsPath  string   // resolved absolute path
-	Content  string   // file text content (only for text files)
+	Content  string   // file text (for text files) or base64-encoded data (for images)
 	MimeType string
 	Language string   // code fence language hint (e.g. "go", "python")
 	Type     FileType
@@ -140,24 +146,29 @@ func resolveOne(ref string) Attachment {
 		att.Error = fmt.Sprintf("binary file not supported: %s", ref)
 		return att
 	}
-	if fileType == FileTypeImage {
-		att.Error = fmt.Sprintf("image attachments not yet supported: %s", ref)
-		return att
-	}
-
 	data, err := os.ReadFile(abs)
 	if err != nil {
 		att.Error = fmt.Sprintf("read file: %v", err)
 		return att
 	}
 
-	if int64(len(data)) > maxAttachmentSize {
-		att.Error = fmt.Sprintf("file too large (%d bytes, max %d): %s", len(data), maxAttachmentSize, ref)
+	if len(data) == 0 {
+		att.Error = fmt.Sprintf("file is empty: %s", ref)
 		return att
 	}
 
-	if len(data) == 0 {
-		att.Error = fmt.Sprintf("file is empty: %s", ref)
+	if fileType == FileTypeImage {
+		if int64(len(data)) > maxImageAttachmentSize {
+			att.Error = fmt.Sprintf("file too large (%s, max %s): %s", formatSize(int64(len(data))), formatSize(maxImageAttachmentSize), ref)
+			return att
+		}
+		att.Content = base64.StdEncoding.EncodeToString(data)
+		att.MimeType = mimeForExt(ext)
+		return att
+	}
+
+	if int64(len(data)) > maxAttachmentSize {
+		att.Error = fmt.Sprintf("file too large (%s, max %s): %s", formatSize(int64(len(data))), formatSize(maxAttachmentSize), ref)
 		return att
 	}
 
@@ -198,7 +209,7 @@ func classifyFile(ext string) FileType {
 		".gitignore", ".gitattributes", ".editorconfig",
 		".mod", ".sum", ".lock":
 		return FileTypeText
-	case ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".bmp", ".ico":
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp":
 		return FileTypeImage
 	default:
 		return FileTypeBinary
@@ -260,7 +271,7 @@ func langForExt(ext string) string {
 	return ""
 }
 
-// mimeForExt returns a MIME type for the given extension, defaulting to text/plain.
+// mimeForExt returns a MIME type for the given extension.
 func mimeForExt(ext string) string {
 	switch ext {
 	case ".json":
@@ -275,8 +286,40 @@ func mimeForExt(ext string) string {
 		return "text/javascript"
 	case ".md":
 		return "text/markdown"
+	case ".png":
+		return "image/png"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
 	default:
 		return "text/plain"
+	}
+}
+
+// formatSize returns a human-readable file size (e.g. "1.2 MB", "450 KB").
+func formatSize(bytes int64) string {
+	switch {
+	case bytes >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/float64(1<<20))
+	case bytes >= 1<<10:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/float64(1<<10))
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}
+
+// toAttachmentType converts a TUI FileType to a wire-format AttachmentType.
+func toAttachmentType(ft FileType) models.AttachmentType {
+	switch ft {
+	case FileTypeImage:
+		return models.AttachmentTypeImage
+	case FileTypeText:
+		return models.AttachmentTypeText
+	default:
+		return models.AttachmentTypeText
 	}
 }
 

--- a/internal/tui/attachment_test.go
+++ b/internal/tui/attachment_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"bytes"
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"strings"
@@ -87,7 +89,10 @@ func TestClassifyFile(t *testing.T) {
 		{".jpg", FileTypeImage},
 		{".jpeg", FileTypeImage},
 		{".gif", FileTypeImage},
-		{".svg", FileTypeImage},
+		{".webp", FileTypeImage},
+		{".svg", FileTypeBinary},
+		{".bmp", FileTypeBinary},
+		{".ico", FileTypeBinary},
 		{".exe", FileTypeBinary},
 		{".zip", FileTypeBinary},
 		{".pdf", FileTypeBinary},
@@ -280,7 +285,8 @@ func TestResolveAttachments(t *testing.T) {
 	t.Run("image file", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "photo.png")
-		if err := os.WriteFile(path, []byte("\x89PNG"), 0o644); err != nil {
+		imgData := []byte("\x89PNG\r\n\x1a\nfakedata")
+		if err := os.WriteFile(path, imgData, 0o644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -288,17 +294,71 @@ func TestResolveAttachments(t *testing.T) {
 		if len(atts) != 1 {
 			t.Fatalf("got %d attachments, want 1", len(atts))
 		}
-		if !strings.Contains(atts[0].Error, "image attachments not yet supported") {
-			t.Errorf("expected image error, got: %s", atts[0].Error)
+		att := atts[0]
+		if att.Error != "" {
+			t.Fatalf("unexpected error: %s", att.Error)
 		}
-		if atts[0].Content != "" {
-			t.Error("expected empty content for image file")
+		if att.Content == "" {
+			t.Fatal("expected base64 content for image file")
+		}
+		// Verify base64 round-trip
+		decoded, err := base64.StdEncoding.DecodeString(att.Content)
+		if err != nil {
+			t.Fatalf("Content is not valid base64: %v", err)
+		}
+		if !bytes.Equal(decoded, imgData) {
+			t.Error("base64 decoded content does not match original image data")
+		}
+		if att.MimeType != "image/png" {
+			t.Errorf("MimeType = %q, want %q", att.MimeType, "image/png")
+		}
+		if att.Type != FileTypeImage {
+			t.Errorf("type = %v, want %v", att.Type, FileTypeImage)
+		}
+		if att.Size != int64(len(imgData)) {
+			t.Errorf("Size = %d, want %d", att.Size, len(imgData))
+		}
+	})
+
+	t.Run("oversized image file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "huge.png")
+		data := make([]byte, maxImageAttachmentSize+1)
+		for i := range data {
+			data[i] = 0xFF
+		}
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		atts := resolveAttachments([]string{path})
+		if len(atts) != 1 {
+			t.Fatalf("got %d attachments, want 1", len(atts))
+		}
+		if !strings.Contains(atts[0].Error, "too large") {
+			t.Errorf("expected size error, got: %s", atts[0].Error)
 		}
 	})
 
 	t.Run("empty file", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "empty.go")
+		if err := os.WriteFile(path, []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		atts := resolveAttachments([]string{path})
+		if len(atts) != 1 {
+			t.Fatalf("got %d attachments, want 1", len(atts))
+		}
+		if !strings.Contains(atts[0].Error, "empty") {
+			t.Errorf("expected empty file error, got: %s", atts[0].Error)
+		}
+	})
+
+	t.Run("empty image file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "empty.png")
 		if err := os.WriteFile(path, []byte{}, 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -339,4 +399,50 @@ func TestResolveAttachments(t *testing.T) {
 			t.Errorf("LineCount() = %d, want 3", atts[0].LineCount())
 		}
 	})
+}
+
+func TestMimeForExt_Images(t *testing.T) {
+	tests := []struct {
+		ext  string
+		want string
+	}{
+		{".png", "image/png"},
+		{".jpg", "image/jpeg"},
+		{".jpeg", "image/jpeg"},
+		{".gif", "image/gif"},
+		{".webp", "image/webp"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ext, func(t *testing.T) {
+			got := mimeForExt(tt.ext)
+			if got != tt.want {
+				t.Errorf("mimeForExt(%q) = %q, want %q", tt.ext, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatSize(t *testing.T) {
+	tests := []struct {
+		bytes int64
+		want  string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{10485760, "10.0 MB"},
+		{1572864, "1.5 MB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := formatSize(tt.bytes)
+			if got != tt.want {
+				t.Errorf("formatSize(%d) = %q, want %q", tt.bytes, got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -117,7 +117,12 @@ func renderUserMessage(content string, attachments []Attachment) string {
 	sb.WriteString("\n")
 
 	for _, att := range attachments {
-		line := fmt.Sprintf("  %s (%s, %d lines)", att.Name(), att.Path, att.LineCount())
+		var line string
+		if att.Type == FileTypeImage {
+			line = fmt.Sprintf("  %s (%s, %s)", att.Name(), att.Path, formatSize(att.Size))
+		} else {
+			line = fmt.Sprintf("  %s (%s, %d lines)", att.Name(), att.Path, att.LineCount())
+		}
 		sb.WriteString(attachmentStyle.Render(line))
 		sb.WriteString("\n")
 	}


### PR DESCRIPTION
## Summary

- Enable `@`-referencing image files (PNG, JPG, GIF, WebP) in TUI chat — images are base64-encoded and sent as multimodal messages to vision-capable LLMs
- Add server-side validation: image MIME type checks (400), `MaxBytesError` → 413 instead of generic 400, unsupported attachment types emit user-facing SSE errors
- Extract `buildUserMessage` as a testable pure function with tests for plain text, multimodal, and pointer-aliasing correctness
- Unify `imageMimeForExt` into `mimeForExt`, add `toAttachmentType` converter, consistent `formatSize` usage for error messages

## Test plan

- [x] `just build` succeeds
- [x] `just test` — all tests pass including new tests:
  - `TestBuildUserMessage` (plain text, multimodal, pointer aliasing)
  - `TestMimeForExt_Images` (all supported image MIME types)
  - Image file resolution (base64 round-trip, Size field, MimeType)
  - Empty image file and oversized image file error paths
- [ ] Manual: attach a PNG via `@./screenshot.png` in TUI chat and verify the LLM describes the image
- [ ] Manual: attach multiple images + text files in a single message

🤖 Generated with [Claude Code](https://claude.com/claude-code)