### PR TITLE
fix: push helm chart to charts/ prefix in Zot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,4 +101,4 @@ jobs:
       - name: Package and push Helm chart
         run: |
           helm package helm/know/
-          helm push know-*.tgz oci://${{ env.REGISTRY }}
+          helm push know-*.tgz oci://${{ env.REGISTRY }}/charts


### PR DESCRIPTION
## Summary
- Push helm chart to `oci://zot/charts/know` instead of `oci://zot/know`
- Avoids collision with the container image which uses the same repo name

## Context
Images stay at root (`zot/know`), charts go under `charts/` prefix (`zot/charts/know`). The ArgoCD application in turingpi-k8s has already been updated to pull from `charts/know`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)