### PR TITLE
feat: drag-and-drop file attachments with editable list

### DIFF
--- a/docs/tui-syntax-highlighting.md
+++ b/docs/tui-syntax-highlighting.md
@@ -1,0 +1,81 @@
+# TUI Per-Token Syntax Highlighting (Archived)
+
+This documents the approach used for per-token `@path` syntax highlighting in the bubbletea v2 text input. The feature was implemented and then replaced with a file list UI, but the techniques are reusable for any per-token coloring in bubbletea.
+
+## Problem
+
+Bubbles v2 `textinput.Model` has no API for per-token styling. The component renders its `View()` as a single styled string with cursor management, padding, and placeholder logic baked in. There's no way to inject custom colors for specific character ranges.
+
+See: [charmbracelet/bubbles#633](https://github.com/charmbracelet/bubbles/issues/633)
+
+Existing solutions like [resterm's RuneStyler fork](https://github.com/unkn0wn-root/resterm) reimplement cursor rendering entirely — heavy and fragile.
+
+## Solution: `lipgloss.StyleRanges()` Overlay
+
+`lipgloss.StyleRanges(s string, ranges ...Range)` (lipgloss v2) applies styles to character ranges in a string, respecting existing ANSI escapes. The key insight: positions are in the **ANSI-stripped** string, so you can overlay colors on top of textinput's already-rendered output without interfering with cursor styling, padding, or placeholder logic.
+
+```go
+// View() — the core pattern
+func (h *HighlightedInput) View() string {
+    base := h.inner.View()               // textinput handles everything
+    if h.inner.Value() == "" { return base }
+    ranges := h.buildStyleRanges(base)    // find tokens, map positions
+    return lipgloss.StyleRanges(base, ranges...)  // paint on top
+}
+```
+
+### Position Mapping
+
+The challenge is converting token positions in the **value string** (full input text) to positions in the **stripped view string** (only the visible window). The formula:
+
+```
+viewPos = promptRuneLen + (tokenRunePos - offset)
+```
+
+Where:
+- `promptRuneLen` = rune length of the prompt in the stripped view (e.g. `"> "` = 2)
+- `offset` = first visible rune index (the scroll position)
+- Tokens must be clamped to `[offset, offsetRight]` before mapping
+
+### Offset Tracking
+
+textinput's `offset` and `offsetRight` fields are **private**, so we replicate the overflow algorithm (~30 lines) to track the visible window. Called after every `Update()` and `SetValue()`/`SetCursor()`.
+
+The algorithm (from `textinput.handleOverflow()`):
+1. If value fits within width → offset=0, offsetRight=len(value)
+2. If cursor moved left of offset → shift window left, compute new offsetRight by measuring rune widths forward
+3. If cursor moved right of offsetRight → shift window right, compute new offset by measuring rune widths backward
+
+Uses `rw.RuneWidth()` from `github.com/mattn/go-runewidth` for character width measurement (handles CJK, emoji, etc).
+
+### Path Validation Cache
+
+`pathCache map[string]bool` caches `os.Stat` results to avoid stat-ing the same path on every `View()` call (which happens on every render frame during typing).
+
+Cache invalidation: on `SetValue()`, diff current `parseAtRefs()` against cache keys and evict entries for paths no longer present.
+
+## Wrapper Pattern
+
+The `HighlightedInput` struct delegates all editing to `textinput.Model` and only intervenes in `View()`:
+
+```go
+type HighlightedInput struct {
+    inner       textinput.Model
+    offset      int              // mirrors textinput's private field
+    offsetRight int
+    pathCache   map[string]bool
+}
+
+// All editing methods delegate directly
+func (h *HighlightedInput) Value() string  { return h.inner.Value() }
+func (h *HighlightedInput) Update(msg) Cmd { /* delegate + sync offsets */ }
+func (h *HighlightedInput) View() string   { /* delegate + overlay colors */ }
+```
+
+This pattern works for any component where you want to add syntax highlighting without forking the upstream component.
+
+## Limitations
+
+- **Prompt length hardcoded**: `promptRuneLen()` returns 2 for `"> "`. Dynamic prompts would need a different approach (e.g. measuring the stripped prefix before the value content).
+- **Offset drift risk**: if upstream changes the overflow algorithm, our replica diverges silently. Tests catch this but it's fragile.
+- **Single-line only**: the offset tracking assumes a single-line textinput. Multi-line (textarea) would need a completely different approach.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -23,8 +23,9 @@ type Model struct {
 	conversationID string
 
 	// Input
-	input   textinput.Model
-	spinner spinner.Model
+	input    textinput.Model
+	fileList FileList
+	spinner  spinner.Model
 
 	// Streaming state
 	streaming       bool
@@ -136,6 +137,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		return m.handleKey(msg)
 
+	case tea.PasteMsg:
+		return m.handlePaste(msg)
+
 	case conversationCreatedMsg:
 		if msg.err != nil {
 			m.errMsg = fmt.Sprintf("Failed to create conversation: %v", msg.err)
@@ -207,6 +211,11 @@ func (m Model) View() tea.View {
 		content.WriteString("\n\n")
 	}
 
+	// File list (above input, only when files are attached)
+	if fl := m.fileList.View(m.width); fl != "" {
+		content.WriteString(fl)
+	}
+
 	// Input always visible
 	content.WriteString(m.input.View())
 	content.WriteString("\n\n")
@@ -232,6 +241,41 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// File list focused — handle navigation and deletion
+	if m.fileList.Focused() {
+		switch msg.String() {
+		case "up":
+			m.fileList.Up()
+			return m, nil
+		case "down":
+			if m.fileList.AtBottom() {
+				m.fileList.Blur()
+				return m, m.input.Focus()
+			}
+			m.fileList.Down()
+			return m, nil
+		case "backspace":
+			m.fileList.RemoveSelected()
+			if !m.fileList.Focused() {
+				// Last item was removed, return to input
+				return m, m.input.Focus()
+			}
+			return m, nil
+		case "escape":
+			m.fileList.Blur()
+			return m, m.input.Focus()
+		default:
+			return m, nil
+		}
+	}
+
+	// Up arrow with files attached → focus file list
+	if msg.String() == "up" && m.fileList.Len() > 0 {
+		m.input.Blur()
+		m.fileList.Focus()
+		return m, nil
+	}
+
 	// ESC clears input text; no-op if already empty
 	if key.Matches(msg, keys.Escape) {
 		if m.input.Value() != "" {
@@ -252,6 +296,23 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// handlePaste adds file paths to the file list or delegates to textinput for normal text.
+func (m Model) handlePaste(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
+	content := strings.TrimSpace(msg.Content)
+
+	if looksLikeFilePath(content) {
+		if reason := m.fileList.Add(content); reason != "" {
+			m.errMsg = reason
+		}
+		return m, nil
+	}
+
+	// Normal paste — delegate to textinput
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	return m, cmd
+}
+
 func (m *Model) createConversation() tea.Cmd {
 	client := m.client
 	ctx := m.ctx
@@ -264,46 +325,43 @@ func (m *Model) createConversation() tea.Cmd {
 
 func (m *Model) sendMessage() tea.Cmd {
 	content := m.input.Value()
-	if content == "" || m.streaming || !m.ready {
+
+	if content == "" && m.fileList.Len() == 0 {
+		return nil
+	}
+	if content == "" {
+		m.errMsg = "message is empty"
+		return nil
+	}
+	if m.streaming || !m.ready {
 		return nil
 	}
 
-	// Parse @-references and resolve local files
-	refs := parseAtRefs(content)
+	// Check for resolution errors before clearing
+	var errs []string
+	for _, att := range m.fileList.files {
+		if att.Error != "" {
+			errs = append(errs, att.Error)
+		}
+	}
+	if len(errs) > 0 {
+		m.errMsg = strings.Join(errs, "; ")
+		return nil
+	}
+
+	// Past the point of no return — clear file list and input
+	files := m.fileList.Clear()
+
+	// Build wire-format attachments
 	var chatAttachments []models.ChatAttachment
-	var resolved []Attachment
-
-	if len(refs) > 0 {
-		resolved = resolveAttachments(refs)
-
-		// Check for errors
-		var errs []string
-		for _, att := range resolved {
-			if att.Error != "" {
-				errs = append(errs, att.Error)
-			}
-		}
-		if len(errs) > 0 {
-			m.errMsg = strings.Join(errs, "; ")
-			return nil
-		}
-
-		// Build wire-format attachments
-		for _, att := range resolved {
-			chatAttachments = append(chatAttachments, models.ChatAttachment{
-				Path:     att.Path,
-				Content:  att.Content,
-				MimeType: att.MimeType,
-				Language: att.Language,
-				Type:     toAttachmentType(att.Type),
-			})
-		}
-
-		content = stripAtRefs(content, refs)
-		if content == "" {
-			m.errMsg = "message is empty after removing @-references"
-			return nil
-		}
+	for _, att := range files {
+		chatAttachments = append(chatAttachments, models.ChatAttachment{
+			Path:     att.Path,
+			Content:  att.Content,
+			MimeType: att.MimeType,
+			Language: att.Language,
+			Type:     toAttachmentType(att.Type),
+		})
 	}
 
 	m.input.SetValue("")
@@ -315,6 +373,7 @@ func (m *Model) sendMessage() tea.Cmd {
 	convID := m.conversationID
 	vaultID := m.vaultID
 	attachments := chatAttachments
+	resolved := files
 
 	startStreamCmd := func() tea.Msg {
 		ch, err := client.Chat(ctx, convID, vaultID, content, attachments, false)

--- a/internal/tui/attachment.go
+++ b/internal/tui/attachment.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/raphi011/knowhow/internal/models"
@@ -41,9 +40,9 @@ const maxAttachmentSize = 1 << 20
 // 10MB per image file. Vision APIs accept larger payloads than text.
 const maxImageAttachmentSize = 10 << 20
 
-// Attachment holds a resolved @-reference with its file content.
+// Attachment holds a resolved file reference with its content.
 type Attachment struct {
-	Path     string   // original path from @-reference
+	Path     string   // original path as provided (before resolution)
 	AbsPath  string   // resolved absolute path
 	Content  string   // file text (for text files) or base64-encoded data (for images)
 	MimeType string
@@ -69,36 +68,6 @@ func (a Attachment) LineCount() int {
 		n++
 	}
 	return n
-}
-
-// atRefRegex matches @-prefixed file paths. Supports:
-// - relative: @./foo.go, @../bar/baz.py
-// - absolute: @/usr/local/file.txt
-// - tilde: @~/Documents/notes.md
-// - bare: @file.go (must contain a dot to avoid matching @mentions)
-//
-// Paths with spaces or unicode are not matched; use a relative path
-// like @./path\ with\ spaces. Extensionless filenames (e.g. @Makefile)
-// are not matched; use @./Makefile instead.
-//
-// The regex requires @ to be preceded by start-of-string or whitespace
-// to avoid matching email-like patterns (e.g. user@config.yaml).
-var atRefRegex = regexp.MustCompile(`(?:^|\s)@((?:\.\.?/[\w./_\-]+)|(?:~/[\w./_\-]+)|(?:/[\w./_\-]+)|(?:[\w.\-]+\.[\w]+))`)
-
-// parseAtRefs extracts @-prefixed file paths from input text.
-func parseAtRefs(input string) []string {
-	matches := atRefRegex.FindAllStringSubmatch(input, -1)
-	seen := make(map[string]struct{}, len(matches))
-	var refs []string
-	for _, m := range matches {
-		ref := m[1]
-		if _, ok := seen[ref]; ok {
-			continue
-		}
-		seen[ref] = struct{}{}
-		refs = append(refs, ref)
-	}
-	return refs
 }
 
 // resolveAttachments expands paths, reads files, and classifies them.
@@ -323,13 +292,15 @@ func toAttachmentType(ft FileType) models.AttachmentType {
 	}
 }
 
-// stripAtRefs removes @path tokens from input, cleaning up extra whitespace.
-func stripAtRefs(input string, refs []string) string {
-	result := input
-	for _, ref := range refs {
-		result = strings.ReplaceAll(result, "@"+ref, "")
+// looksLikeFilePath returns true if the string appears to be a filesystem path
+// (single-line, starts with /, ~/, ./, or ../).
+func looksLikeFilePath(s string) bool {
+	if strings.Contains(s, "\n") {
+		return false
 	}
-	// Collapse multiple spaces into one and trim
-	result = strings.Join(strings.Fields(result), " ")
-	return result
+	return strings.HasPrefix(s, "/") ||
+		strings.HasPrefix(s, "~/") ||
+		strings.HasPrefix(s, "./") ||
+		strings.HasPrefix(s, "../")
 }
+

--- a/internal/tui/attachment_test.go
+++ b/internal/tui/attachment_test.go
@@ -9,63 +9,29 @@ import (
 	"testing"
 )
 
-func TestParseAtRefs(t *testing.T) {
+func TestLooksLikeFilePath(t *testing.T) {
 	tests := []struct {
-		name  string
 		input string
-		want  []string
+		want  bool
 	}{
-		{"no refs", "hello world", nil},
-		{"single relative", "explain @./main.go", []string{"./main.go"}},
-		{"single absolute", "read @/etc/hosts please", []string{"/etc/hosts"}},
-		{"tilde path", "check @~/Documents/notes.md", []string{"~/Documents/notes.md"}},
-		{"multiple refs", "@./a.go @./b.go compare", []string{"./a.go", "./b.go"}},
-		{"duplicate refs", "@./a.go @./a.go", []string{"./a.go"}},
-		{"bare file with dot", "review @main.go", []string{"main.go"}},
-		{"path with hyphens", "@./my-file.ts ok", []string{"./my-file.ts"}},
-		{"path with dots", "@./dir.name/file.ext", []string{"./dir.name/file.ext"}},
-		{"nested path", "@./internal/tui/app.go", []string{"./internal/tui/app.go"}},
-		{"parent path", "@../other/file.py", []string{"../other/file.py"}},
-		{"no match for @mention", "hey @john how are you", nil},
-		{"no match for email", "email admin@config.yaml", nil},
-		{"path with space stops at space", "check @./my file.go", []string{"./my"}},
+		{"/Users/me/file.md", true},
+		{"~/Documents/notes.md", true},
+		{"./relative/path.md", true},
+		{"../parent/path.md", true},
+		{"/", true},
+		{"~/", true},
+		{"some random text", false},
+		{"main.go", false},
+		{"", false},
+		{"/path/one\n/path/two", false},
+		{"http://example.com", false},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := parseAtRefs(tt.input)
-			if len(got) != len(tt.want) {
-				t.Fatalf("parseAtRefs(%q) = %v, want %v", tt.input, got, tt.want)
-			}
-			for i, g := range got {
-				if g != tt.want[i] {
-					t.Errorf("parseAtRefs(%q)[%d] = %q, want %q", tt.input, i, g, tt.want[i])
-				}
-			}
-		})
-	}
-}
-
-func TestStripAtRefs(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		refs  []string
-		want  string
-	}{
-		{"single ref", "explain @./main.go please", []string{"./main.go"}, "explain please"},
-		{"multiple refs", "@./a.go @./b.go compare these", []string{"./a.go", "./b.go"}, "compare these"},
-		{"no refs", "hello world", nil, "hello world"},
-		{"ref at end", "review @./file.go", []string{"./file.go"}, "review"},
-		{"ref at start", "@./file.go explain", []string{"./file.go"}, "explain"},
-		{"only refs", "@./file.go", []string{"./file.go"}, ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := stripAtRefs(tt.input, tt.refs)
+		t.Run(tt.input, func(t *testing.T) {
+			got := looksLikeFilePath(tt.input)
 			if got != tt.want {
-				t.Errorf("stripAtRefs(%q, %v) = %q, want %q", tt.input, tt.refs, got, tt.want)
+				t.Errorf("looksLikeFilePath(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/internal/tui/filelist.go
+++ b/internal/tui/filelist.go
@@ -1,0 +1,167 @@
+package tui
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// acceptedExtensions lists file types that can be attached via drag-and-drop.
+// This gate applies only to the drag-and-drop entry point; resolveOne() itself
+// accepts all text/image types from classifyFile().
+var acceptedExtensions = map[string]bool{
+	".md": true, ".png": true, ".jpg": true, ".jpeg": true, ".gif": true, ".webp": true,
+}
+
+// FileList manages a list of file attachments above the text input.
+// Files are added via drag-and-drop (paste) and can be removed with
+// keyboard navigation.
+//
+// Focus state is represented by the selected field alone:
+// selected >= 0 means focused at that index, -1 means not focused.
+type FileList struct {
+	files    []Attachment
+	selected int // >= 0: focused at index, -1: not focused
+}
+
+// Add resolves a file path and appends it to the list.
+// Returns a user-visible rejection reason, or "" on success.
+// Duplicate paths are silently ignored (returns "").
+func (fl *FileList) Add(path string) string {
+	path = strings.TrimSpace(path)
+
+	ext := strings.ToLower(filepath.Ext(path))
+	if !acceptedExtensions[ext] {
+		return fmt.Sprintf("unsupported file type %s (accepted: .md, .png, .jpg, .jpeg, .gif, .webp)", ext)
+	}
+
+	att := resolveOne(path)
+
+	// Ignore duplicates (only when AbsPath was successfully resolved)
+	if att.AbsPath != "" {
+		for _, existing := range fl.files {
+			if existing.AbsPath == att.AbsPath {
+				return ""
+			}
+		}
+	}
+
+	fl.files = append(fl.files, att)
+	return ""
+}
+
+// Remove deletes the file at the given index and adjusts selection.
+func (fl *FileList) Remove(index int) {
+	if index < 0 || index >= len(fl.files) {
+		return
+	}
+	fl.files = append(fl.files[:index], fl.files[index+1:]...)
+
+	if len(fl.files) == 0 {
+		fl.selected = -1
+		return
+	}
+	if fl.selected >= len(fl.files) {
+		fl.selected = len(fl.files) - 1
+	}
+}
+
+// RemoveSelected deletes the currently selected file.
+// No-op if the list is not focused.
+func (fl *FileList) RemoveSelected() {
+	if fl.selected < 0 {
+		return
+	}
+	fl.Remove(fl.selected)
+}
+
+// Clear returns all files and empties the list.
+func (fl *FileList) Clear() []Attachment {
+	files := fl.files
+	fl.files = nil
+	fl.selected = -1
+	return files
+}
+
+// Focus activates keyboard navigation on the file list,
+// selecting the last item (closest to the input).
+func (fl *FileList) Focus() {
+	if len(fl.files) == 0 {
+		return
+	}
+	fl.selected = len(fl.files) - 1
+}
+
+// Blur deactivates keyboard navigation.
+func (fl *FileList) Blur() {
+	fl.selected = -1
+}
+
+// Focused returns whether the file list has keyboard focus.
+func (fl *FileList) Focused() bool { return fl.selected >= 0 && len(fl.files) > 0 }
+
+// Len returns the number of attached files.
+func (fl *FileList) Len() int { return len(fl.files) }
+
+// AtBottom returns true if the selection is on the last item.
+func (fl *FileList) AtBottom() bool {
+	return fl.selected >= 0 && fl.selected == len(fl.files)-1
+}
+
+// Up moves selection towards the first item (clamped).
+func (fl *FileList) Up() {
+	if fl.selected <= 0 {
+		return
+	}
+	fl.selected--
+}
+
+// Down moves selection towards the last item (clamped).
+func (fl *FileList) Down() {
+	if fl.selected < 0 || fl.selected >= len(fl.files)-1 {
+		return
+	}
+	fl.selected++
+}
+
+// View renders the file list. Returns empty string when no files are attached.
+func (fl *FileList) View(width int) string {
+	if len(fl.files) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	for i, att := range fl.files {
+		label := formatFileLabel(att)
+		marker := "[x]"
+
+		// Right-align the [x] marker
+		// 6 = PaddingLeft(2) + len("[x]") + 1 space
+		padding := width - 6 - len([]rune(label)) - len(marker)
+		if padding < 1 {
+			padding = 1
+		}
+		line := label + strings.Repeat(" ", padding) + marker
+
+		if fl.selected >= 0 && i == fl.selected {
+			sb.WriteString(fileListSelectedStyle.Render(line))
+		} else {
+			sb.WriteString(fileListItemStyle.Render(line))
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// formatFileLabel returns a display string like "notes.md (42 lines)" or "screenshot.png (1.2 MB)".
+func formatFileLabel(att Attachment) string {
+	name := att.Name()
+	if att.Error != "" {
+		return fmt.Sprintf("%s (error: %s)", name, att.Error)
+	}
+	if att.Type == FileTypeImage {
+		return fmt.Sprintf("%s (%s)", name, formatSize(att.Size))
+	}
+	return fmt.Sprintf("%s (%d lines)", name, att.LineCount())
+}

--- a/internal/tui/filelist_test.go
+++ b/internal/tui/filelist_test.go
@@ -1,0 +1,318 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFileList_Add_AcceptedExtensions(t *testing.T) {
+	dir := t.TempDir()
+
+	mdFile := filepath.Join(dir, "notes.md")
+	os.WriteFile(mdFile, []byte("# Notes\nSome content\n"), 0o644)
+	pngFile := filepath.Join(dir, "img.png")
+	os.WriteFile(pngFile, []byte("fakepng"), 0o644)
+
+	fl := &FileList{}
+	if reason := fl.Add(mdFile); reason != "" {
+		t.Fatalf("unexpected rejection: %s", reason)
+	}
+	if reason := fl.Add(pngFile); reason != "" {
+		t.Fatalf("unexpected rejection: %s", reason)
+	}
+
+	if fl.Len() != 2 {
+		t.Fatalf("expected 2 files, got %d", fl.Len())
+	}
+	if fl.files[0].Name() != "notes.md" {
+		t.Errorf("first file = %s, want notes.md", fl.files[0].Name())
+	}
+	if fl.files[1].Name() != "img.png" {
+		t.Errorf("second file = %s, want img.png", fl.files[1].Name())
+	}
+}
+
+func TestFileList_Add_RejectedExtensions(t *testing.T) {
+	dir := t.TempDir()
+
+	goFile := filepath.Join(dir, "main.go")
+	os.WriteFile(goFile, []byte("package main"), 0o644)
+	zipFile := filepath.Join(dir, "archive.zip")
+	os.WriteFile(zipFile, []byte("fakearchive"), 0o644)
+
+	fl := &FileList{}
+
+	if reason := fl.Add(goFile); reason == "" {
+		t.Error("expected rejection for .go file")
+	} else if !strings.Contains(reason, ".go") {
+		t.Errorf("rejection should mention .go, got: %s", reason)
+	}
+
+	if reason := fl.Add(zipFile); reason == "" {
+		t.Error("expected rejection for .zip file")
+	}
+
+	if fl.Len() != 0 {
+		t.Errorf("expected 0 files (rejected extensions), got %d", fl.Len())
+	}
+}
+
+func TestFileList_Add_Duplicate(t *testing.T) {
+	dir := t.TempDir()
+	mdFile := filepath.Join(dir, "notes.md")
+	os.WriteFile(mdFile, []byte("# Notes\n"), 0o644)
+
+	fl := &FileList{}
+	fl.Add(mdFile)
+	fl.Add(mdFile)
+
+	if fl.Len() != 1 {
+		t.Errorf("expected 1 file (duplicate ignored), got %d", fl.Len())
+	}
+}
+
+func TestFileList_Add_WhitespacePadding(t *testing.T) {
+	dir := t.TempDir()
+	mdFile := filepath.Join(dir, "notes.md")
+	os.WriteFile(mdFile, []byte("# Notes\n"), 0o644)
+
+	fl := &FileList{}
+	fl.Add("  " + mdFile + "  ")
+
+	if fl.Len() != 1 {
+		t.Fatalf("expected 1 file after trimmed add, got %d", fl.Len())
+	}
+}
+
+func TestFileList_Remove(t *testing.T) {
+	fl := &FileList{
+		files: []Attachment{
+			{Path: "a.md", AbsPath: "/a.md"},
+			{Path: "b.md", AbsPath: "/b.md"},
+			{Path: "c.md", AbsPath: "/c.md"},
+		},
+		selected: 2,
+	}
+
+	fl.Remove(1)
+
+	if fl.Len() != 2 {
+		t.Fatalf("expected 2 files after removal, got %d", fl.Len())
+	}
+	if fl.files[1].Path != "c.md" {
+		t.Errorf("second file should be c.md, got %s", fl.files[1].Path)
+	}
+	// Selected was 2, now there are only 2 items (0,1), so selected should clamp to 1
+	if fl.selected != 1 {
+		t.Errorf("selected = %d, want 1", fl.selected)
+	}
+}
+
+func TestFileList_Remove_LastItem(t *testing.T) {
+	fl := &FileList{
+		files:    []Attachment{{Path: "a.md", AbsPath: "/a.md"}},
+		selected: 0,
+	}
+
+	fl.Remove(0)
+
+	if fl.Len() != 0 {
+		t.Errorf("expected 0 files, got %d", fl.Len())
+	}
+	if fl.Focused() {
+		t.Error("should not be focused after removing last item")
+	}
+}
+
+func TestFileList_Remove_OutOfBounds(t *testing.T) {
+	fl := &FileList{
+		files:    []Attachment{{Path: "a.md", AbsPath: "/a.md"}},
+		selected: 0,
+	}
+
+	fl.Remove(-1)
+	fl.Remove(5)
+
+	if fl.Len() != 1 {
+		t.Errorf("out-of-bounds Remove should be no-op, got %d files", fl.Len())
+	}
+}
+
+func TestFileList_RemoveSelected(t *testing.T) {
+	fl := &FileList{
+		files: []Attachment{
+			{Path: "a.md", AbsPath: "/a.md"},
+			{Path: "b.md", AbsPath: "/b.md"},
+		},
+		selected: 1,
+	}
+
+	fl.RemoveSelected()
+
+	if fl.Len() != 1 {
+		t.Fatalf("expected 1 file after RemoveSelected, got %d", fl.Len())
+	}
+	if fl.files[0].Path != "a.md" {
+		t.Errorf("remaining file should be a.md, got %s", fl.files[0].Path)
+	}
+}
+
+func TestFileList_RemoveSelected_NotFocused(t *testing.T) {
+	fl := &FileList{
+		files:    []Attachment{{Path: "a.md", AbsPath: "/a.md"}},
+		selected: -1,
+	}
+
+	fl.RemoveSelected()
+
+	if fl.Len() != 1 {
+		t.Error("RemoveSelected when not focused should be no-op")
+	}
+}
+
+func TestFileList_Clear(t *testing.T) {
+	fl := &FileList{
+		files: []Attachment{
+			{Path: "a.md", AbsPath: "/a.md"},
+			{Path: "b.md", AbsPath: "/b.md"},
+		},
+		selected: 1,
+	}
+
+	files := fl.Clear()
+	if len(files) != 2 {
+		t.Fatalf("Clear should return 2 files, got %d", len(files))
+	}
+	if fl.Len() != 0 {
+		t.Error("list should be empty after Clear")
+	}
+	if fl.Focused() {
+		t.Error("should not be focused after Clear")
+	}
+}
+
+func TestFileList_Navigation(t *testing.T) {
+	fl := &FileList{
+		files: []Attachment{
+			{Path: "a.md", AbsPath: "/a.md"},
+			{Path: "b.md", AbsPath: "/b.md"},
+			{Path: "c.md", AbsPath: "/c.md"},
+		},
+	}
+
+	fl.Focus()
+	if fl.selected != 2 {
+		t.Errorf("Focus should select last item (2), got %d", fl.selected)
+	}
+
+	// Up from last
+	fl.Up()
+	if fl.selected != 1 {
+		t.Errorf("Up: selected = %d, want 1", fl.selected)
+	}
+
+	// Up again
+	fl.Up()
+	if fl.selected != 0 {
+		t.Errorf("Up: selected = %d, want 0", fl.selected)
+	}
+
+	// Up at top — should clamp
+	fl.Up()
+	if fl.selected != 0 {
+		t.Errorf("Up at top: selected = %d, want 0 (clamped)", fl.selected)
+	}
+
+	// Down
+	fl.Down()
+	if fl.selected != 1 {
+		t.Errorf("Down: selected = %d, want 1", fl.selected)
+	}
+
+	// Down to last
+	fl.Down()
+	if !fl.AtBottom() {
+		t.Error("should be at bottom")
+	}
+
+	// Down at bottom — should clamp
+	fl.Down()
+	if fl.selected != 2 {
+		t.Errorf("Down at bottom: selected = %d, want 2 (clamped)", fl.selected)
+	}
+}
+
+func TestFileList_Navigation_NotFocused(t *testing.T) {
+	fl := &FileList{
+		files: []Attachment{
+			{Path: "a.md", AbsPath: "/a.md"},
+			{Path: "b.md", AbsPath: "/b.md"},
+		},
+		selected: -1,
+	}
+
+	fl.Up()
+	fl.Down()
+
+	if fl.Focused() {
+		t.Error("Up/Down on blurred list should not change focus state")
+	}
+}
+
+func TestFileList_AtBottom_Empty(t *testing.T) {
+	fl := &FileList{}
+	if fl.AtBottom() {
+		t.Error("AtBottom should be false for empty list")
+	}
+}
+
+func TestFileList_AtBottom_NotFocused(t *testing.T) {
+	fl := &FileList{
+		files:    []Attachment{{Path: "a.md", AbsPath: "/a.md"}},
+		selected: -1,
+	}
+	if fl.AtBottom() {
+		t.Error("AtBottom should be false when not focused")
+	}
+}
+
+func TestFileList_View(t *testing.T) {
+	fl := &FileList{
+		files: []Attachment{
+			{Path: "notes.md", AbsPath: "/notes.md", Type: FileTypeText, Content: "line1\nline2\nline3\n"},
+			{Path: "img.png", AbsPath: "/img.png", Type: FileTypeImage, Size: 1536},
+		},
+		selected: 0,
+	}
+
+	view := fl.View(60)
+	if view == "" {
+		t.Fatal("view should not be empty")
+	}
+	if !strings.Contains(view, "notes.md") {
+		t.Error("view should contain notes.md")
+	}
+	if !strings.Contains(view, "img.png") {
+		t.Error("view should contain img.png")
+	}
+	if !strings.Contains(view, "[x]") {
+		t.Error("view should contain [x] markers")
+	}
+}
+
+func TestFileList_View_Empty(t *testing.T) {
+	fl := &FileList{}
+	if fl.View(80) != "" {
+		t.Error("empty file list should return empty view")
+	}
+}
+
+func TestFileList_FocusEmpty(t *testing.T) {
+	fl := &FileList{}
+	fl.Focus()
+	if fl.Focused() {
+		t.Error("should not be able to focus empty list")
+	}
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -68,4 +68,8 @@ var (
 	attachmentStyle = lipgloss.NewStyle().
 			Foreground(mutedColor).
 			PaddingLeft(2)
+
+	// File list styles (drag-and-drop attachments above input)
+	fileListItemStyle     = lipgloss.NewStyle().Foreground(mutedColor).PaddingLeft(2)
+	fileListSelectedStyle = lipgloss.NewStyle().Foreground(primaryColor).Bold(true).PaddingLeft(2)
 )


### PR DESCRIPTION
## Summary

- Replace inline @-reference system (syntax highlighting, tab-completion, regex parsing) with drag-and-drop file list above the prompt
- Files attached by dragging from Finder onto the terminal (bracketed paste)
- Only markdown (.md) and image files (.png, .jpg, .jpeg, .gif, .webp) accepted; others silently ignored
- File list supports keyboard navigation: Up from input enters list, Down from last item returns to input, Backspace removes selected file
- Documented the `lipgloss.StyleRanges()` overlay technique in `docs/tui-syntax-highlighting.md` before removing the code

## Test plan

- [ ] `just build` compiles cleanly
- [ ] `just test` — all tests pass
- [ ] Drag a `.md` file from Finder → appears in file list above prompt
- [ ] Drag a `.png` file → appears in file list
- [ ] Drag a `.go` file → silently ignored
- [ ] Press Up → focus moves to file list (selected item highlighted)
- [ ] Press Backspace → selected file removed from list
- [ ] Press Down from last item → returns focus to text input
- [ ] Type message + Enter with files attached → sends with attachments, list clears
- [ ] Paste normal text → inserted into input as text (not treated as file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)