### PR TITLE
fix: include deploy.yml in path filter for backend builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
               - 'go.mod'
               - 'go.sum'
               - 'Dockerfile'
+              - '.github/workflows/deploy.yml'
             helm:
               - 'helm/**'
 


### PR DESCRIPTION
The `dorny/paths-filter` backend filter didn't include `.github/workflows/deploy.yml`, so workflow-only changes (like the image rename in #113) were skipped by `build-backend`.

This adds the workflow file to the filter so deploy config changes trigger a rebuild and push.

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)