### PR TITLE
fix: prevent TUI from clearing terminal output on startup

### DIFF
--- a/cmd/knowhow/cmd_agent.go
+++ b/cmd/knowhow/cmd_agent.go
@@ -46,6 +46,10 @@ func runAgent(_ *cobra.Command, _ []string) error {
 	// bubbletea is running.
 	isDark := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
 
+	// Print banner before bubbletea starts — tea.Println inside the program
+	// would clear all previous terminal output in inline mode.
+	fmt.Println(tui.Banner())
+
 	client := tui.NewClient(agentAPI.URL, agentAPI.Token)
 	model := tui.NewModel(client, *agentVaultID, isDark)
 	defer model.Close()

--- a/docs/bubbletea.md
+++ b/docs/bubbletea.md
@@ -553,6 +553,38 @@ No viewport component needed — terminal scrollback handles history.
 - Very long streaming responses grow the managed region toward terminal height; top lines are dropped if it exceeds
 - Inline mode cursor sits at end of managed region by default; set `View.Cursor` explicitly for text input positioning
 
+### `tea.Println` Clears Previous Terminal Output
+
+**Critical**: `tea.Println` wipes all terminal content above the managed region on its first call. This means any startup banner or welcome message printed via `tea.Println` will destroy the user's previous terminal scrollback.
+
+**Rule**: Never use `tea.Println` during initialization (Init or early Cmd results). Print any startup content with `fmt.Println` **before** calling `p.Run()`.
+
+```go
+// BAD — tea.Println in Init or early handler eats all previous output
+func (m model) Init() tea.Cmd {
+    return tea.Println("Welcome!")  // wipes terminal
+}
+
+// BAD — tea.Println in async init result also eats everything
+case initDoneMsg:
+    return m, tea.Println("Ready!")  // wipes terminal
+
+// GOOD — print before bubbletea starts
+func main() {
+    fmt.Println(banner())           // safe: before p.Run()
+    p := tea.NewProgram(model{})
+    p.Run()
+}
+```
+
+`tea.Println` is safe to use **during interaction** (e.g. committing chat messages to scrollback) — at that point the scrollback is TUI content, not previous terminal output.
+
+### Multi-Line Views Eat Terminal Lines
+
+Each line in `View()` output costs one line of previous terminal scrollback on startup — bubbletea scrolls the terminal to make room. A 3-line view eats 2 lines. Keep the base managed region compact: avoid decorative blank lines, use `\n` not `\n\n`.
+
+All `View()` code paths that transition between each other (e.g. loading → ready) should produce the **same height** to avoid additional eating during state changes.
+
 ## Performance Notes
 
 - **Cursed Renderer (v2):** Based on ncurses algorithms, much faster than v1. Handles synchronized output automatically.

--- a/helm/knowhow/Chart.yaml
+++ b/helm/knowhow/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: knowhow
 description: Knowhow - Personal Knowledge RAG Database with REST API and WebDAV
 type: application
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.4.1
+appVersion: "0.4.1"
 keywords:
   - knowhow
   - knowledge-graph

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -152,8 +152,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.conversationID = msg.conv.ID
 		m.ready = true
-		banner := headerStyle.Render("knowhow")
-		return m, tea.Batch(tea.Println(banner), m.tryFocus())
+		return m, m.tryFocus()
 
 	case streamEventMsg:
 		return m.handleStreamEvent(msg)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -14,6 +14,14 @@ var (
 	headerStyle = lipgloss.NewStyle().
 			Bold(true).
 			Foreground(primaryColor)
+)
+
+// Banner returns the styled startup banner for printing before bubbletea starts.
+func Banner() string {
+	return headerStyle.Render("knowhow")
+}
+
+var (
 
 	// Status bar
 	statusStyle = lipgloss.NewStyle().


### PR DESCRIPTION
`tea.Println` in bubbletea v2 inline mode wipes all previous terminal scrollback on its first call. Moved the startup banner from inside the bubbletea event loop to `fmt.Println` before `tea.NewProgram().Run()`.

Also bumps version to 0.4.1 and documents the bubbletea inline-mode gotcha.

## Breaking Changes
- None