### PR TITLE
feat: add `know note` daily note command

### DIFF
--- a/cmd/know/cmd_note.go
+++ b/cmd/know/cmd_note.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/raphi011/know/internal/apiclient"
+	"github.com/raphi011/know/internal/tui"
+	"github.com/spf13/cobra"
+)
+
+var (
+	noteAPI     *apiFlags
+	noteVaultID *string
+	noteDate    string
+	noteFolder  string
+	noteEdit    bool
+)
+
+var noteCmd = &cobra.Command{
+	Use:   "note [message]",
+	Short: "Add to today's daily note",
+	Long: `Add an entry to today's daily note or open it in an editor.
+
+Modes:
+  know note "message"        Agent appends entry to today's note
+  know note -e               Open today's note in $EDITOR
+  know note -e "message"     Agent drafts, then open in editor for review
+  know note                  Print today's note to stdout
+
+The daily note is created automatically on first use with a daily-note label.
+
+Environment variables:
+  KNOW_VAULT          vault name (alternative to --vault flag)
+  KNOW_DAILY_FOLDER   folder path for daily notes (alternative to --folder flag)`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runNote,
+}
+
+func init() {
+	noteAPI = addAPIFlags(noteCmd)
+	noteVaultID = addVaultFlag(noteCmd)
+	noteCmd.Flags().StringVarP(&noteDate, "date", "d", "", "target date in YYYY-MM-DD format (default: today)")
+	noteCmd.Flags().StringVar(&noteFolder, "folder", envOrDefault("KNOW_DAILY_FOLDER", "/daily/"), "folder path for daily notes (env: KNOW_DAILY_FOLDER)")
+	noteCmd.Flags().BoolVarP(&noteEdit, "edit", "e", false, "open daily note in $EDITOR")
+}
+
+func runNote(_ *cobra.Command, args []string) error {
+	// Parse date.
+	date := noteDate
+	if date == "" {
+		date = time.Now().Format("2006-01-02")
+	}
+	if _, err := time.Parse("2006-01-02", date); err != nil {
+		return fmt.Errorf("invalid date %q (expected YYYY-MM-DD): %w", date, err)
+	}
+
+	// Normalize folder path.
+	folder := noteFolder
+	if !strings.HasPrefix(folder, "/") {
+		folder = "/" + folder
+	}
+	if !strings.HasSuffix(folder, "/") {
+		folder = folder + "/"
+	}
+
+	docPath := folder + date + ".md"
+	prompt := ""
+	if len(args) > 0 {
+		prompt = args[0]
+	}
+
+	ctx := context.Background()
+	client := noteAPI.newClient()
+
+	// Ensure daily note exists.
+	doc, err := ensureDailyNote(ctx, client, *noteVaultID, docPath, date)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case prompt == "" && !noteEdit:
+		// Mode A: print note to stdout.
+		fmt.Print(doc.Content)
+		return nil
+
+	case prompt != "" && !noteEdit:
+		// Mode B: agent oneshot.
+		agentClient := tui.NewClient(noteAPI.URL, noteAPI.Token)
+		return agentAppend(ctx, agentClient, docPath, prompt)
+
+	case prompt == "" && noteEdit:
+		// Mode C: editor only.
+		return editNote(ctx, client, *noteVaultID, docPath, doc.Content)
+
+	default:
+		// Mode D: agent draft then editor.
+		agentClient := tui.NewClient(noteAPI.URL, noteAPI.Token)
+		if err := agentAppend(ctx, agentClient, docPath, prompt); err != nil {
+			return err
+		}
+		updated, err := client.GetDocument(ctx, *noteVaultID, docPath)
+		if err != nil {
+			return fmt.Errorf("fetch updated note: %w", err)
+		}
+		return editNote(ctx, client, *noteVaultID, docPath, updated.Content)
+	}
+}
+
+// ensureDailyNote fetches the daily note or creates it with a template if it doesn't exist.
+func ensureDailyNote(ctx context.Context, client *apiclient.Client, vaultID, path, date string) (*apiclient.Document, error) {
+	doc, err := client.GetDocument(ctx, vaultID, path)
+	if err == nil {
+		return doc, nil
+	}
+
+	var httpErr *apiclient.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != 404 {
+		return nil, fmt.Errorf("check daily note: %w", err)
+	}
+
+	// Create template.
+	template := fmt.Sprintf("---\ntitle: %q\nlabels:\n  - daily-note\n---\n# %s\n", date, date)
+	doc, err = client.CreateDocument(ctx, apiclient.CreateDocumentRequest{
+		VaultID: vaultID,
+		Path:    path,
+		Content: template,
+		Source:  "note",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create daily note: %w", err)
+	}
+
+	return doc, nil
+}
+
+// agentAppend sends a prompt to the agent to update the daily note.
+func agentAppend(ctx context.Context, agentClient *tui.Client, path, message string) error {
+	prompt := fmt.Sprintf(
+		"Update the daily note at %s. Add the following entry:\n\n%s\n\nKeep all existing content intact. Add a timestamp (%s) prefix to the new entry.",
+		path, message, time.Now().Format("15:04"),
+	)
+
+	events, err := agentClient.Chat(ctx, "", *noteVaultID, prompt, nil, true)
+	if err != nil {
+		return fmt.Errorf("start agent: %w", err)
+	}
+
+	return streamToStdout(events)
+}
+
+// streamToStdout prints agent text events to stdout until the stream ends.
+func streamToStdout(events <-chan tui.StreamEvent) error {
+	for event := range events {
+		switch event.Type {
+		case "text":
+			fmt.Print(event.Content)
+		case "error":
+			return fmt.Errorf("agent: %s", event.Content)
+		case "interrupted":
+			return fmt.Errorf("agent: interrupted")
+		case "msg_end":
+			fmt.Println()
+			return nil
+		}
+	}
+	return fmt.Errorf("agent: stream ended unexpectedly")
+}
+
+// editNote opens the note content in $EDITOR and saves changes back.
+func editNote(ctx context.Context, client *apiclient.Client, vaultID, path, content string) error {
+	updated, err := openInEditor(content)
+	if err != nil {
+		return err
+	}
+
+	if updated == content {
+		fmt.Println("no changes")
+		return nil
+	}
+
+	if _, err := client.EditDocument(ctx, apiclient.EditDocumentRequest{
+		VaultID: vaultID,
+		Path:    path,
+		Content: updated,
+		Source:  "note",
+	}); err != nil {
+		return fmt.Errorf("save note: %w", err)
+	}
+
+	fmt.Println("saved")
+	return nil
+}
+
+// openInEditor writes content to a temp file, opens $EDITOR, and returns the edited content.
+func openInEditor(content string) (string, error) {
+	tmpFile, err := os.CreateTemp("", "know-note-*.md")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath) // best-effort cleanup; OS cleans /tmp periodically
+
+	if _, err := tmpFile.WriteString(content); err != nil {
+		tmpFile.Close()
+		return "", fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return "", fmt.Errorf("close temp file: %w", err)
+	}
+
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "vi"
+	}
+	if _, err := exec.LookPath(editor); err != nil {
+		return "", fmt.Errorf("editor %q not found: set $EDITOR to your preferred editor", editor)
+	}
+
+	cmd := exec.Command(editor, tmpPath)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("run editor: %w", err)
+	}
+
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return "", fmt.Errorf("read edited file: %w", err)
+	}
+
+	return string(data), nil
+}

--- a/cmd/know/main.go
+++ b/cmd/know/main.go
@@ -69,6 +69,7 @@ func main() {
 	rootCmd.AddCommand(backupCmd)
 	rootCmd.AddCommand(lsCmd)
 	rootCmd.AddCommand(catCmd)
+	rootCmd.AddCommand(noteCmd)
 	rootCmd.AddCommand(rmCmd)
 	rootCmd.AddCommand(vaultCmd)
 	rootCmd.AddCommand(remoteCmd)

--- a/internal/agent/middleware.go
+++ b/internal/agent/middleware.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/components/tool"
@@ -50,8 +51,9 @@ func (m *contextInjectionMiddleware) BeforeAgent(ctx context.Context, runCtx *ad
 	}
 
 	vals := map[string]any{
-		"FolderTree": folderTree,
-		"Labels":     labels,
+		"FolderTree":  folderTree,
+		"Labels":      labels,
+		"CurrentDate": time.Now().Format("2006-01-02"),
 	}
 	adk.AddSessionValues(ctx, vals)
 

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -82,9 +82,11 @@ func (s *Service) Available() bool {
 	return s.getModel() != nil
 }
 
-// instructionTemplate is the system prompt template for the agent. {FolderTree} and
-// {Labels} are hydrated from DB via session values in contextInjectionMiddleware.BeforeAgent.
+// instructionTemplate is the system prompt template for the agent. {FolderTree},
+// {Labels}, and {CurrentDate} are hydrated via session values in contextInjectionMiddleware.BeforeAgent.
 const instructionTemplate = `You are a helpful knowledge assistant for the Know knowledge base. You help users find and understand information stored in their documents.
+
+Today's date is {CurrentDate}.
 
 - Use search to find relevant documents in the knowledge base
 - Use read_document to read the full content of a specific document by path


### PR DESCRIPTION
## Summary

- Add `know note` CLI command with 4 modes: print (`know note`), agent append (`know note "msg"`), editor (`know note -e`), and agent+editor (`know note -e "msg"`)
- Daily notes auto-created at `/daily/YYYY-MM-DD.md` with `daily-note` label on first use
- Inject `{CurrentDate}` into agent system prompt so the agent knows today's date
- Configurable via `--date`, `--folder`, `--vault` flags and `KNOW_DAILY_FOLDER` env var

## Test plan

- [ ] `know note` — prints today's note to stdout (creates if missing)
- [ ] `know note "had a meeting about X"` — agent appends entry with timestamp
- [ ] `know note -e` — opens note in `$EDITOR`, saves on close
- [ ] `know note -e "draft this"` — agent drafts, then opens editor for review
- [ ] `know note -d 2026-03-13` — targets a specific date
- [ ] Verify agent responses include correct date awareness

🤖 Generated with [Claude Code](https://claude.com/claude-code)