### PR TITLE
fix: make log file opt-in and update GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       helm: ${{ steps.filter.outputs.helm }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -95,7 +95,7 @@ jobs:
           echo "$ZOT_IP ${{ env.REGISTRY }}" | sudo tee -a /etc/hosts
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        run: curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
       - name: Package and push Helm chart
         run: |

--- a/cmd/knowhow/cmd_serve.go
+++ b/cmd/knowhow/cmd_serve.go
@@ -64,9 +64,6 @@ func runServe(_ *cobra.Command, _ []string) error {
 	levelVar.Set(level)
 
 	logFile := os.Getenv("KNOWHOW_LOG_FILE")
-	if logFile == "" {
-		logFile = "knowhow.log"
-	}
 	logger, logCleanup, err := config.SetupLogger(logFile, &levelVar)
 	if err != nil {
 		return fmt.Errorf("setup logger: %w", err)

--- a/helm/knowhow/Chart.yaml
+++ b/helm/knowhow/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: knowhow
 description: Knowhow - Personal Knowledge RAG Database with REST API and WebDAV
 type: application
-version: 0.4.1
-appVersion: "0.4.1"
+version: 0.4.2
+appVersion: "0.4.2"
 keywords:
   - knowhow
   - knowledge-graph

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -179,7 +179,7 @@ func Load() Config {
 		TavilyAPIKey:    getEnv("TAVILY_API_KEY", ""),
 
 		// Logging
-		LogFile:  getEnv("KNOWHOW_LOG_FILE", "/tmp/knowhow.log"),
+		LogFile:  getEnv("KNOWHOW_LOG_FILE", ""),
 		LogLevel: parseLogLevel(getEnv("KNOWHOW_LOG_LEVEL", "INFO")),
 
 		// Server settings

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -18,6 +18,11 @@ func SetupLogger(logFile string, levelVar *slog.LevelVar) (*slog.Logger, func() 
 		Level: levelVar,
 	})
 
+	// No log file configured — stderr only (container-friendly)
+	if logFile == "" {
+		return slog.New(stderrHandler), func() error { return nil }, nil
+	}
+
 	file, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open log file %s: %w", logFile, err)


### PR DESCRIPTION
## Summary
- **Pod crash fix**: Server defaulted to writing `knowhow.log` in CWD, which fails with `readOnlyRootFilesystem: true`. Log file is now opt-in via `KNOWHOW_LOG_FILE` — without it, logs go to stderr only (container-friendly).
- **GitHub Actions warnings**: Updated `dorny/paths-filter` v3→v4 (Node 24) and replaced `azure/setup-helm` with Helm's official install script to eliminate Node 20 deprecation warnings.
- **Helm chart bump**: 0.4.1 → 0.4.2 to trigger deployment.

## Test plan
- [ ] `just build` passes
- [ ] `just test` passes
- [ ] Server starts without `KNOWHOW_LOG_FILE` set (stderr only, no crash)
- [ ] Server starts with `KNOWHOW_LOG_FILE=/tmp/test.log` (writes to file)
- [ ] GitHub Actions deploy workflow runs without Node.js deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)