### PR TITLE
feat: decouple agent execution from client connection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,8 +132,10 @@ The server exposes a REST API at `/api/` for CLI and TUI communication:
 - `DELETE /api/documents?vault={id}&path={path}&recursive=true&dry-run=true` — delete document or folder
 - `GET /api/config` — server configuration
 
-Agent endpoints (SSE streaming):
-- `POST /agent/chat` — send message, receive SSE stream
+Agent endpoints (background execution):
+- `POST /agent/chat` — start agent, returns 202 `{conversationId, status}`
+- `GET /agent/events/{id}` — SSE stream (replay + live events, reconnectable)
+- `POST /agent/cancel/{id}` — cancel running agent
 - `POST /agent/approval` — approve/reject tool calls
 
 ## Documentation

--- a/cmd/knowhow/cmd_serve.go
+++ b/cmd/knowhow/cmd_serve.go
@@ -159,8 +159,10 @@ func runServe(_ *cobra.Command, _ []string) error {
 	}
 
 	// Agent endpoints
-	mux.Handle("/agent/chat", authMw(app.AgentService().HandleChat()))
-	mux.Handle("/agent/approval", authMw(app.AgentService().HandleApproval()))
+	mux.Handle("POST /agent/chat", authMw(app.AgentRunner().HandleChat()))
+	mux.Handle("GET /agent/events/{id}", authMw(app.AgentRunner().HandleEvents()))
+	mux.Handle("POST /agent/cancel/{id}", authMw(app.AgentRunner().HandleCancel()))
+	mux.Handle("POST /agent/approval", authMw(app.AgentService().HandleApproval()))
 
 	// REST API
 	apiServer := api.NewServer(app)

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -14,16 +14,22 @@ import (
 const maxAttachments = 20
 
 type chatRequestBody struct {
-	ConversationID string               `json:"conversationId"`
-	VaultID        string               `json:"vaultId"`
-	Content        string               `json:"content"`
-	DocRefs        []string             `json:"docRefs"`
+	ConversationID string                  `json:"conversationId"`
+	VaultID        string                  `json:"vaultId"`
+	Content        string                  `json:"content"`
+	DocRefs        []string                `json:"docRefs"`
 	Attachments    []models.ChatAttachment `json:"attachments,omitempty"`
-	AutoApprove    bool                 `json:"autoApprove"`
+	AutoApprove    bool                    `json:"autoApprove"`
 }
 
-// HandleChat returns an HTTP handler for POST /agent/chat that streams SSE events back to the client.
-func (s *Service) HandleChat() http.HandlerFunc {
+type chatResponseBody struct {
+	ConversationID string `json:"conversationId"`
+	Status         string `json:"status"`
+}
+
+// HandleChat returns an HTTP handler for POST /agent/chat that starts a background
+// agent goroutine and returns 202 with the conversation ID.
+func (rn *Runner) HandleChat() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -85,6 +91,94 @@ func (s *Service) HandleChat() http.HandlerFunc {
 			return
 		}
 
+		req := ChatRequest{
+			ConversationID: body.ConversationID,
+			VaultID:        body.VaultID,
+			UserID:         ac.UserID,
+			Content:        body.Content,
+			DocRefs:        body.DocRefs,
+			Attachments:    body.Attachments,
+			AutoApprove:    body.AutoApprove,
+		}
+
+		convID, err := rn.Start(r.Context(), req)
+		if err != nil {
+			logutil.FromCtx(r.Context()).Error("failed to start agent", "error", err)
+			http.Error(w, "failed to start agent", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(chatResponseBody{
+			ConversationID: convID,
+			Status:         "running",
+		})
+	}
+}
+
+// HandleEvents returns an HTTP handler for GET /agent/events/{id} that streams
+// SSE events for a running (or recently completed) agent.
+func (rn *Runner) HandleEvents() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		if _, err := auth.FromContext(r.Context()); err != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		convID := r.PathValue("id")
+		if convID == "" {
+			http.Error(w, "conversation ID required", http.StatusBadRequest)
+			return
+		}
+
+		// Try to subscribe to a running task
+		history, ch, unsub, err := rn.Subscribe(convID)
+		if err != nil {
+			// Task not running — check DB for completed/failed status
+			conv, dbErr := rn.db.GetConversation(r.Context(), convID)
+			if dbErr != nil || conv == nil {
+				http.Error(w, "conversation not found", http.StatusNotFound)
+				return
+			}
+			if conv.BgStatus == nil {
+				http.Error(w, "not a background task", http.StatusNotFound)
+				return
+			}
+
+			// Return terminal status as SSE
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				http.Error(w, "streaming not supported", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+			w.Header().Set("X-Accel-Buffering", "no")
+
+			switch *conv.BgStatus {
+			case "completed":
+				writeSSE(w, flusher, StreamEvent{Type: "msg_end"})
+			case "failed":
+				errMsg := "agent failed"
+				if conv.BgError != nil {
+					errMsg = *conv.BgError
+				}
+				writeSSE(w, flusher, StreamEvent{Type: "error", Content: errMsg})
+			default:
+				// "running" but not in tasks map — race condition or server restart
+				http.Error(w, "task not available", http.StatusNotFound)
+			}
+			return
+		}
+		defer unsub()
+
 		// Set up SSE
 		flusher, ok := w.(http.Flusher)
 		if !ok {
@@ -97,40 +191,71 @@ func (s *Service) HandleChat() http.HandlerFunc {
 		w.Header().Set("Connection", "keep-alive")
 		w.Header().Set("X-Accel-Buffering", "no")
 
-		emit := func(event StreamEvent) {
-			data, err := json.Marshal(event)
-			if err != nil {
-				logutil.FromCtx(r.Context()).Warn("failed to marshal SSE event", "error", err)
+		// Replay history
+		for _, event := range history {
+			if !writeSSE(w, flusher, event) {
 				return
 			}
-			if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+		}
+
+		// Stream live events
+		for {
+			select {
+			case event, ok := <-ch:
+				if !ok {
+					return // agent done, channel closed
+				}
+				if !writeSSE(w, flusher, event) {
+					return // client disconnected
+				}
+			case <-r.Context().Done():
 				return // client disconnected
 			}
-			flusher.Flush()
-		}
-
-		// Enrich context logger with conversation and vault info
-		chatLogger := logutil.FromCtx(r.Context()).With(
-			"conversation_id", body.ConversationID,
-			"vault_id", body.VaultID,
-		)
-		ctx := logutil.WithLogger(r.Context(), chatLogger)
-
-		req := ChatRequest{
-			ConversationID: body.ConversationID,
-			VaultID:        body.VaultID,
-			UserID:         ac.UserID,
-			Content:        body.Content,
-			DocRefs:        body.DocRefs,
-			Attachments:    body.Attachments,
-			AutoApprove:    body.AutoApprove,
-		}
-
-		if err := s.Chat(ctx, req, emit); err != nil {
-			logutil.FromCtx(ctx).Error("agent chat error", "error", err)
-			emit(StreamEvent{Type: "error", Content: "Failed to process chat request. Please try again."})
 		}
 	}
+}
+
+// HandleCancel returns an HTTP handler for POST /agent/cancel/{id} that cancels
+// a running agent.
+func (rn *Runner) HandleCancel() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		if _, err := auth.FromContext(r.Context()); err != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		convID := r.PathValue("id")
+		if convID == "" {
+			http.Error(w, "conversation ID required", http.StatusBadRequest)
+			return
+		}
+
+		if err := rn.Cancel(convID); err != nil {
+			http.Error(w, "no running task for this conversation", http.StatusNotFound)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+// writeSSE marshals an event and writes it as an SSE data line.
+// Returns false if the write failed (client disconnected).
+func writeSSE(w http.ResponseWriter, flusher http.Flusher, event StreamEvent) bool {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return false
+	}
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+		return false
+	}
+	flusher.Flush()
+	return true
 }
 
 type approvalRequestBody struct {

--- a/internal/agent/ringbuffer.go
+++ b/internal/agent/ringbuffer.go
@@ -1,0 +1,101 @@
+package agent
+
+import "sync"
+
+// RingBuffer is a thread-safe bounded buffer with pub/sub for event replay on reconnect.
+// When the buffer is full, the oldest item is overwritten.
+type RingBuffer[T any] struct {
+	mu       sync.Mutex
+	items    []T
+	capacity int
+	subs     map[uint64]chan T
+	nextSub  uint64
+	closed   bool
+}
+
+// NewRingBuffer creates a ring buffer with the given capacity.
+func NewRingBuffer[T any](capacity int) *RingBuffer[T] {
+	return &RingBuffer[T]{
+		items:    make([]T, 0, capacity),
+		capacity: capacity,
+		subs:     make(map[uint64]chan T),
+	}
+}
+
+// Push appends an item and broadcasts it to all subscribers.
+// If a subscriber's channel is full, the event is dropped for that subscriber
+// (they can reconnect and replay from the buffer).
+func (rb *RingBuffer[T]) Push(item T) {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	if rb.closed {
+		return
+	}
+
+	if len(rb.items) < rb.capacity {
+		rb.items = append(rb.items, item)
+	} else {
+		// Shift items left and append at the end
+		copy(rb.items, rb.items[1:])
+		rb.items[rb.capacity-1] = item
+	}
+
+	for _, ch := range rb.subs {
+		select {
+		case ch <- item:
+		default:
+			// subscriber channel full, drop event
+		}
+	}
+}
+
+// Subscribe returns a snapshot of the current buffer contents plus a live channel
+// for new items. Call unsub to stop receiving and clean up.
+func (rb *RingBuffer[T]) Subscribe() (history []T, ch <-chan T, unsub func()) {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	// Copy current items as history
+	history = make([]T, len(rb.items))
+	copy(history, rb.items)
+
+	if rb.closed {
+		// Buffer already closed — return history and a closed channel
+		closed := make(chan T)
+		close(closed)
+		return history, closed, func() {}
+	}
+
+	live := make(chan T, 64)
+	id := rb.nextSub
+	rb.nextSub++
+	rb.subs[id] = live
+
+	unsub = func() {
+		rb.mu.Lock()
+		defer rb.mu.Unlock()
+		if _, ok := rb.subs[id]; ok {
+			delete(rb.subs, id)
+			close(live)
+		}
+	}
+
+	return history, live, unsub
+}
+
+// Close closes all subscriber channels. After Close, Push is a no-op.
+func (rb *RingBuffer[T]) Close() {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	if rb.closed {
+		return
+	}
+	rb.closed = true
+
+	for id, ch := range rb.subs {
+		close(ch)
+		delete(rb.subs, id)
+	}
+}

--- a/internal/agent/ringbuffer_test.go
+++ b/internal/agent/ringbuffer_test.go
@@ -1,0 +1,143 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestRingBuffer_PushAndSubscribe(t *testing.T) {
+	rb := NewRingBuffer[int](5)
+
+	// Push some items
+	rb.Push(1)
+	rb.Push(2)
+	rb.Push(3)
+
+	// Subscribe gets history + live channel
+	history, ch, unsub := rb.Subscribe()
+	defer unsub()
+
+	if len(history) != 3 {
+		t.Fatalf("expected 3 history items, got %d", len(history))
+	}
+	if history[0] != 1 || history[1] != 2 || history[2] != 3 {
+		t.Fatalf("unexpected history: %v", history)
+	}
+
+	// Push after subscribe delivers to channel
+	rb.Push(4)
+	got := <-ch
+	if got != 4 {
+		t.Fatalf("expected 4 from channel, got %d", got)
+	}
+}
+
+func TestRingBuffer_Overflow(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+
+	rb.Push(1)
+	rb.Push(2)
+	rb.Push(3)
+	rb.Push(4) // overwrites 1
+	rb.Push(5) // overwrites 2
+
+	history, _, unsub := rb.Subscribe()
+	defer unsub()
+
+	if len(history) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(history))
+	}
+	if history[0] != 3 || history[1] != 4 || history[2] != 5 {
+		t.Fatalf("expected [3,4,5], got %v", history)
+	}
+}
+
+func TestRingBuffer_Close(t *testing.T) {
+	rb := NewRingBuffer[int](10)
+	rb.Push(1)
+
+	_, ch, _ := rb.Subscribe()
+
+	rb.Close()
+
+	// Channel should be closed
+	_, ok := <-ch
+	if ok {
+		t.Fatal("expected channel to be closed after Close()")
+	}
+
+	// Push after close is a no-op
+	rb.Push(2)
+	history, ch2, _ := rb.Subscribe()
+	if len(history) != 1 {
+		t.Fatalf("expected 1 item after close, got %d", len(history))
+	}
+
+	// New subscriber on closed buffer gets closed channel
+	_, ok = <-ch2
+	if ok {
+		t.Fatal("expected new subscriber channel to be closed")
+	}
+}
+
+func TestRingBuffer_Unsub(t *testing.T) {
+	rb := NewRingBuffer[int](10)
+
+	_, ch, unsub := rb.Subscribe()
+	unsub()
+
+	// Channel should be closed after unsub
+	_, ok := <-ch
+	if ok {
+		t.Fatal("expected channel to be closed after unsub")
+	}
+
+	// Double unsub should not panic
+	unsub()
+}
+
+func TestRingBuffer_MultipleSubscribers(t *testing.T) {
+	rb := NewRingBuffer[int](10)
+
+	_, ch1, unsub1 := rb.Subscribe()
+	defer unsub1()
+	_, ch2, unsub2 := rb.Subscribe()
+	defer unsub2()
+
+	rb.Push(42)
+
+	got1 := <-ch1
+	got2 := <-ch2
+	if got1 != 42 || got2 != 42 {
+		t.Fatalf("expected both subscribers to get 42, got %d and %d", got1, got2)
+	}
+}
+
+func TestRingBuffer_ConcurrentAccess(t *testing.T) {
+	rb := NewRingBuffer[int](100)
+	var wg sync.WaitGroup
+
+	// Concurrent pushes
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(v int) {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				rb.Push(v*10 + j)
+			}
+		}(i)
+	}
+
+	// Concurrent subscribe/unsub
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, unsub := rb.Subscribe()
+			unsub()
+		}()
+	}
+
+	wg.Wait()
+	rb.Close()
+}

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -1,0 +1,181 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/raphi011/knowhow/internal/auth"
+	"github.com/raphi011/knowhow/internal/db"
+	"github.com/raphi011/knowhow/internal/logutil"
+	"github.com/raphi011/knowhow/internal/models"
+)
+
+const defaultBufferCapacity = 1000
+
+// Runner manages running agent goroutines, decoupled from HTTP requests.
+type Runner struct {
+	mu      sync.Mutex
+	tasks   map[string]*runningTask // conversationID → task
+	service *Service
+	db      *db.Client
+}
+
+type runningTask struct {
+	cancel context.CancelFunc
+	events *RingBuffer[StreamEvent]
+	done   chan struct{}
+	userID string
+	err    error // set on completion
+}
+
+// NewRunner creates a Runner that manages background agent goroutines.
+func NewRunner(svc *Service, db *db.Client) *Runner {
+	return &Runner{
+		tasks:   make(map[string]*runningTask),
+		service: svc,
+		db:      db,
+	}
+}
+
+// Start launches an agent goroutine for the given chat request.
+// It returns the conversation ID (created if empty) and any validation error.
+// The agent runs in a background context independent of the HTTP request.
+func (r *Runner) Start(requestCtx context.Context, req ChatRequest) (string, error) {
+	// Detach auth from request context into a background context
+	bgCtx, err := auth.DetachContext(requestCtx)
+	if err != nil {
+		return "", fmt.Errorf("detach auth context: %w", err)
+	}
+
+	// Propagate the request logger's fields (request_id, etc.) into the background context
+	logger := logutil.FromCtx(requestCtx).With(
+		"vault_id", req.VaultID,
+	)
+	bgCtx = logutil.WithLogger(bgCtx, logger)
+
+	// Create conversation upfront so we can return its ID
+	if req.ConversationID == "" {
+		conv, createErr := r.db.CreateConversation(bgCtx, req.VaultID, req.UserID)
+		if createErr != nil {
+			return "", fmt.Errorf("create conversation: %w", createErr)
+		}
+		convID, idErr := models.RecordIDString(conv.ID)
+		if idErr != nil {
+			return "", fmt.Errorf("extract conversation ID: %w", idErr)
+		}
+		req.ConversationID = convID
+	}
+
+	bgCtx, cancel := context.WithCancel(bgCtx)
+	logger = logger.With("conversation_id", req.ConversationID)
+	bgCtx = logutil.WithLogger(bgCtx, logger)
+
+	buf := NewRingBuffer[StreamEvent](defaultBufferCapacity)
+	done := make(chan struct{})
+
+	task := &runningTask{
+		cancel: cancel,
+		events: buf,
+		done:   done,
+		userID: req.UserID,
+	}
+
+	r.mu.Lock()
+	r.tasks[req.ConversationID] = task
+	r.mu.Unlock()
+
+	// Mark conversation as running in DB
+	if err := r.db.SetConversationBgRunning(bgCtx, req.ConversationID); err != nil {
+		logger.Warn("failed to set bg_status running", "error", err)
+	}
+
+	// Emit conv_id so subscribers know which conversation this is
+	buf.Push(StreamEvent{Type: "conv_id", ConvID: req.ConversationID})
+
+	convID := req.ConversationID
+
+	go func() {
+		defer close(done)
+		defer buf.Close()
+
+		emit := func(event StreamEvent) {
+			buf.Push(event)
+		}
+
+		chatErr := r.service.Chat(bgCtx, req, emit)
+
+		task.err = chatErr
+
+		if chatErr != nil {
+			logger.Error("agent chat error", "error", chatErr)
+			buf.Push(StreamEvent{Type: "error", Content: "Failed to process chat request. Please try again."})
+			if dbErr := r.db.SetConversationBgFailed(context.Background(), convID, chatErr.Error()); dbErr != nil {
+				logger.Warn("failed to set bg_status failed", "error", dbErr)
+			}
+		} else {
+			if dbErr := r.db.SetConversationBgCompleted(context.Background(), convID); dbErr != nil {
+				logger.Warn("failed to set bg_status completed", "error", dbErr)
+			}
+		}
+
+		// Clean up task from map after a brief period to allow final event reads
+		r.mu.Lock()
+		delete(r.tasks, convID)
+		r.mu.Unlock()
+	}()
+
+	return convID, nil
+}
+
+// Subscribe returns the event history and a live channel for a running task.
+// Returns an error if the task is not found (check DB bg_status for completed tasks).
+func (r *Runner) Subscribe(conversationID string) ([]StreamEvent, <-chan StreamEvent, func(), error) {
+	r.mu.Lock()
+	task, ok := r.tasks[conversationID]
+	r.mu.Unlock()
+
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("no running task for conversation %s", conversationID)
+	}
+
+	history, ch, unsub := task.events.Subscribe()
+	return history, ch, unsub, nil
+}
+
+// Cancel cancels a running agent goroutine.
+func (r *Runner) Cancel(conversationID string) error {
+	r.mu.Lock()
+	task, ok := r.tasks[conversationID]
+	r.mu.Unlock()
+
+	if !ok {
+		return fmt.Errorf("no running task for conversation %s", conversationID)
+	}
+
+	task.cancel()
+	return nil
+}
+
+// IsRunning returns true if an agent is currently running for the given conversation.
+func (r *Runner) IsRunning(conversationID string) bool {
+	r.mu.Lock()
+	_, ok := r.tasks[conversationID]
+	r.mu.Unlock()
+	return ok
+}
+
+// Shutdown cancels all running agents and waits for them to finish.
+func (r *Runner) Shutdown() {
+	r.mu.Lock()
+	tasks := make([]*runningTask, 0, len(r.tasks))
+	for _, t := range r.tasks {
+		tasks = append(tasks, t)
+		t.cancel()
+	}
+	r.mu.Unlock()
+
+	for _, t := range tasks {
+		<-t.done
+	}
+}

--- a/internal/api/conversations.go
+++ b/internal/api/conversations.go
@@ -244,6 +244,7 @@ func conversationFromModel(c *models.Conversation) Conversation {
 		Title:       c.Title,
 		TokenInput:  c.TokenInput,
 		TokenOutput: c.TokenOutput,
+		BgStatus:    c.BgStatus,
 		CreatedAt:   c.CreatedAt,
 		UpdatedAt:   c.UpdatedAt,
 	}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -38,6 +38,7 @@ type Conversation struct {
 	Title       string         `json:"title"`
 	TokenInput  int64          `json:"tokenInput"`
 	TokenOutput int64          `json:"tokenOutput"`
+	BgStatus    *string        `json:"bgStatus,omitempty"`
 	CreatedAt   time.Time      `json:"createdAt"`
 	UpdatedAt   time.Time      `json:"updatedAt"`
 	Messages    []*ChatMessage `json:"messages,omitempty"`

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -46,6 +46,17 @@ func WithAuth(ctx context.Context, ac AuthContext) context.Context {
 	return context.WithValue(ctx, contextKey{}, ac)
 }
 
+// DetachContext creates a new context.Background() with the auth context copied
+// from the given request context. This allows background goroutines to retain
+// auth info after the original HTTP request context is cancelled.
+func DetachContext(requestCtx context.Context) (context.Context, error) {
+	ac, err := FromContext(requestCtx)
+	if err != nil {
+		return nil, err
+	}
+	return WithAuth(context.Background(), ac), nil
+}
+
 // FromContext extracts auth context from the request context.
 func FromContext(ctx context.Context) (AuthContext, error) {
 	ac, ok := ctx.Value(contextKey{}).(AuthContext)

--- a/internal/db/queries_conversation.go
+++ b/internal/db/queries_conversation.go
@@ -100,6 +100,43 @@ func (c *Client) UpdateConversationTokens(ctx context.Context, id string, inputT
 	return nil
 }
 
+func (c *Client) SetConversationBgRunning(ctx context.Context, id string) error {
+	defer c.logOp(ctx, "conversation.set_bg_running", time.Now())
+	sql := `UPDATE type::record("conversation", $id) SET bg_status = "running", bg_started_at = time::now(), bg_error = NONE, bg_completed_at = NONE`
+	_, err := surrealdb.Query[[]models.Conversation](ctx, c.DB(), sql, map[string]any{
+		"id": bareID("conversation", id),
+	})
+	if err != nil {
+		return fmt.Errorf("set conversation bg running: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) SetConversationBgCompleted(ctx context.Context, id string) error {
+	defer c.logOp(ctx, "conversation.set_bg_completed", time.Now())
+	sql := `UPDATE type::record("conversation", $id) SET bg_status = "completed", bg_completed_at = time::now()`
+	_, err := surrealdb.Query[[]models.Conversation](ctx, c.DB(), sql, map[string]any{
+		"id": bareID("conversation", id),
+	})
+	if err != nil {
+		return fmt.Errorf("set conversation bg completed: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) SetConversationBgFailed(ctx context.Context, id, errMsg string) error {
+	defer c.logOp(ctx, "conversation.set_bg_failed", time.Now())
+	sql := `UPDATE type::record("conversation", $id) SET bg_status = "failed", bg_error = $error, bg_completed_at = time::now()`
+	_, err := surrealdb.Query[[]models.Conversation](ctx, c.DB(), sql, map[string]any{
+		"id":    bareID("conversation", id),
+		"error": errMsg,
+	})
+	if err != nil {
+		return fmt.Errorf("set conversation bg failed: %w", err)
+	}
+	return nil
+}
+
 func (c *Client) CreateMessage(ctx context.Context, conversationID string, role models.MessageRole, content string, docRefs []string, toolName, toolInput, toolMeta, toolCallID, toolCalls *string) (*models.Message, error) {
 	defer c.logOp(ctx, "message.create", time.Now())
 	if docRefs == nil {

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -287,6 +287,10 @@ func SchemaSQL(dimension int) string {
     DEFINE FIELD IF NOT EXISTS updated_at    ON conversation TYPE datetime VALUE time::now();
     DEFINE FIELD IF NOT EXISTS token_input   ON conversation TYPE int DEFAULT 0;
     DEFINE FIELD IF NOT EXISTS token_output  ON conversation TYPE int DEFAULT 0;
+    DEFINE FIELD IF NOT EXISTS bg_status       ON conversation TYPE option<string>;
+    DEFINE FIELD IF NOT EXISTS bg_error        ON conversation TYPE option<string>;
+    DEFINE FIELD IF NOT EXISTS bg_started_at   ON conversation TYPE option<datetime>;
+    DEFINE FIELD IF NOT EXISTS bg_completed_at ON conversation TYPE option<datetime>;
 
     DEFINE INDEX IF NOT EXISTS idx_conversation_vault ON conversation FIELDS vault;
     DEFINE INDEX IF NOT EXISTS idx_conversation_user  ON conversation FIELDS user;

--- a/internal/models/conversation.go
+++ b/internal/models/conversation.go
@@ -18,14 +18,18 @@ const (
 
 // Conversation represents a multi-turn agent chat session.
 type Conversation struct {
-	ID          surrealmodels.RecordID `json:"id"`
-	Vault       surrealmodels.RecordID `json:"vault"`
-	User        surrealmodels.RecordID `json:"user"`
-	Title       string                 `json:"title"`
-	TokenInput  int64                  `json:"token_input"`
-	TokenOutput int64                  `json:"token_output"`
-	CreatedAt   time.Time              `json:"created_at"`
-	UpdatedAt   time.Time              `json:"updated_at"`
+	ID            surrealmodels.RecordID `json:"id"`
+	Vault         surrealmodels.RecordID `json:"vault"`
+	User          surrealmodels.RecordID `json:"user"`
+	Title         string                 `json:"title"`
+	TokenInput    int64                  `json:"token_input"`
+	TokenOutput   int64                  `json:"token_output"`
+	BgStatus      *string                `json:"bg_status,omitempty"`
+	BgError       *string                `json:"bg_error,omitempty"`
+	BgStartedAt   *time.Time             `json:"bg_started_at,omitempty"`
+	BgCompletedAt *time.Time             `json:"bg_completed_at,omitempty"`
+	CreatedAt     time.Time              `json:"created_at"`
+	UpdatedAt     time.Time              `json:"updated_at"`
 }
 
 // Message represents a single message in a conversation.

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -58,6 +58,7 @@ type App struct {
 	searchService            *search.Service
 	templateService          *template.Service
 	agentService             *agent.Service
+	agentRunner              *agent.Runner
 	remoteService            *remote.Service
 	memoryService            *memory.Service
 	bus                      *event.Bus
@@ -165,6 +166,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 
 	searchSvc := search.NewService(dbClient, embedder)
 	agentSvc := agent.NewService(dbClient, model, searchSvc, docService, cfg.TavilyAPIKey)
+	agentRunner := agent.NewRunner(agentSvc, dbClient)
 
 	assetSvc := asset.NewService(dbClient, bus)
 
@@ -183,6 +185,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		searchService:            searchSvc,
 		templateService:          template.NewService(dbClient),
 		agentService:             agentSvc,
+		agentRunner:              agentRunner,
 		bus:                      bus,
 		workerDone:               embeddingWorkerDone,
 		processingWorkerDone:     processingWorkerDone,
@@ -222,6 +225,11 @@ func (a *App) DBClient() *db.Client {
 // AgentService returns the agent service.
 func (a *App) AgentService() *agent.Service {
 	return a.agentService
+}
+
+// AgentRunner returns the agent runner for background agent goroutines.
+func (a *App) AgentRunner() *agent.Runner {
+	return a.agentRunner
 }
 
 // EventBus returns the event bus.
@@ -298,6 +306,9 @@ func (a *App) Close(ctx context.Context) error {
 	if procCancel != nil {
 		procCancel()
 		<-procDone
+	}
+	if a.agentRunner != nil {
+		a.agentRunner.Shutdown()
 	}
 	if a.db != nil {
 		return a.db.Close(ctx)

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -40,20 +40,27 @@ func (c *Client) CreateConversation(ctx context.Context, vaultID string) (*api.C
 // StreamEvent represents a server-sent event from the agent chat endpoint.
 // Field names and types must match the server's agent.StreamEvent JSON output.
 type StreamEvent struct {
-	Type         string `json:"type"` // "text" | "tool_start" | "tool_end" | "tool_approval_required" | "msg_end" | "conv_id" | "error"
-	Content      string `json:"content,omitempty"`
-	ConvID       string `json:"convId,omitempty"`
-	Tool         string `json:"tool,omitempty"`
-	CallID       string `json:"callId,omitempty"`
-	Diff         string `json:"diff,omitempty"`
+	Type              string `json:"type"` // "text" | "tool_start" | "tool_end" | "tool_approval_required" | "msg_end" | "conv_id" | "error"
+	Content           string `json:"content,omitempty"`
+	ConvID            string `json:"convId,omitempty"`
+	Tool              string `json:"tool,omitempty"`
+	CallID            string `json:"callId,omitempty"`
+	Diff              string `json:"diff,omitempty"`
 	InputTokens       int64  `json:"inputTokens,omitempty"`
 	OutputTokens      int64  `json:"outputTokens,omitempty"`
 	ContextWindowMax  int    `json:"contextWindowMax,omitempty"`
 	ContextWindowUsed int64  `json:"contextWindowUsed,omitempty"`
 }
 
-// Chat sends a message and returns a channel of SSE events.
-func (c *Client) Chat(ctx context.Context, conversationID, vaultID, content string, attachments []models.ChatAttachment, autoApprove bool) (<-chan StreamEvent, error) {
+// chatStartResponse is the JSON body returned by POST /agent/chat (202 Accepted).
+type chatStartResponse struct {
+	ConversationID string `json:"conversationId"`
+	Status         string `json:"status"`
+}
+
+// StartChat sends a chat request and returns the conversation ID.
+// The agent runs in the background on the server.
+func (c *Client) StartChat(ctx context.Context, conversationID, vaultID, content string, attachments []models.ChatAttachment, autoApprove bool) (string, error) {
 	body := map[string]any{
 		"conversationId": conversationID,
 		"vaultId":        vaultID,
@@ -66,14 +73,42 @@ func (c *Client) Chat(ctx context.Context, conversationID, vaultID, content stri
 
 	data, err := json.Marshal(body)
 	if err != nil {
-		return nil, fmt.Errorf("marshal chat request: %w", err)
+		return "", fmt.Errorf("marshal chat request: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/agent/chat", strings.NewReader(string(data)))
 	if err != nil {
-		return nil, fmt.Errorf("create chat request: %w", err)
+		return "", fmt.Errorf("create chat request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("send chat request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		return "", fmt.Errorf("chat request failed: HTTP %d", resp.StatusCode)
+	}
+
+	var result chatStartResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decode chat response: %w", err)
+	}
+
+	return result.ConversationID, nil
+}
+
+// SubscribeEvents connects to the SSE event stream for a running agent.
+func (c *Client) SubscribeEvents(ctx context.Context, conversationID string) (<-chan StreamEvent, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/agent/events/"+conversationID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create events request: %w", err)
+	}
 	req.Header.Set("Accept", "text/event-stream")
 	if c.token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.token)
@@ -81,12 +116,12 @@ func (c *Client) Chat(ctx context.Context, conversationID, vaultID, content stri
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("send chat request: %w", err)
+		return nil, fmt.Errorf("subscribe events: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
-		return nil, fmt.Errorf("chat request failed: HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("events request failed: HTTP %d", resp.StatusCode)
 	}
 
 	ch := make(chan StreamEvent, 16)
@@ -124,6 +159,22 @@ func (c *Client) Chat(ctx context.Context, conversationID, vaultID, content stri
 			}
 		}
 	}()
+
+	return ch, nil
+}
+
+// Chat sends a message and returns a channel of SSE events.
+// This is a convenience method that calls StartChat + SubscribeEvents.
+func (c *Client) Chat(ctx context.Context, conversationID, vaultID, content string, attachments []models.ChatAttachment, autoApprove bool) (<-chan StreamEvent, error) {
+	convID, err := c.StartChat(ctx, conversationID, vaultID, content, attachments, autoApprove)
+	if err != nil {
+		return nil, err
+	}
+
+	ch, err := c.SubscribeEvents(ctx, convID)
+	if err != nil {
+		return nil, err
+	}
 
 	return ch, nil
 }


### PR DESCRIPTION
## Summary

- Agent goroutines now run server-side in the background, independent of the HTTP request lifecycle — clients can disconnect and reconnect without killing the agent
- New ring buffer with pub/sub enables event replay on reconnect (missed events are replayed from a bounded buffer)
- `Service.Chat()` is completely unchanged — the `emit` callback abstraction enables the entire refactor without touching the core agent loop

## API Changes

| Before | After |
|--------|-------|
| `POST /agent/chat` → SSE stream | `POST /agent/chat` → 202 JSON `{conversationId, status}` |
| (SSE on same response) | `GET /agent/events/{id}` → SSE stream (subscribe/reconnect) |
| — | `POST /agent/cancel/{id}` → cancel running agent |

New request field: `autoApprove: true` for fully unattended background execution.

## Key Components

- **`RingBuffer[T]`** (`ringbuffer.go`): Thread-safe bounded buffer with snapshot-then-stream subscribe for event replay
- **`Runner`** (`runner.go`): Manages agent goroutines with `Start`/`Subscribe`/`Cancel`/`Shutdown`
- **`auth.DetachContext`** (`context.go`): Copies auth context into `context.Background()` so agents survive HTTP disconnect
- **`bg_status` fields** on conversation: persists running/completed/failed state for reconnect after server restart

## Test plan

- [x] `just build` compiles
- [x] `just test` — all tests pass (including 6 new ring buffer tests)
- [ ] Manual: `POST /agent/chat` with `autoApprove: true` → 202 + conversationId
- [ ] Manual: `GET /agent/events/{id}` → SSE stream with text/tool events
- [ ] Manual: disconnect and reconnect → replays missed events
- [ ] Manual: `POST /agent/cancel/{id}` while agent is running
- [ ] Manual: TUI `just run agent` → normal chat still works (transparent 2-step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)