### PR TITLE
feat: multi-vault tool routing for agent service

### DIFF
--- a/internal/agent/approval_tool.go
+++ b/internal/agent/approval_tool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/schema"
@@ -51,10 +52,29 @@ func (w *approvalToolWrapper) InvokableRun(ctx context.Context, argumentsInJSON 
 			},
 		}
 
-		approvalReq, buildErr := w.service.buildApprovalRequest(ctx, w.vaultID, call)
-		if buildErr != nil {
-			logger.Warn("failed to build approval request", "tool", info.Name, "error", buildErr)
-			return fmt.Sprintf("error: %v", buildErr), nil
+		// Determine the effective vault for approval.
+		// If the tool args contain a "vault" field with "/" (remote), show
+		// content-only approval since we can't compute diffs on remote vaults.
+		isRemoteVault := false
+		var vaultArg struct {
+			Vault string `json:"vault"`
+		}
+		if err := json.Unmarshal([]byte(argumentsInJSON), &vaultArg); err != nil {
+			logger.Warn("failed to parse vault arg for approval routing", "tool", info.Name, "error", err)
+		} else if vaultArg.Vault != "" && strings.Contains(vaultArg.Vault, "/") {
+			isRemoteVault = true
+		}
+
+		var approvalReq *ApprovalRequest
+		if isRemoteVault {
+			approvalReq = w.service.buildRemoteApprovalRequest(call)
+		} else {
+			var buildErr error
+			approvalReq, buildErr = w.service.buildApprovalRequest(ctx, w.vaultID, call)
+			if buildErr != nil {
+				logger.Warn("failed to build approval request", "tool", info.Name, "error", buildErr)
+				return fmt.Sprintf("error: %v", buildErr), nil
+			}
 		}
 
 		saved := &approvalToolState{

--- a/internal/agent/middleware.go
+++ b/internal/agent/middleware.go
@@ -227,7 +227,6 @@ func (m *toolExecutionMiddleware) WrapInvokableToolCall(ctx context.Context, end
 
 		// Inject context for result metadata collection
 		ctx = tools.WithResultMeta(ctx)
-		opts = append(opts, tools.WithVaultID(m.req.VaultID))
 
 		result, err := endpoint(ctx, argumentsInJSON, opts...)
 

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -11,16 +11,15 @@ import (
 	"time"
 
 	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/schema"
 	"github.com/raphi011/know/internal/db"
 	"github.com/raphi011/know/internal/diff"
-	"github.com/raphi011/know/internal/document"
 	"github.com/raphi011/know/internal/llm"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 	"github.com/raphi011/know/internal/parser"
-	"github.com/raphi011/know/internal/search"
 	"github.com/raphi011/know/internal/tools"
 )
 
@@ -48,9 +47,7 @@ const defaultAgentTimeout = 10 * time.Minute
 type Service struct {
 	db              *db.Client
 	model           atomic.Pointer[llm.Model]
-	search          *search.Service
-	docService      *document.Service
-	executor        *tools.Executor
+	tools           []tool.BaseTool
 	tavily          *tavilyClient
 	checkpointStore *SurrealCheckPointStore
 }
@@ -65,17 +62,12 @@ func (s *Service) getModel() *llm.Model {
 	return s.model.Load()
 }
 
-// NewService creates a new agent service.
-func NewService(db *db.Client, model *llm.Model, search *search.Service, docService *document.Service, tavilyAPIKey string) *Service {
+// NewService creates a new agent service. The tools slice should contain
+// multi-vault tool wrappers built by the bootstrap layer.
+func NewService(db *db.Client, model *llm.Model, agentTools []tool.BaseTool, tavilyAPIKey string) *Service {
 	s := &Service{
-		db:         db,
-		search:     search,
-		docService: docService,
-		executor: &tools.Executor{
-			DB:         db,
-			Search:     search,
-			DocService: docService,
-		},
+		db:              db,
+		tools:           agentTools,
 		checkpointStore: NewCheckPointStore(db),
 	}
 	s.model.Store(model)
@@ -104,7 +96,9 @@ const instructionTemplate = `You are a helpful knowledge assistant for the Know 
 - If the knowledge base has no results, tell the user and offer to search the web
 - NEVER call web_search without the user's explicit permission
 - Always cite document paths when referencing information from the knowledge base
-- Do not include a sources section at the end of your response — sources are shown separately in the UI{FolderTree}{Labels}`
+- Do not include a sources section at the end of your response — sources are shown separately in the UI
+- You can access multiple vaults including remote ones. Read tools (search, read_document, etc.) automatically query all accessible vaults. Results from remote vaults are prefixed with [namespace].
+- For write tools (create_document, edit_document, etc.), you can target a specific vault by setting the "vault" field. Use "remote-name/vault-name" format for remote vaults. If omitted, the first local vault is used.{FolderTree}{Labels}`
 
 // buildMessages converts DB messages to eino schema messages.
 func buildMessages(ctx context.Context, dbMsgs []models.Message) []*schema.Message {
@@ -264,7 +258,8 @@ func (s *Service) finalizeRun(ctx context.Context, convID string, model *llm.Mod
 // buildAgent constructs a ChatModelAgent + Runner per request.
 func (s *Service) buildAgent(ctx context.Context, model *llm.Model, req *ChatRequest, emit func(StreamEvent)) (*adk.Runner, *tokenTrackingMiddleware, *toolExecutionMiddleware, error) {
 	// Collect tools — wrap write tools for interrupt/resume approval if needed
-	agentTools := s.executor.Tools()
+	agentTools := make([]tool.BaseTool, len(s.tools))
+	copy(agentTools, s.tools)
 	if s.tavily != nil {
 		agentTools = append(agentTools, &WebSearchTool{tavily: s.tavily})
 	}
@@ -617,6 +612,36 @@ func (s *Service) buildApprovalRequest(ctx context.Context, vaultID string, call
 		Stats: diff.ComputeStats(hunks),
 	}
 	return req, nil
+}
+
+// buildRemoteApprovalRequest creates a content-only approval request for
+// remote vault writes where we can't compute diffs.
+func (s *Service) buildRemoteApprovalRequest(call schema.ToolCall) *ApprovalRequest {
+	var args struct {
+		Path    string  `json:"path"`
+		Content *string `json:"content"`
+	}
+	if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
+		// Show raw arguments so the user can still make an informed approval decision.
+		return &ApprovalRequest{
+			CallID:  call.ID,
+			Tool:    call.Function.Name,
+			Path:    "(unable to parse path)",
+			IsNew:   true,
+			Content: call.Function.Arguments,
+		}
+	}
+
+	req := &ApprovalRequest{
+		CallID: call.ID,
+		Tool:   call.Function.Name,
+		Path:   args.Path,
+		IsNew:  true, // treat as new — we can't read remote doc for diff
+	}
+	if args.Content != nil {
+		req.Content = *args.Content
+	}
+	return req
 }
 
 func (s *Service) autoTitle(ctx context.Context, conversationID, firstMessage string) {

--- a/internal/mcptools/auth.go
+++ b/internal/mcptools/auth.go
@@ -13,13 +13,8 @@ import (
 	"github.com/raphi011/know/internal/vault"
 )
 
-// VaultRef is a resolved vault reference with its executor and namespace.
-type VaultRef struct {
-	VaultID   string             // vault ID (local bare ID or remote server vault ID)
-	Executor  tools.ToolExecutor // local or remote executor
-	Namespace string             // "" for local, "home" for remote
-	IsRemote  bool
-}
+// VaultRef is an alias for tools.VaultRef used in MCP tool handlers.
+type VaultRef = tools.VaultRef
 
 // resolveVaultIDs returns the list of vault IDs the caller has access to.
 // In no-auth mode (wildcard access), it fetches all vault IDs from the DB.
@@ -99,7 +94,6 @@ func (t *mcpTools) resolveAllVaults(ctx context.Context) ([]VaultRef, error) {
 			VaultID:   rv.VaultID,
 			Executor:  remote.NewExecutor(client, rv.RemoteName),
 			Namespace: rv.Namespace,
-			IsRemote:  true,
 		})
 	}
 
@@ -109,49 +103,48 @@ func (t *mcpTools) resolveAllVaults(ctx context.Context) ([]VaultRef, error) {
 // resolveWriteVault resolves the target vault for a write operation.
 // If vaultName contains "/" it routes to a remote vault.
 // Otherwise, it uses the first local vault.
-func (t *mcpTools) resolveWriteVault(ctx context.Context, vaultName string) (*VaultRef, error) {
+func (t *mcpTools) resolveWriteVault(ctx context.Context, vaultName string) (VaultRef, error) {
 	if vaultName != "" && strings.Contains(vaultName, "/") {
 		// Remote vault: "home/default" → remote="home", vaultName="default"
 		parts := strings.SplitN(vaultName, "/", 2)
 		remoteName := parts[0]
 
 		if t.remoteService == nil {
-			return nil, fmt.Errorf("remote vaults not configured")
+			return VaultRef{}, fmt.Errorf("remote vaults not configured")
 		}
 
 		client, err := t.remoteService.ClientFor(ctx, remoteName)
 		if err != nil {
-			return nil, fmt.Errorf("resolve remote %q: %w", remoteName, err)
+			return VaultRef{}, fmt.Errorf("resolve remote %q: %w", remoteName, err)
 		}
 
 		// Find the vault ID on the remote by name
 		remoteVaults, err := t.remoteService.ListRemoteVaults(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("list remote vaults: %w", err)
+			return VaultRef{}, fmt.Errorf("list remote vaults: %w", err)
 		}
 		for _, rv := range remoteVaults {
 			if rv.Namespace == vaultName {
-				return &VaultRef{
+				return VaultRef{
 					VaultID:   rv.VaultID,
 					Executor:  remote.NewExecutor(client, remoteName),
 					Namespace: rv.Namespace,
-					IsRemote:  true,
 				}, nil
 			}
 		}
-		return nil, fmt.Errorf("remote vault %q not found", vaultName)
+		return VaultRef{}, fmt.Errorf("remote vault %q not found", vaultName)
 	}
 
 	// Local vault
 	vaultIDs, err := resolveVaultIDs(ctx, t.vaultService)
 	if err != nil {
-		return nil, err
+		return VaultRef{}, err
 	}
 	if len(vaultIDs) == 0 {
-		return nil, fmt.Errorf("no vaults accessible")
+		return VaultRef{}, fmt.Errorf("no vaults accessible")
 	}
 
-	return &VaultRef{
+	return VaultRef{
 		VaultID:  vaultIDs[0],
 		Executor: t.executor,
 	}, nil

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -156,7 +156,7 @@ func (t *mcpTools) searchDocuments(ctx context.Context, req *mcp.CallToolRequest
 			continue
 		}
 		if result != "" && result != "No results found." {
-			if ref.IsRemote {
+			if ref.IsRemote() {
 				fmt.Fprintf(&sb, "[%s]\n", ref.Namespace)
 			}
 			sb.WriteString(result)
@@ -196,7 +196,7 @@ func (t *mcpTools) getDocument(ctx context.Context, req *mcp.CallToolRequest, in
 			continue
 		}
 		if !strings.HasPrefix(result, "Document not found:") {
-			if ref.IsRemote {
+			if ref.IsRemote() {
 				result = fmt.Sprintf("[%s]\n%s", ref.Namespace, result)
 			}
 			return textResult(result), nil, nil
@@ -264,7 +264,7 @@ func (t *mcpTools) listFolders(ctx context.Context, req *mcp.CallToolRequest, in
 			continue
 		}
 		if result != "No folders found." {
-			if ref.IsRemote {
+			if ref.IsRemote() {
 				fmt.Fprintf(&sb, "[%s]\n", ref.Namespace)
 			}
 			sb.WriteString(result)
@@ -304,7 +304,7 @@ func (t *mcpTools) listFolderContents(ctx context.Context, req *mcp.CallToolRequ
 			continue
 		}
 		if !strings.HasPrefix(result, "No contents found") {
-			if ref.IsRemote {
+			if ref.IsRemote() {
 				fmt.Fprintf(&sb, "[%s]\n", ref.Namespace)
 			}
 			sb.WriteString(result)
@@ -347,7 +347,7 @@ func (t *mcpTools) getDocumentVersions(ctx context.Context, req *mcp.CallToolReq
 			continue
 		}
 		if !strings.HasPrefix(result, "Document not found:") {
-			if ref.IsRemote {
+			if ref.IsRemote() {
 				result = fmt.Sprintf("[%s]\n%s", ref.Namespace, result)
 			}
 			return textResult(result), nil, nil
@@ -380,7 +380,7 @@ func (t *mcpTools) executeWriteTool(ctx context.Context, toolName, vaultName str
 		}
 		return nil, nil, fmt.Errorf("execute write tool %s: %w", toolName, execErr)
 	}
-	if ref.IsRemote {
+	if ref.IsRemote() {
 		result = fmt.Sprintf("[%s] %s", ref.Namespace, result)
 	}
 	return textResult(result), nil, nil

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -13,8 +13,10 @@ import (
 	"time"
 
 	"github.com/joho/godotenv"
+	"github.com/cloudwego/eino/components/tool"
 	"github.com/raphi011/know/internal/agent"
 	"github.com/raphi011/know/internal/asset"
+	"github.com/raphi011/know/internal/auth"
 	"github.com/raphi011/know/internal/config"
 	"github.com/raphi011/know/internal/db"
 	"github.com/raphi011/know/internal/document"
@@ -26,6 +28,7 @@ import (
 	"github.com/raphi011/know/internal/remote"
 	"github.com/raphi011/know/internal/search"
 	"github.com/raphi011/know/internal/template"
+	"github.com/raphi011/know/internal/tools"
 	"github.com/raphi011/know/internal/vault"
 )
 
@@ -170,17 +173,24 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	close(processingWorkerDone)
 
 	searchSvc := search.NewService(dbClient, embedder)
-	agentSvc := agent.NewService(dbClient, model, searchSvc, docService, cfg.TavilyAPIKey)
-	agentRunner := agent.NewRunner(agentSvc, dbClient)
-
 	assetSvc := asset.NewService(dbClient, bus)
-
 	remoteSvc := remote.NewService(dbClient)
+
+	// Build multi-vault tool resolvers for the agent.
+	localExecutor := &tools.Executor{
+		DB:         dbClient,
+		Search:     searchSvc,
+		DocService: docService,
+	}
+	vaultSvc := vault.NewService(dbClient)
+	agentTools := buildAgentTools(localExecutor, vaultSvc, remoteSvc)
+	agentSvc := agent.NewService(dbClient, model, agentTools, cfg.TavilyAPIKey)
+	agentRunner := agent.NewRunner(agentSvc, dbClient)
 	memorySvc := memory.NewService(dbClient, docService, model)
 
 	app := &App{
 		db:                       dbClient,
-		vaultService:             vault.NewService(dbClient),
+		vaultService:             vaultSvc,
 		remoteService:            remoteSvc,
 		memoryService:            memorySvc,
 		assetService:             assetSvc,
@@ -619,4 +629,134 @@ func seedIfEmpty(ctx context.Context, dbClient *db.Client) error {
 
 	slog.Info("auto-bootstrap complete", "user", userID, "vault", vaultID)
 	return nil
+}
+
+// buildAgentTools creates multi-vault tool wrappers for the agent service.
+// The resolvers close over the local executor, vault service, and remote service
+// to route tool calls to the appropriate vault.
+func buildAgentTools(localExecutor *tools.Executor, vaultSvc *vault.Service, remoteSvc *remote.Service) []tool.BaseTool {
+	resolver := func(ctx context.Context) ([]tools.VaultRef, error) {
+		localIDs, err := resolveVaultIDs(ctx, vaultSvc)
+		if err != nil {
+			return nil, err
+		}
+
+		refs := make([]tools.VaultRef, 0, len(localIDs))
+		for _, id := range localIDs {
+			refs = append(refs, tools.VaultRef{
+				VaultID:  id,
+				Executor: localExecutor,
+			})
+		}
+
+		if remoteSvc == nil {
+			return refs, nil
+		}
+
+		remoteVaults, err := remoteSvc.ListRemoteVaults(ctx)
+		if err != nil {
+			logutil.FromCtx(ctx).Warn("failed to list remote vaults, using local only", "error", err)
+			return refs, nil
+		}
+		for _, rv := range remoteVaults {
+			client, clientErr := remoteSvc.ClientFor(ctx, rv.RemoteName)
+			if clientErr != nil {
+				logutil.FromCtx(ctx).Warn("failed to get client for remote, skipping", "remote", rv.RemoteName, "error", clientErr)
+				continue
+			}
+			refs = append(refs, tools.VaultRef{
+				VaultID:   rv.VaultID,
+				Executor:  remote.NewExecutor(client, rv.RemoteName),
+				Namespace: rv.Namespace,
+			})
+		}
+
+		return refs, nil
+	}
+
+	writeResolver := func(ctx context.Context, vaultName string) (tools.VaultRef, error) {
+		if vaultName != "" && strings.Contains(vaultName, "/") {
+			parts := strings.SplitN(vaultName, "/", 2)
+			remoteName := parts[0]
+
+			if remoteSvc == nil {
+				return tools.VaultRef{}, fmt.Errorf("remote vaults not configured")
+			}
+
+			client, err := remoteSvc.ClientFor(ctx, remoteName)
+			if err != nil {
+				return tools.VaultRef{}, fmt.Errorf("resolve remote %q: %w", remoteName, err)
+			}
+
+			remoteVaults, err := remoteSvc.ListRemoteVaults(ctx)
+			if err != nil {
+				return tools.VaultRef{}, fmt.Errorf("list remote vaults: %w", err)
+			}
+			for _, rv := range remoteVaults {
+				if rv.Namespace == vaultName {
+					return tools.VaultRef{
+						VaultID:   rv.VaultID,
+						Executor:  remote.NewExecutor(client, remoteName),
+						Namespace: rv.Namespace,
+					}, nil
+				}
+			}
+			return tools.VaultRef{}, fmt.Errorf("remote vault %q not found", vaultName)
+		}
+
+		vaultIDs, err := resolveVaultIDs(ctx, vaultSvc)
+		if err != nil {
+			return tools.VaultRef{}, err
+		}
+		if len(vaultIDs) == 0 {
+			return tools.VaultRef{}, fmt.Errorf("no vaults accessible")
+		}
+
+		return tools.VaultRef{
+			VaultID:  vaultIDs[0],
+			Executor: localExecutor,
+		}, nil
+	}
+
+	return tools.NewMultiVaultTools(resolver, writeResolver)
+}
+
+// resolveVaultIDs returns the list of vault IDs the caller has access to.
+// In no-auth mode (wildcard access), it fetches all vault IDs from the DB.
+func resolveVaultIDs(ctx context.Context, vaultService *vault.Service) ([]string, error) {
+	ac, err := auth.FromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve vault IDs: %w", err)
+	}
+
+	hasWildcard := false
+	for _, vp := range ac.Vaults {
+		if vp.VaultID == auth.WildcardVaultAccess {
+			hasWildcard = true
+			break
+		}
+	}
+
+	if !hasWildcard {
+		ids := make([]string, 0, len(ac.Vaults))
+		for _, vp := range ac.Vaults {
+			ids = append(ids, vp.VaultID)
+		}
+		return ids, nil
+	}
+
+	vaults, err := vaultService.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list vaults: %w", err)
+	}
+	ids := make([]string, 0, len(vaults))
+	for _, v := range vaults {
+		id, idErr := models.RecordIDString(v.ID)
+		if idErr != nil {
+			logutil.FromCtx(ctx).Warn("failed to extract vault ID, skipping", "vault_name", v.Name, "error", idErr)
+			continue
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
 }

--- a/internal/tools/multivault.go
+++ b/internal/tools/multivault.go
@@ -1,0 +1,329 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/schema"
+	"github.com/raphi011/know/internal/logutil"
+)
+
+// MultiVaultReadTool fans out a read operation across all accessible vaults
+// and merges the results. Remote results are prefixed with [namespace].
+type MultiVaultReadTool struct {
+	toolInfo *schema.ToolInfo
+	resolver VaultResolver
+	merge    mergeStrategy
+}
+
+// mergeStrategy controls how results from multiple vaults are combined.
+type mergeStrategy int
+
+const (
+	// mergeConcat concatenates non-empty results from all vaults.
+	mergeConcat mergeStrategy = iota
+	// mergeFirstHit returns the first non-empty/non-"not found" result.
+	mergeFirstHit
+	// mergeDedupCSV deduplicates comma-separated values across vaults.
+	mergeDedupCSV
+)
+
+func (t *MultiVaultReadTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return t.toolInfo, nil
+}
+
+func (t *MultiVaultReadTool) InvokableRun(ctx context.Context, argsJSON string, _ ...tool.Option) (string, error) {
+	refs, err := t.resolver(ctx)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), nil
+	}
+
+	switch t.merge {
+	case mergeFirstHit:
+		return t.runFirstHit(ctx, refs, argsJSON)
+	case mergeDedupCSV:
+		return t.runDedupCSV(ctx, refs, argsJSON)
+	default:
+		return t.runConcat(ctx, refs, argsJSON)
+	}
+}
+
+func (t *MultiVaultReadTool) runConcat(ctx context.Context, refs []VaultRef, argsJSON string) (string, error) {
+	logger := logutil.FromCtx(ctx)
+	var sb strings.Builder
+	var failedVaults int
+
+	for _, ref := range refs {
+		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, t.toolInfo.Name, argsJSON)
+		if execErr != nil {
+			logger.Warn("multi-vault tool failed", "tool", t.toolInfo.Name, "vault", ref.VaultID, "namespace", ref.Namespace, "error", execErr)
+			failedVaults++
+			continue
+		}
+		if result != "" && !isEmptyResult(result) {
+			if ref.IsRemote() {
+				fmt.Fprintf(&sb, "[%s]\n", ref.Namespace)
+			}
+			sb.WriteString(result)
+			if !strings.HasSuffix(result, "\n") {
+				sb.WriteByte('\n')
+			}
+		}
+	}
+
+	if sb.Len() == 0 {
+		if failedVaults > 0 {
+			return fmt.Sprintf("No results found. Note: %d vault(s) were unreachable and could not be queried.", failedVaults), nil
+		}
+		return "No results found.", nil
+	}
+	return sb.String(), nil
+}
+
+func (t *MultiVaultReadTool) runFirstHit(ctx context.Context, refs []VaultRef, argsJSON string) (string, error) {
+	logger := logutil.FromCtx(ctx)
+	var failedVaults int
+
+	for _, ref := range refs {
+		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, t.toolInfo.Name, argsJSON)
+		if execErr != nil {
+			logger.Warn("multi-vault tool failed", "tool", t.toolInfo.Name, "vault", ref.VaultID, "namespace", ref.Namespace, "error", execErr)
+			failedVaults++
+			continue
+		}
+		if result != "" && !isNotFoundResult(result) {
+			if ref.IsRemote() {
+				result = fmt.Sprintf("[%s]\n%s", ref.Namespace, result)
+			}
+			return result, nil
+		}
+	}
+
+	if failedVaults > 0 {
+		return fmt.Sprintf("No results found. Note: %d vault(s) were unreachable and could not be queried.", failedVaults), nil
+	}
+	return "No results found.", nil
+}
+
+func (t *MultiVaultReadTool) runDedupCSV(ctx context.Context, refs []VaultRef, argsJSON string) (string, error) {
+	logger := logutil.FromCtx(ctx)
+	seen := map[string]bool{}
+	var failedVaults int
+
+	for _, ref := range refs {
+		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, t.toolInfo.Name, argsJSON)
+		if execErr != nil {
+			logger.Warn("multi-vault tool failed", "tool", t.toolInfo.Name, "vault", ref.VaultID, "namespace", ref.Namespace, "error", execErr)
+			failedVaults++
+			continue
+		}
+		if result != "" && !isEmptyResult(result) {
+			for item := range strings.SplitSeq(result, ", ") {
+				seen[item] = true
+			}
+		}
+	}
+
+	if len(seen) == 0 {
+		if failedVaults > 0 {
+			return fmt.Sprintf("No results found. Note: %d vault(s) were unreachable and could not be queried.", failedVaults), nil
+		}
+		return "No results found.", nil
+	}
+
+	items := make([]string, 0, len(seen))
+	for item := range seen {
+		items = append(items, item)
+	}
+	return strings.Join(items, ", "), nil
+}
+
+// MultiVaultWriteTool routes a write operation to a single vault resolved by name.
+type MultiVaultWriteTool struct {
+	toolInfo      *schema.ToolInfo
+	writeResolver WriteVaultResolver
+}
+
+func (t *MultiVaultWriteTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return t.toolInfo, nil
+}
+
+func (t *MultiVaultWriteTool) InvokableRun(ctx context.Context, argsJSON string, _ ...tool.Option) (string, error) {
+	// Extract optional "vault" field from args to determine target vault.
+	var args struct {
+		Vault string `json:"vault"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return fmt.Sprintf("error: parse args: %v", err), nil
+	}
+
+	ref, err := t.writeResolver(ctx, args.Vault)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), nil
+	}
+
+	result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, t.toolInfo.Name, argsJSON)
+	if execErr != nil {
+		var toolErr *ToolError
+		if errors.As(execErr, &toolErr) {
+			return fmt.Sprintf("error: %s", toolErr.Message), nil
+		}
+		return fmt.Sprintf("error: %v", execErr), nil
+	}
+	if ref.IsRemote() {
+		result = fmt.Sprintf("[%s] %s", ref.Namespace, result)
+	}
+	return result, nil
+}
+
+// NewMultiVaultTools returns all knowledge-base tools as multi-vault wrappers.
+// Read tools fan out across all vaults; write tools route to a specified vault.
+func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver) []tool.BaseTool {
+	readTools := []struct {
+		info  *schema.ToolInfo
+		merge mergeStrategy
+	}{
+		{
+			info: &schema.ToolInfo{
+				Name: "search",
+				Desc: "Search the knowledge base for relevant documents across all vaults",
+				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+					"query": {Type: schema.String, Desc: "The search query", Required: true},
+				}),
+			},
+			merge: mergeConcat,
+		},
+		{
+			info: &schema.ToolInfo{
+				Name: "read_document",
+				Desc: "Read the full content of a specific document by its path. Set sections=true to include a section outline for use with edit_document_section.",
+				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+					"path":     {Type: schema.String, Desc: "The document path (e.g. /folder/document-name)", Required: true},
+					"sections": {Type: schema.Boolean, Desc: "Include section outline for targeted editing"},
+				}),
+			},
+			merge: mergeFirstHit,
+		},
+		{
+			info: &schema.ToolInfo{
+				Name: "list_labels",
+				Desc: "List all labels/categories used across documents in all vaults",
+				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{}),
+			},
+			merge: mergeDedupCSV,
+		},
+		{
+			info: &schema.ToolInfo{
+				Name: "list_folders",
+				Desc: "List the folder structure across all vaults",
+				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+					"parent": {Type: schema.String, Desc: "Parent folder path to list children of (e.g. /guides/). Lists all folders if omitted."},
+				}),
+			},
+			merge: mergeConcat,
+		},
+		{
+			info: &schema.ToolInfo{
+				Name: "list_folder_contents",
+				Desc: "List documents and subfolders in a specific folder. Returns immediate children only.",
+				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+					"folder": {Type: schema.String, Desc: "Folder path (e.g. /guides/)", Required: true},
+				}),
+			},
+			merge: mergeConcat,
+		},
+		{
+			info: &schema.ToolInfo{
+				Name: "get_document_versions",
+				Desc: "Get version history for a document by path",
+				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+					"path":  {Type: schema.String, Desc: "Document path", Required: true},
+					"limit": {Type: schema.Integer, Desc: "Max versions to return (default 20)"},
+				}),
+			},
+			merge: mergeFirstHit,
+		},
+	}
+
+	writeTools := []*schema.ToolInfo{
+		{
+			Name: "create_document",
+			Desc: "Create a new document in the knowledge base. The content should be markdown. Fails if a document already exists at the given path.",
+			ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+				"path":    {Type: schema.String, Desc: "Document path (e.g. /guides/new-guide.md)", Required: true},
+				"content": {Type: schema.String, Desc: "Full markdown content for the document", Required: true},
+				"vault":   {Type: schema.String, Desc: "Target vault (e.g. remote-name/vault-name). Defaults to first local vault."},
+			}),
+		},
+		{
+			Name: "edit_document",
+			Desc: "Edit an existing document by replacing its full content. Read the document first to get the current content, then modify and pass the complete new content.",
+			ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+				"path":          {Type: schema.String, Desc: "Document path of the existing document", Required: true},
+				"content":       {Type: schema.String, Desc: "Complete new markdown content (replaces existing content entirely)", Required: true},
+				"expected_hash": {Type: schema.String, Desc: "Content hash from read_document for optimistic concurrency check"},
+				"vault":         {Type: schema.String, Desc: "Target vault (e.g. remote-name/vault-name). Defaults to first local vault."},
+			}),
+		},
+		{
+			Name: "edit_document_section",
+			Desc: "Edit a specific section of a document by heading, without sending the full content. Use read_document with sections=true to see available sections.",
+			ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+				"path":          {Type: schema.String, Desc: "Document path", Required: true},
+				"operation":     {Type: schema.String, Desc: "One of: replace, insert_after, insert_before, delete, append", Required: true},
+				"heading":       {Type: schema.String, Desc: "Target section heading (empty string for preamble, omit for append)"},
+				"position":      {Type: schema.Integer, Desc: "Disambiguation index for duplicate headings (default 0)"},
+				"content":       {Type: schema.String, Desc: "New section body (required for replace, insert, append)"},
+				"new_heading":   {Type: schema.String, Desc: "Heading text for insert/append operations"},
+				"new_level":     {Type: schema.Integer, Desc: "Heading level 1-6 for insert/append operations"},
+				"expected_hash": {Type: schema.String, Desc: "Content hash from read_document for optimistic concurrency check"},
+				"vault":         {Type: schema.String, Desc: "Target vault (e.g. remote-name/vault-name). Defaults to first local vault."},
+			}),
+		},
+		{
+			Name: "create_memory",
+			Desc: "Create a memory, optionally scoped to a project",
+			ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+				"title":   {Type: schema.String, Desc: "Memory title (used for filename)", Required: true},
+				"content": {Type: schema.String, Desc: "Memory content (markdown)", Required: true},
+				"project": {Type: schema.String, Desc: "Optional project identifier"},
+				"labels":  {Type: schema.Array, Desc: "Additional labels for categorization", ElemInfo: &schema.ParameterInfo{Type: schema.String}},
+				"vault":   {Type: schema.String, Desc: "Target vault (e.g. remote-name/vault-name). Defaults to first local vault."},
+			}),
+		},
+	}
+
+	out := make([]tool.BaseTool, 0, len(readTools)+len(writeTools))
+	for _, rt := range readTools {
+		out = append(out, &MultiVaultReadTool{
+			toolInfo: rt.info,
+			resolver: resolver,
+			merge:    rt.merge,
+		})
+	}
+	for _, info := range writeTools {
+		out = append(out, &MultiVaultWriteTool{
+			toolInfo:      info,
+			writeResolver: writeResolver,
+		})
+	}
+	return out
+}
+
+// isEmptyResult checks for common "no results" responses from underlying tools.
+func isEmptyResult(result string) bool {
+	return result == "No results found." ||
+		result == "No labels found." ||
+		result == "No folders found."
+}
+
+// isNotFoundResult checks for "not found" responses that indicate the item
+// doesn't exist in this vault (but might exist in another).
+func isNotFoundResult(result string) bool {
+	return isEmptyResult(result) ||
+		strings.HasPrefix(result, "Document not found:")
+}

--- a/internal/tools/vault_ref.go
+++ b/internal/tools/vault_ref.go
@@ -1,0 +1,20 @@
+package tools
+
+import "context"
+
+// VaultRef is a resolved vault reference with its executor and namespace.
+type VaultRef struct {
+	VaultID   string       // vault ID (local bare ID or remote server vault ID)
+	Executor  ToolExecutor // local or remote executor
+	Namespace string       // "" for local, "namespace/vault" for remote
+}
+
+// IsRemote returns true if this vault reference points to a remote vault.
+func (r VaultRef) IsRemote() bool { return r.Namespace != "" }
+
+// VaultResolver returns all accessible vaults (local + remote) for the current auth context.
+type VaultResolver func(ctx context.Context) ([]VaultRef, error)
+
+// WriteVaultResolver resolves a single vault for write operations.
+// If vaultName contains "/" it routes to a remote vault; otherwise uses the first local vault.
+type WriteVaultResolver func(ctx context.Context, vaultName string) (VaultRef, error)


### PR DESCRIPTION
Extract tool construction from agent service to bootstrap layer using multi-vault wrappers. Read tools fan out across all accessible vaults (local + remote) and merge results; write tools route to a single vault resolved by name.

## New Features
- `MultiVaultReadTool` — fans out read operations across all vaults with 3 merge strategies (concat, first-hit, dedup-csv)
- `MultiVaultWriteTool` — routes write operations to a specified vault (local or `remote/vault` format)
- `VaultRef` type with `IsRemote()` method derived from `Namespace` (eliminates redundant boolean field)
- Failed-vault tracking — surfaces unreachable vault count in "no results" messages
- Remote vault approval flow with content-only display (no diff computation)

## Breaking Changes
- `agent.NewService` signature changed: accepts `[]tool.BaseTool` instead of search/doc services
- `VaultRef.IsRemote` field replaced with `IsRemote()` method
- `WriteVaultResolver` returns `(VaultRef, error)` instead of `(*VaultRef, error)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)