### PR TITLE
chore: rename docker image from know-server to know

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   REGISTRY: zot.manx-turtle.ts.net
-  BACKEND_IMAGE: know-server
+  BACKEND_IMAGE: know
 
 jobs:
   changes:


### PR DESCRIPTION
Renames the Docker image from `know-server` to `know` in the deploy workflow.

## Breaking Changes
- Image published to `zot.manx-turtle.ts.net/know` instead of `zot.manx-turtle.ts.net/know-server` — update Kubernetes/Helm references if pointing to the old name

🤖 Generated with [Claude Code](https://claude.com/claude-code)