### PR TITLE
fix: remove unnecessary -buildvcs=false from CI, Docker, and goreleaser

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -37,7 +37,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Build all binaries
-        run: go build -buildvcs=false ./...
+        run: go build ./...
 
   test:
     needs: changes
@@ -51,7 +51,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Run tests with coverage
-        run: go test -buildvcs=false -coverprofile=coverage.out -covermode=atomic -v ./...
+        run: go test -coverprofile=coverage.out -covermode=atomic -v ./...
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5
@@ -72,7 +72,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Vet
-        run: go vet -buildvcs=false ./...
+        run: go vet ./...
 
   ci-result:
     needs: [build, test, vet]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Test
-        run: go test -buildvcs=false -v ./...
+        run: go test -v ./...
 
   release:
     needs: test

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,9 +4,9 @@ before:
   hooks:
     - go mod tidy
     - mkdir -p completions
-    - sh -c "go run -buildvcs=false ./cmd/know completion bash > completions/know.bash"
-    - sh -c "go run -buildvcs=false ./cmd/know completion zsh > completions/_know"
-    - sh -c "go run -buildvcs=false ./cmd/know completion fish > completions/know.fish"
+    - sh -c "go run ./cmd/know completion bash > completions/know.bash"
+    - sh -c "go run ./cmd/know completion zsh > completions/_know"
+    - sh -c "go run ./cmd/know completion fish > completions/know.fish"
     - sh -c "test -s completions/know.bash && test -s completions/_know && test -s completions/know.fish"
 
 builds:
@@ -21,8 +21,6 @@ builds:
     goarch:
       - amd64
       - arm64
-    flags:
-      - -buildvcs=false
     ldflags:
       - -s -w
       - -X main.version={{.Version}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY cmd/ ./cmd/
 COPY internal/ ./internal/
 
 # Build single binary
-RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o /know ./cmd/know
+RUN CGO_ENABLED=0 GOOS=linux go build -o /know ./cmd/know
 
 # Runtime
 FROM alpine:3.21


### PR DESCRIPTION
Remove `-buildvcs=false` from Dockerfile, CI workflows, and goreleaser config. This flag is only needed in the justfile where the Go module lives in a subdirectory of the git repo. In CI (proper checkout), Docker (no .git dir), and goreleaser (clean checkout) it's unnecessary.

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)