### PR TITLE
refactor: remove DocumentSource type and source fields

### DIFF
--- a/cmd/know/cmd_cp.go
+++ b/cmd/know/cmd_cp.go
@@ -18,7 +18,6 @@ var (
 	cpLabels    []string
 	cpDryRun    bool
 	cpForce     bool
-	cpSource    string
 	cpRecursive bool
 )
 
@@ -50,7 +49,6 @@ func init() {
 	cpCmd.Flags().StringSliceVarP(&cpLabels, "labels", "l", nil, "labels to include in document path metadata")
 	cpCmd.Flags().BoolVar(&cpDryRun, "dry-run", false, "show what would be copied without changes")
 	cpCmd.Flags().BoolVar(&cpForce, "force", false, "overwrite existing files if content hash differs")
-	cpCmd.Flags().StringVar(&cpSource, "source", "cp", "document source tag")
 	cpCmd.Flags().BoolVarP(&cpRecursive, "recursive", "r", false, "recurse into subdirectories")
 	if err := cpCmd.MarkFlagRequired("vault"); err != nil {
 		panic(fmt.Sprintf("mark vault flag required: %v", err))
@@ -121,7 +119,6 @@ func runCp(cmd *cobra.Command, args []string) error {
 	client := cpAPI.newClient()
 	meta := apiclient.BulkMeta{
 		VaultID: cpVaultID,
-		Source:  cpSource,
 		Force:   cpForce,
 		DryRun:  cpDryRun,
 	}

--- a/cmd/know/cmd_note.go
+++ b/cmd/know/cmd_note.go
@@ -139,7 +139,6 @@ func ensureDailyNote(ctx context.Context, client *apiclient.Client, vaultID, pat
 		VaultID: vaultID,
 		Path:    path,
 		Content: content,
-		Source:  "note",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create daily note: %w", err)
@@ -222,7 +221,6 @@ func editNote(ctx context.Context, client *apiclient.Client, vaultID, path, cont
 		VaultID: vaultID,
 		Path:    path,
 		Content: updated,
-		Source:  "note",
 	}); err != nil {
 		return fmt.Errorf("save note: %w", err)
 	}

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -15,7 +15,6 @@ import (
 // bulkMeta is the JSON metadata sent as the first multipart part ("meta").
 type bulkMeta struct {
 	VaultID string `json:"vaultId"`
-	Source  string `json:"source"`
 	Force   bool   `json:"force"`
 	DryRun  bool   `json:"dryRun"`
 }
@@ -69,15 +68,6 @@ func (s *Server) bulkUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	src := models.SourceCP
-	if meta.Source != "" {
-		src = models.DocumentSource(meta.Source)
-		if !src.Valid() {
-			writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid source: %q", meta.Source))
-			return
-		}
-	}
-
 	var results []bulkFileResult
 
 	// Process remaining parts — each is a file.
@@ -93,7 +83,7 @@ func (s *Server) bulkUpload(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 
-		result := s.processBulkPart(r, part, meta, src)
+		result := s.processBulkPart(r, part, meta)
 		results = append(results, result)
 	}
 
@@ -108,7 +98,7 @@ func (s *Server) bulkUpload(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func (s *Server) processBulkPart(r *http.Request, part *multipart.Part, meta bulkMeta, src models.DocumentSource) bulkFileResult {
+func (s *Server) processBulkPart(r *http.Request, part *multipart.Part, meta bulkMeta) bulkFileResult {
 	path := part.FormName()
 	if path == "" {
 		return bulkFileResult{Path: "(unknown)", Status: "error", Error: "missing path in form name"}
@@ -124,10 +114,10 @@ func (s *Server) processBulkPart(r *http.Request, part *multipart.Part, meta bul
 	if isImage {
 		return s.processBulkAsset(r, path, data, meta)
 	}
-	return s.processBulkDocument(r, path, string(data), meta, src)
+	return s.processBulkDocument(r, path, string(data), meta)
 }
 
-func (s *Server) processBulkDocument(r *http.Request, path, content string, meta bulkMeta, src models.DocumentSource) bulkFileResult {
+func (s *Server) processBulkDocument(r *http.Request, path, content string, meta bulkMeta) bulkFileResult {
 	logger := logutil.FromCtx(r.Context())
 	hash := models.ContentHash(content)
 
@@ -157,7 +147,6 @@ func (s *Server) processBulkDocument(r *http.Request, path, content string, meta
 		VaultID: meta.VaultID,
 		Path:    path,
 		Content: content,
-		Source:  src,
 	})
 	if err != nil {
 		logger.Error("bulk: upsert document", "vault", meta.VaultID, "path", path, "error", err)

--- a/internal/api/documents.go
+++ b/internal/api/documents.go
@@ -48,7 +48,6 @@ type upsertDocumentRequest struct {
 	VaultID string `json:"vaultId"`
 	Path    string `json:"path"`
 	Content string `json:"content"`
-	Source  string `json:"source"`
 }
 
 func (s *Server) upsertDocument(w http.ResponseWriter, r *http.Request) {
@@ -73,22 +72,12 @@ func (s *Server) upsertDocument(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	src := models.SourceManual
-	if body.Source != "" {
-		src = models.DocumentSource(body.Source)
-		if !src.Valid() {
-			writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid document source: %q", body.Source))
-			return
-		}
-	}
-
 	logger := logutil.FromCtx(r.Context())
 
 	doc, err := s.app.DocumentService().Create(r.Context(), models.DocumentInput{
 		VaultID: body.VaultID,
 		Path:    body.Path,
 		Content: body.Content,
-		Source:  src,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to create/update document")
@@ -216,7 +205,6 @@ func documentFromModel(d *models.Document) Document {
 		Path:        d.Path,
 		Title:       d.Title,
 		Content:     d.Content,
-		Source:      string(d.Source),
 		ContentHash: d.ContentHash,
 		CreatedAt:   d.CreatedAt,
 		UpdatedAt:   d.UpdatedAt,

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -25,7 +25,6 @@ type Document struct {
 	Path        string    `json:"path"`
 	Title       string    `json:"title"`
 	Content     string    `json:"content"`
-	Source      string    `json:"source"`
 	ContentHash *string   `json:"contentHash,omitempty"`
 	CreatedAt   time.Time `json:"createdAt"`
 	UpdatedAt   time.Time `json:"updatedAt"`
@@ -130,7 +129,6 @@ type FolderResponse struct {
 type VersionResponse struct {
 	Version     int       `json:"version"`
 	Title       string    `json:"title"`
-	Source      string    `json:"source"`
 	ContentHash string    `json:"contentHash"`
 	CreatedAt   time.Time `json:"createdAt"`
 }

--- a/internal/api/versions.go
+++ b/internal/api/versions.go
@@ -63,7 +63,6 @@ func (s *Server) listVersions(w http.ResponseWriter, r *http.Request) {
 		resp[i] = VersionResponse{
 			Version:     v.Version,
 			Title:       v.Title,
-			Source:      string(v.Source),
 			ContentHash: v.ContentHash,
 			CreatedAt:   v.CreatedAt,
 		}

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -108,7 +108,6 @@ type BulkFile struct {
 // BulkMeta holds shared metadata for a bulk upload request.
 type BulkMeta struct {
 	VaultID string `json:"vaultId"`
-	Source  string `json:"source"`
 	Force   bool   `json:"force"`
 	DryRun  bool   `json:"dryRun"`
 }
@@ -267,7 +266,6 @@ type CreateDocumentRequest struct {
 	VaultID string `json:"vaultId"`
 	Path    string `json:"path"`
 	Content string `json:"content"`
-	Source  string `json:"source"`
 }
 
 // CreateDocument creates a new document on the remote server.
@@ -296,7 +294,6 @@ func (c *Client) EditDocument(ctx context.Context, req EditDocumentRequest) (*Do
 type Version struct {
 	Version     int       `json:"version"`
 	Title       string    `json:"title"`
-	Source      string    `json:"source"`
 	ContentHash string    `json:"contentHash"`
 	CreatedAt   time.Time `json:"createdAt"`
 }
@@ -321,7 +318,6 @@ type Document struct {
 	Path        string  `json:"path"`
 	Title       string  `json:"title"`
 	Content     string  `json:"content"`
-	Source      string  `json:"source"`
 	ContentHash *string `json:"contentHash,omitempty"`
 }
 

--- a/internal/db/queries_chunk_test.go
+++ b/internal/db/queries_chunk_test.go
@@ -23,7 +23,6 @@ func TestCreateAndGetChunks(t *testing.T) {
 		Title:       "Chunk Test",
 		Content:     "long content",
 		ContentBody: "long content",
-		Source:      models.SourceManual,
 		Labels:      []string{"test"},
 	})
 	if err != nil {
@@ -65,7 +64,6 @@ func TestDeleteChunks(t *testing.T) {
 		Title:       "Chunk Delete",
 		Content:     "content",
 		ContentBody: "content",
-		Source:      models.SourceManual,
 		Labels:      []string{},
 	})
 	if err != nil {
@@ -106,7 +104,6 @@ func TestCascadeDeleteChunksOnDocumentDelete(t *testing.T) {
 		Title:       "Cascade",
 		Content:     "content",
 		ContentBody: "content",
-		Source:      models.SourceManual,
 		Labels:      []string{},
 	})
 	if err != nil {
@@ -145,7 +142,7 @@ func TestCreateChunks_WithEmbedAt(t *testing.T) {
 
 	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/embed-at-test.md", Title: "Embed At Test",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument failed: %v", err)
@@ -185,7 +182,7 @@ func TestClaimChunksForEmbedding(t *testing.T) {
 
 	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/claim-test.md", Title: "Claim Test",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument failed: %v", err)
@@ -254,7 +251,7 @@ func TestClaimChunksForEmbedding_SkipsFutureEmbedAt(t *testing.T) {
 
 	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/future-embed-test.md", Title: "Future Embed",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument failed: %v", err)
@@ -291,7 +288,7 @@ func TestUpdateChunkEmbedding(t *testing.T) {
 
 	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/update-embed-test.md", Title: "Update Embed",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument failed: %v", err)
@@ -338,7 +335,7 @@ func TestRescheduleChunkEmbedding(t *testing.T) {
 
 	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/reschedule-test.md", Title: "Reschedule",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument failed: %v", err)
@@ -385,7 +382,7 @@ func TestDeleteChunkByID(t *testing.T) {
 
 	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/delete-chunk-byid.md", Title: "Delete Chunk",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument failed: %v", err)
@@ -435,7 +432,7 @@ func TestUpdateChunkPosition(t *testing.T) {
 
 	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/update-pos-test.md", Title: "Update Pos",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument failed: %v", err)
@@ -478,7 +475,7 @@ func TestClaimChunksForEmbedding_RespectsLimit(t *testing.T) {
 
 	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/limit-test.md", Title: "Limit Test",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument failed: %v", err)
@@ -534,7 +531,7 @@ func TestRescheduleAndReclaimRoundTrip(t *testing.T) {
 
 	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/roundtrip-test.md", Title: "Roundtrip",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument failed: %v", err)

--- a/internal/db/queries_document.go
+++ b/internal/db/queries_document.go
@@ -104,8 +104,6 @@ func (c *Client) CreateDocument(ctx context.Context, input models.DocumentInput)
 			content_length = $content_length,
 			labels = $labels,
 			doc_type = $doc_type,
-			source = $source,
-			source_path = $source_path,
 			content_hash = $content_hash,
 			metadata = $metadata,
 			processed = false
@@ -120,8 +118,6 @@ func (c *Client) CreateDocument(ctx context.Context, input models.DocumentInput)
 		"content_length": len(input.Content),
 		"labels":         labels,
 		"doc_type":       optionalString(input.DocType),
-		"source":         string(input.Source),
-		"source_path":    optionalString(input.SourcePath),
 		"content_hash":   optionalString(input.ContentHash),
 		"metadata":       optionalObject(input.Metadata),
 	})
@@ -251,7 +247,7 @@ func (c *Client) ListDocuments(ctx context.Context, filter ListDocumentsFilter) 
 	return (*results)[0].Result, nil
 }
 
-func (c *Client) UpdateDocument(ctx context.Context, id string, content, contentBody, title string, source models.DocumentSource, labels []string, contentHash *string, metadata map[string]any) (*models.Document, error) {
+func (c *Client) UpdateDocument(ctx context.Context, id string, content, contentBody, title string, labels []string, contentHash *string, metadata map[string]any) (*models.Document, error) {
 	defer c.logOp(ctx, "document.update", time.Now())
 	if labels == nil {
 		labels = []string{}
@@ -263,7 +259,6 @@ func (c *Client) UpdateDocument(ctx context.Context, id string, content, content
 			content_body = $content_body,
 			content_length = $content_length,
 			title = $title,
-			source = $source,
 			labels = $labels,
 			content_hash = $content_hash,
 			metadata = $metadata,
@@ -276,7 +271,6 @@ func (c *Client) UpdateDocument(ctx context.Context, id string, content, content
 		"content_body":   contentBody,
 		"content_length": len(content),
 		"title":          title,
-		"source":         string(source),
 		"labels":         labels,
 		"content_hash":   optionalString(contentHash),
 		"metadata":       optionalObject(metadata),
@@ -505,7 +499,7 @@ func (c *Client) UpsertDocument(ctx context.Context, input models.DocumentInput)
 			return nil, false, nil, fmt.Errorf("extract document id: %w", err)
 		}
 
-		doc, err = c.UpdateDocument(ctx, idStr, input.Content, input.ContentBody, input.Title, input.Source, input.Labels, input.ContentHash, input.Metadata)
+		doc, err = c.UpdateDocument(ctx, idStr, input.Content, input.ContentBody, input.Title, input.Labels, input.ContentHash, input.Metadata)
 		if err != nil {
 			return nil, false, nil, err
 		}

--- a/internal/db/queries_document_test.go
+++ b/internal/db/queries_document_test.go
@@ -23,7 +23,6 @@ func TestCreateDocument(t *testing.T) {
 		Title:       "Hello World",
 		Content:     "---\ntitle: Hello\n---\nHello world content",
 		ContentBody: "Hello world content",
-		Source:      models.SourceManual,
 		Labels:      []string{"test", "greeting"},
 		ContentHash: &hash,
 	})
@@ -54,7 +53,6 @@ func TestGetDocumentByPath(t *testing.T) {
 		Title:       "Unique Path Doc",
 		Content:     "content",
 		ContentBody: "content",
-		Source:      models.SourceManual,
 		Labels:      []string{},
 	})
 	if err != nil {
@@ -95,7 +93,6 @@ func TestListDocuments(t *testing.T) {
 			Title:       "Doc " + path,
 			Content:     "content of " + path,
 			ContentBody: "content of " + path,
-			Source:      models.SourceManual,
 			Labels:      []string{"test"},
 		})
 		if err != nil {
@@ -136,7 +133,6 @@ func TestUpdateDocument(t *testing.T) {
 		Title:       "Original",
 		Content:     "original",
 		ContentBody: "original",
-		Source:      models.SourceManual,
 		Labels:      []string{"old"},
 	})
 	if err != nil {
@@ -144,7 +140,7 @@ func TestUpdateDocument(t *testing.T) {
 	}
 	docID := models.MustRecordIDString(doc.ID)
 
-	updated, err := testDB.UpdateDocument(ctx, docID, "new content", "new content", "Updated Title", models.SourceManual, []string{"new"}, nil, nil)
+	updated, err := testDB.UpdateDocument(ctx, docID, "new content", "new content", "Updated Title", []string{"new"}, nil, nil)
 	if err != nil {
 		t.Fatalf("UpdateDocument failed: %v", err)
 	}
@@ -169,7 +165,6 @@ func TestDeleteDocument(t *testing.T) {
 		Title:       "Delete Me",
 		Content:     "content",
 		ContentBody: "content",
-		Source:      models.SourceManual,
 		Labels:      []string{},
 	})
 	if err != nil {
@@ -204,7 +199,6 @@ func TestMoveDocument(t *testing.T) {
 		Title:       "Move Test",
 		Content:     "content",
 		ContentBody: "content",
-		Source:      models.SourceManual,
 		Labels:      []string{},
 	})
 	if err != nil {
@@ -244,7 +238,6 @@ func TestListDocuments_LabelFilter(t *testing.T) {
 			Content:     "# " + doc.title,
 			ContentBody: doc.title,
 			Labels:      doc.labels,
-			Source:      models.SourceManual,
 		})
 		if err != nil {
 			t.Fatalf("create doc %s: %v", doc.path, err)
@@ -290,7 +283,6 @@ func TestGetDocumentByID(t *testing.T) {
 		Title:       "GetByID Test",
 		Content:     "get by id content",
 		ContentBody: "get by id content",
-		Source:      models.SourceManual,
 		Labels:      []string{"test"},
 	})
 	if err != nil {
@@ -338,7 +330,6 @@ func TestDeleteDocumentsByPrefix(t *testing.T) {
 			Title:       "Doc " + path,
 			Content:     "content of " + path,
 			ContentBody: "content of " + path,
-			Source:      models.SourceManual,
 			Labels:      []string{},
 		})
 		if err != nil {
@@ -378,7 +369,6 @@ func TestMoveDocumentsByPrefix(t *testing.T) {
 			Title:       "Doc " + path,
 			Content:     "content of " + path,
 			ContentBody: "content of " + path,
-			Source:      models.SourceManual,
 			Labels:      []string{},
 		})
 		if err != nil {
@@ -433,7 +423,6 @@ func TestListLabels(t *testing.T) {
 			Title:       "Doc " + doc.path,
 			Content:     "content",
 			ContentBody: "content",
-			Source:      models.SourceManual,
 			Labels:      doc.labels,
 		})
 		if err != nil {
@@ -492,7 +481,6 @@ func TestListLabelsWithCounts(t *testing.T) {
 			Title:       "Doc " + doc.path,
 			Content:     "content",
 			ContentBody: "content",
-			Source:      models.SourceManual,
 			Labels:      doc.labels,
 		})
 		if err != nil {
@@ -542,7 +530,6 @@ func TestUpsertDocument(t *testing.T) {
 		Title:       "Upsert Original",
 		Content:     "original content",
 		ContentBody: "original content",
-		Source:      models.SourceManual,
 		Labels:      []string{"v1"},
 	})
 	if err != nil {
@@ -565,7 +552,6 @@ func TestUpsertDocument(t *testing.T) {
 		Title:       "Upsert Updated",
 		Content:     "updated content",
 		ContentBody: "updated content",
-		Source:      models.SourceManual,
 		Labels:      []string{"v2"},
 	})
 	if err != nil {

--- a/internal/db/queries_label_test.go
+++ b/internal/db/queries_label_test.go
@@ -51,7 +51,7 @@ func TestSyncDocumentLabels(t *testing.T) {
 
 	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/label-sync.md", Title: "Label Sync",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument failed: %v", err)
@@ -110,14 +110,14 @@ func TestGetDocumentsByLabel(t *testing.T) {
 
 	doc1, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/label-query-1.md", Title: "Label Query 1",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument 1 failed: %v", err)
 	}
 	doc2, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/label-query-2.md", Title: "Label Query 2",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument 2 failed: %v", err)

--- a/internal/db/queries_relation_test.go
+++ b/internal/db/queries_relation_test.go
@@ -19,14 +19,14 @@ func TestCreateRelation(t *testing.T) {
 	suffix := fmt.Sprint(time.Now().UnixNano())
 	docA, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/rel-a-" + suffix + ".md", Title: "Rel Doc A",
-		Content: "content a", ContentBody: "content a", Source: models.SourceManual, Labels: []string{},
+		Content: "content a", ContentBody: "content a", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument A failed: %v", err)
 	}
 	docB, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/rel-b-" + suffix + ".md", Title: "Rel Doc B",
-		Content: "content b", ContentBody: "content b", Source: models.SourceManual, Labels: []string{},
+		Content: "content b", ContentBody: "content b", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument B failed: %v", err)
@@ -61,21 +61,21 @@ func TestGetRelations(t *testing.T) {
 	suffix := fmt.Sprint(time.Now().UnixNano())
 	docA, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/getrel-a-" + suffix + ".md", Title: "GetRel A",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument A failed: %v", err)
 	}
 	docB, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/getrel-b-" + suffix + ".md", Title: "GetRel B",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument B failed: %v", err)
 	}
 	docC, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/getrel-c-" + suffix + ".md", Title: "GetRel C",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument C failed: %v", err)
@@ -117,14 +117,14 @@ func TestGetRelationByID(t *testing.T) {
 	suffix := fmt.Sprint(time.Now().UnixNano())
 	docA, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/relbyid-a-" + suffix + ".md", Title: "RelByID A",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument A failed: %v", err)
 	}
 	docB, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/relbyid-b-" + suffix + ".md", Title: "RelByID B",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument B failed: %v", err)
@@ -171,21 +171,21 @@ func TestDeleteRelationsBySource(t *testing.T) {
 	suffix := fmt.Sprint(time.Now().UnixNano())
 	docA, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/delsrc-a-" + suffix + ".md", Title: "DelSrc A",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument A failed: %v", err)
 	}
 	docB, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/delsrc-b-" + suffix + ".md", Title: "DelSrc B",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument B failed: %v", err)
 	}
 	docC, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/delsrc-c-" + suffix + ".md", Title: "DelSrc C",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument C failed: %v", err)
@@ -237,14 +237,14 @@ func TestDeleteRelation(t *testing.T) {
 	suffix := fmt.Sprint(time.Now().UnixNano())
 	docA, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/delrel-a-" + suffix + ".md", Title: "DelRel A",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument A failed: %v", err)
 	}
 	docB, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/delrel-b-" + suffix + ".md", Title: "DelRel B",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument B failed: %v", err)

--- a/internal/db/queries_search_test.go
+++ b/internal/db/queries_search_test.go
@@ -19,7 +19,7 @@ func TestBM25ChunkSearch(t *testing.T) {
 	goDoc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/search-go.md", Title: "Go Programming",
 		Content: "---\ntitle: Go\n---\nGo is a statically typed language", ContentBody: "Go is a statically typed language",
-		Source: models.SourceManual, Labels: []string{"programming"},
+		Labels: []string{"programming"},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument go failed: %v", err)
@@ -29,7 +29,7 @@ func TestBM25ChunkSearch(t *testing.T) {
 	pyDoc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/search-python.md", Title: "Python Programming",
 		Content: "---\ntitle: Python\n---\nPython is a dynamic language", ContentBody: "Python is a dynamic language",
-		Source: models.SourceManual, Labels: []string{"programming"},
+		Labels: []string{"programming"},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument python failed: %v", err)
@@ -65,7 +65,7 @@ func TestSearchWithLabelFilter(t *testing.T) {
 	webDoc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/label-a.md", Title: "Web Doc",
 		Content: "Web frameworks are great", ContentBody: "Web frameworks are great",
-		Source: models.SourceManual, Labels: []string{"web"},
+		Labels: []string{"web"},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument web failed: %v", err)
@@ -75,7 +75,7 @@ func TestSearchWithLabelFilter(t *testing.T) {
 	cliDoc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/label-b.md", Title: "CLI Doc",
 		Content: "CLI tools are useful frameworks", ContentBody: "CLI tools are useful frameworks",
-		Source: models.SourceManual, Labels: []string{"cli"},
+		Labels: []string{"cli"},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument cli failed: %v", err)
@@ -121,7 +121,7 @@ func TestSearchWithFolderFilter(t *testing.T) {
 	guidesDoc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/guides/setup.md", Title: "Setup Guide",
 		Content: "Install the software first", ContentBody: "Install the software first",
-		Source: models.SourceManual, Labels: []string{},
+		Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument guides failed: %v", err)
@@ -131,7 +131,7 @@ func TestSearchWithFolderFilter(t *testing.T) {
 	notesDoc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/notes/install.md", Title: "Install Notes",
 		Content: "Notes about installing software", ContentBody: "Notes about installing software",
-		Source: models.SourceManual, Labels: []string{},
+		Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument notes failed: %v", err)
@@ -182,7 +182,6 @@ func TestHybridSearch(t *testing.T) {
 		Title:       "Hybrid Search Doc",
 		Content:     "hybrid search content for testing",
 		ContentBody: "hybrid search content for testing",
-		Source:      models.SourceManual,
 		Labels:      []string{"test"},
 	})
 	if err != nil {
@@ -236,7 +235,6 @@ func TestGetDocumentsByIDs(t *testing.T) {
 			Title:       fmt.Sprintf("ByIDs Doc %d", i),
 			Content:     "content " + path,
 			ContentBody: "content " + path,
-			Source:      models.SourceManual,
 			Labels:      []string{},
 		})
 		if err != nil {

--- a/internal/db/queries_vault_test.go
+++ b/internal/db/queries_vault_test.go
@@ -87,7 +87,6 @@ func TestDeleteVault(t *testing.T) {
 		Title:       "Test",
 		Content:     "content",
 		ContentBody: "content",
-		Source:      models.SourceManual,
 		ContentHash: &hash,
 		Labels:      []string{},
 	})
@@ -180,7 +179,6 @@ func TestListDocumentPaths(t *testing.T) {
 			Title:       fmt.Sprintf("Doc %d", i),
 			Content:     "content",
 			ContentBody: "content",
-			Source:      models.SourceManual,
 			ContentHash: &hash,
 			Labels:      []string{},
 		})

--- a/internal/db/queries_version.go
+++ b/internal/db/queries_version.go
@@ -20,8 +20,7 @@ func (c *Client) CreateVersion(ctx context.Context, input models.DocumentVersion
 			version = $version,
 			content = $content,
 			content_hash = $content_hash,
-			title = $title,
-			source = $source
+			title = $title
 		RETURN AFTER
 	`
 	results, err := surrealdb.Query[[]models.DocumentVersion](ctx, c.DB(), sql, map[string]any{
@@ -31,7 +30,6 @@ func (c *Client) CreateVersion(ctx context.Context, input models.DocumentVersion
 		"content":      input.Content,
 		"content_hash": input.ContentHash,
 		"title":        input.Title,
-		"source":       string(input.Source),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create version: %w", err)

--- a/internal/db/queries_version_test.go
+++ b/internal/db/queries_version_test.go
@@ -17,7 +17,6 @@ func createTestDocument(t *testing.T, ctx context.Context, vaultID string) *mode
 		Title:       "Version Test Doc",
 		Content:     "version test content",
 		ContentBody: "version test content",
-		Source:      models.SourceManual,
 		Labels:      []string{},
 	})
 	if err != nil {
@@ -41,7 +40,6 @@ func TestCreateVersion(t *testing.T) {
 		Content:     "version 1 content",
 		ContentHash: "hash1",
 		Title:       "Version 1",
-		Source:      models.SourceManual,
 	}, 1)
 	if err != nil {
 		t.Fatalf("CreateVersion failed: %v", err)
@@ -75,7 +73,6 @@ func TestGetVersion(t *testing.T) {
 		Content:     "get version content",
 		ContentHash: "hash-get",
 		Title:       "Get Version",
-		Source:      models.SourceManual,
 	}, 1)
 	if err != nil {
 		t.Fatalf("CreateVersion failed: %v", err)
@@ -112,7 +109,6 @@ func TestGetVersionByNumber(t *testing.T) {
 		Content:     "by number content",
 		ContentHash: "hash-num",
 		Title:       "By Number",
-		Source:      models.SourceManual,
 	}, 1)
 	if err != nil {
 		t.Fatalf("CreateVersion failed: %v", err)
@@ -149,7 +145,6 @@ func TestListVersions(t *testing.T) {
 			Content:     fmt.Sprintf("content v%d", i),
 			ContentHash: fmt.Sprintf("hash-%d", i),
 			Title:       fmt.Sprintf("Version %d", i),
-			Source:      models.SourceManual,
 		}, i)
 		if err != nil {
 			t.Fatalf("CreateVersion %d failed: %v", i, err)
@@ -181,7 +176,6 @@ func TestGetLatestVersion(t *testing.T) {
 			Content:     fmt.Sprintf("content v%d", i),
 			ContentHash: fmt.Sprintf("hash-%d", i),
 			Title:       fmt.Sprintf("Version %d", i),
-			Source:      models.SourceManual,
 		}, i)
 		if err != nil {
 			t.Fatalf("CreateVersion %d failed: %v", i, err)
@@ -216,7 +210,6 @@ func TestCountVersions(t *testing.T) {
 			Content:     fmt.Sprintf("content v%d", i),
 			ContentHash: fmt.Sprintf("hash-%d", i),
 			Title:       fmt.Sprintf("Version %d", i),
-			Source:      models.SourceManual,
 		}, i)
 		if err != nil {
 			t.Fatalf("CreateVersion %d failed: %v", i, err)
@@ -248,7 +241,6 @@ func TestDeleteOldestVersions(t *testing.T) {
 			Content:     fmt.Sprintf("content v%d", i),
 			ContentHash: fmt.Sprintf("hash-%d", i),
 			Title:       fmt.Sprintf("Version %d", i),
-			Source:      models.SourceManual,
 		}, i)
 		if err != nil {
 			t.Fatalf("CreateVersion %d failed: %v", i, err)
@@ -297,7 +289,6 @@ func TestNextVersionNumber(t *testing.T) {
 		Content:     "content v1",
 		ContentHash: "hash-1",
 		Title:       "Version 1",
-		Source:      models.SourceManual,
 	}, 1)
 	if err != nil {
 		t.Fatalf("CreateVersion failed: %v", err)

--- a/internal/db/queries_wikilink_test.go
+++ b/internal/db/queries_wikilink_test.go
@@ -16,7 +16,7 @@ func TestCreateWikiLinks(t *testing.T) {
 
 	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/link-source.md", Title: "Link Source",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument failed: %v", err)
@@ -49,14 +49,14 @@ func TestGetBacklinks(t *testing.T) {
 
 	docA, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/backlink-a.md", Title: "Doc A",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument docA failed: %v", err)
 	}
 	docB, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/backlink-b.md", Title: "Doc B",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument docB failed: %v", err)
@@ -88,7 +88,7 @@ func TestResolveDanglingLinks(t *testing.T) {
 
 	docA, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/dangling-source.md", Title: "Source",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument docA failed: %v", err)
@@ -114,7 +114,7 @@ func TestResolveDanglingLinks(t *testing.T) {
 
 	docB, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/future-doc.md", Title: "Future Doc",
-		Content: "arrived", ContentBody: "arrived", Source: models.SourceManual, Labels: []string{},
+		Content: "arrived", ContentBody: "arrived", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument docB failed: %v", err)
@@ -150,14 +150,14 @@ func TestUnresolveWikiLinksToDoc(t *testing.T) {
 
 	docA, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/unresolve-a.md", Title: "Unresolve A",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument A failed: %v", err)
 	}
 	docB, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/unresolve-b.md", Title: "Unresolve B",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument B failed: %v", err)
@@ -215,7 +215,7 @@ func TestUpdateWikiLinkRawTargets(t *testing.T) {
 
 	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/raw-target-src.md", Title: "Raw Target Source",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument failed: %v", err)
@@ -264,7 +264,7 @@ func TestUpdateWikiLinkRawTargetsByPrefix(t *testing.T) {
 
 	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/prefix-src.md", Title: "Prefix Source",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument failed: %v", err)
@@ -315,7 +315,7 @@ func TestDeleteWikiLinks(t *testing.T) {
 
 	doc, err := testDB.CreateDocument(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/delete-links-test.md", Title: "Delete Links",
-		Content: "content", ContentBody: "content", Source: models.SourceManual, Labels: []string{},
+		Content: "content", ContentBody: "content", Labels: []string{},
 	})
 	if err != nil {
 		t.Fatalf("CreateDocument failed: %v", err)

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -52,10 +52,10 @@ func SchemaSQL(dimension int) string {
     DEFINE FIELD IF NOT EXISTS content_length  ON document TYPE int;
     DEFINE FIELD IF NOT EXISTS labels       ON document TYPE array<string> DEFAULT [];
     DEFINE FIELD IF NOT EXISTS doc_type     ON document TYPE option<string>;
-    DEFINE FIELD IF NOT EXISTS source       ON document TYPE string DEFAULT "manual";
-    DEFINE FIELD IF NOT EXISTS source_path  ON document TYPE option<string>;
     DEFINE FIELD IF NOT EXISTS content_hash ON document TYPE option<string>;
     DEFINE FIELD IF NOT EXISTS metadata   ON document TYPE option<object> FLEXIBLE;
+    REMOVE FIELD IF EXISTS source ON document;
+    REMOVE FIELD IF EXISTS source_path ON document;
     DEFINE FIELD IF NOT EXISTS processed       ON document TYPE bool DEFAULT false;
     DEFINE FIELD IF NOT EXISTS last_accessed_at ON document TYPE option<datetime>;
     DEFINE FIELD IF NOT EXISTS access_count     ON document TYPE int DEFAULT 0;
@@ -103,8 +103,8 @@ func SchemaSQL(dimension int) string {
     DEFINE FIELD IF NOT EXISTS content      ON document_version TYPE string;
     DEFINE FIELD IF NOT EXISTS content_hash ON document_version TYPE string;
     DEFINE FIELD IF NOT EXISTS title        ON document_version TYPE string;
-    DEFINE FIELD IF NOT EXISTS source       ON document_version TYPE string DEFAULT "manual";
     DEFINE FIELD IF NOT EXISTS created_at   ON document_version TYPE datetime DEFAULT time::now();
+    REMOVE FIELD IF EXISTS source ON document_version;
 
     DEFINE INDEX IF NOT EXISTS idx_version_document        ON document_version FIELDS document;
     DEFINE INDEX IF NOT EXISTS idx_version_document_version ON document_version FIELDS document, version UNIQUE;

--- a/internal/document/service.go
+++ b/internal/document/service.go
@@ -190,8 +190,6 @@ func (s *Service) Create(ctx context.Context, input models.DocumentInput) (*mode
 		Title:       title,
 		Content:     input.Content,
 		ContentBody: contentBody,
-		Source:      input.Source,
-		SourcePath:  input.SourcePath,
 		ContentHash: &contentHash,
 		Labels:      allLabels,
 		DocType:     docType,
@@ -494,7 +492,6 @@ func (s *Service) Update(ctx context.Context, vaultID, path, content string) (*m
 		VaultID: vaultID,
 		Path:    path,
 		Content: content,
-		Source:  models.SourceManual,
 	})
 }
 

--- a/internal/document/template.go
+++ b/internal/document/template.go
@@ -42,4 +42,3 @@ func IsTemplatePath(templateFolder, docPath string) bool {
 	}
 	return strings.HasPrefix(docPath, templateFolder)
 }
-

--- a/internal/document/version.go
+++ b/internal/document/version.go
@@ -47,7 +47,6 @@ func (s *Service) maybeCreateVersion(ctx context.Context, docID, vaultID string,
 		Content:     oldDoc.Content,
 		ContentHash: hash,
 		Title:       oldDoc.Title,
-		Source:      oldDoc.Source,
 	}, nextVersion); err != nil {
 		slog.Warn("failed to create version snapshot", "doc_id", docID, "version", nextVersion, "error", err)
 		return
@@ -104,7 +103,6 @@ func (s *Service) Rollback(ctx context.Context, vaultID, documentID, versionID s
 		VaultID: vaultID,
 		Path:    doc.Path,
 		Content: version.Content,
-		Source:  models.SourceRollback,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("apply rollback: %w", err)

--- a/internal/event/bus_test.go
+++ b/internal/event/bus_test.go
@@ -359,9 +359,7 @@ func TestBus_Close_ConcurrentPublish(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range numPublishers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := range 100 {
 				bus.Publish(ChangeEvent{
 					Type:    "document.updated",
@@ -369,7 +367,7 @@ func TestBus_Close_ConcurrentPublish(t *testing.T) {
 					Payload: DocumentPayload{DocID: "doc:1", Path: "a.md", ContentHash: string(rune(i))},
 				})
 			}
-		}()
+		})
 	}
 
 	// Close while publishers are active — must not panic.
@@ -387,9 +385,7 @@ func TestBus_Close_ConcurrentSubscribe(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range 100 {
 				ch, unsub := bus.Subscribe("vault:a")
 				// Read one event or notice the channel is closed.
@@ -399,7 +395,7 @@ func TestBus_Close_ConcurrentSubscribe(t *testing.T) {
 				}
 				unsub()
 			}
-		}()
+		})
 	}
 
 	// Close while subscribers are registering — must not panic.

--- a/internal/integration/bulk_test.go
+++ b/internal/integration/bulk_test.go
@@ -356,43 +356,6 @@ func TestBulkUpload_EmptyRequest(t *testing.T) {
 	}
 }
 
-func TestBulkUpload_InvalidSource(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "invalid-source")
-
-	var buf bytes.Buffer
-	writer := multipart.NewWriter(&buf)
-
-	metaPart, err := writer.CreateFormField("meta")
-	if err != nil {
-		t.Fatalf("create meta part: %v", err)
-	}
-	if err := json.NewEncoder(metaPart).Encode(map[string]any{
-		"vaultId": vaultID,
-		"source":  "invalid_source",
-	}); err != nil {
-		t.Fatalf("encode meta: %v", err)
-	}
-	if err := writer.Close(); err != nil {
-		t.Fatalf("close writer: %v", err)
-	}
-
-	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/bulk", &buf)
-	if err != nil {
-		t.Fatalf("create request: %v", err)
-	}
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("send request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", resp.StatusCode)
-	}
-}
-
 func TestBulkUpload_MissingVaultID(t *testing.T) {
 	srv, _ := setupBulkServer(t, "no-vault")
 

--- a/internal/integration/folder_test.go
+++ b/internal/integration/folder_test.go
@@ -43,7 +43,6 @@ func TestFolderAutoCreate(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/guides/sub/file.md",
 		Content: "# Guide",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create doc: %v", err)
@@ -84,7 +83,6 @@ func TestFolderRootDocNoFolders(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/readme.md",
 		Content: "# Readme",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create doc: %v", err)
@@ -143,7 +141,6 @@ func TestFolderEmptyPersistence(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/notes/file.md",
 		Content: "# Note",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create doc: %v", err)
@@ -219,7 +216,6 @@ func TestFolderDeleteCascade(t *testing.T) {
 			VaultID: vaultID,
 			Path:    p,
 			Content: "# Doc at " + p,
-			Source:  models.SourceManual,
 		})
 		if err != nil {
 			t.Fatalf("create doc %s: %v", p, err)
@@ -231,7 +227,6 @@ func TestFolderDeleteCascade(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/other/c.md",
 		Content: "# Other",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create other doc: %v", err)
@@ -292,7 +287,6 @@ func TestFolderMoveBasic(t *testing.T) {
 			VaultID: vaultID,
 			Path:    p,
 			Content: "# Doc at " + p,
-			Source:  models.SourceManual,
 		})
 		if err != nil {
 			t.Fatalf("create doc %s: %v", p, err)
@@ -304,7 +298,6 @@ func TestFolderMoveBasic(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/other/c.md",
 		Content: "# Other",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create other doc: %v", err)
@@ -382,7 +375,6 @@ func TestFolderMoveCreatesAncestors(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/guides/a.md",
 		Content: "# Guide",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create doc: %v", err)
@@ -426,7 +418,6 @@ func TestFolderListByParent(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/a/b/c/file.md",
 		Content: "# Deep",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create doc: %v", err)
@@ -437,7 +428,6 @@ func TestFolderListByParent(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/a/sibling/file.md",
 		Content: "# Sibling",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create doc: %v", err)
@@ -491,7 +481,6 @@ func TestFolderListAll(t *testing.T) {
 			VaultID: vaultID,
 			Path:    p,
 			Content: "# Doc",
-			Source:  models.SourceManual,
 		})
 		if err != nil {
 			t.Fatalf("create doc %s: %v", p, err)

--- a/internal/integration/lifecycle_test.go
+++ b/internal/integration/lifecycle_test.go
@@ -150,7 +150,6 @@ See also [[Beta Notes]] and [[missing-page]].
 
 #architecture #go
 `,
-		Source: models.SourceScrape,
 	})
 	if err != nil {
 		t.Fatalf("create doc1: %v", err)
@@ -202,7 +201,6 @@ labels: [notes]
 
 Some notes about the beta project.
 `,
-		Source: models.SourceScrape,
 	})
 	if err != nil {
 		t.Fatalf("create doc2: %v", err)
@@ -353,7 +351,6 @@ labels: [notes, updated]
 
 Updated content for beta.
 `,
-		Source: models.SourceScrape,
 	})
 	if err != nil {
 		t.Fatalf("upsert doc2: %v", err)
@@ -395,7 +392,6 @@ func TestDeleteByPrefix(t *testing.T) {
 			VaultID: vaultID,
 			Path:    path,
 			Content: "# Doc at " + path,
-			Source:  models.SourceManual,
 		})
 		if err != nil {
 			t.Fatalf("create doc %s: %v", path, err)
@@ -463,7 +459,6 @@ func TestMoveByPrefix(t *testing.T) {
 			VaultID: vaultID,
 			Path:    path,
 			Content: "# Doc at " + path,
-			Source:  models.SourceManual,
 		})
 		if err != nil {
 			t.Fatalf("create doc %s: %v", path, err)
@@ -539,7 +534,6 @@ func TestDeleteByPrefix_BoundaryCollision(t *testing.T) {
 			VaultID: vaultID,
 			Path:    path,
 			Content: "# Doc at " + path,
-			Source:  models.SourceManual,
 		})
 		if err != nil {
 			t.Fatalf("create doc %s: %v", path, err)
@@ -613,7 +607,6 @@ func TestMoveByPrefix_NestedSubfolders(t *testing.T) {
 			VaultID: vaultID,
 			Path:    path,
 			Content: "# Doc at " + path,
-			Source:  models.SourceManual,
 		})
 		if err != nil {
 			t.Fatalf("create doc %s: %v", path, err)
@@ -678,7 +671,6 @@ func TestMoveByPrefix_BoundaryCollision(t *testing.T) {
 			VaultID: vaultID,
 			Path:    path,
 			Content: "# Doc at " + path,
-			Source:  models.SourceManual,
 		})
 		if err != nil {
 			t.Fatalf("create doc %s: %v", path, err)
@@ -739,7 +731,6 @@ func TestMoveByPrefix_SamePrefix(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/folder/a.md",
 		Content: "# Doc",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create doc: %v", err)
@@ -791,7 +782,7 @@ func TestDeleteUnresolvesIncomingWikiLinks(t *testing.T) {
 	// Create doc B (target)
 	docB, err := docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/target.md",
-		Content: "# Target\n\nTarget content.", Source: models.SourceManual,
+		Content: "# Target\n\nTarget content.",
 	})
 	if err != nil {
 		t.Fatalf("create target doc: %v", err)
@@ -804,7 +795,7 @@ func TestDeleteUnresolvesIncomingWikiLinks(t *testing.T) {
 	// Create doc A (source) that links to Target
 	docA, err := docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/source.md",
-		Content: "# Source\n\nSee [[Target]].", Source: models.SourceManual,
+		Content: "# Source\n\nSee [[Target]].",
 	})
 	if err != nil {
 		t.Fatalf("create source doc: %v", err)
@@ -883,7 +874,7 @@ func TestMoveUpdatesWikiLinkRawTargets(t *testing.T) {
 	// Create target doc
 	_, err = docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/old/target.md",
-		Content: "# Target", Source: models.SourceManual,
+		Content: "# Target",
 	})
 	if err != nil {
 		t.Fatalf("create target: %v", err)
@@ -895,7 +886,7 @@ func TestMoveUpdatesWikiLinkRawTargets(t *testing.T) {
 	// Create source doc linking by path
 	docA, err := docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/source.md",
-		Content: "# Source\n\nSee [[/old/target.md]].", Source: models.SourceManual,
+		Content: "# Source\n\nSee [[/old/target.md]].",
 	})
 	if err != nil {
 		t.Fatalf("create source: %v", err)
@@ -951,7 +942,7 @@ func TestMoveByPrefixUpdatesWikiLinkRawTargets(t *testing.T) {
 	// Create docs under /old-dir/
 	_, err = docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/old-dir/a.md",
-		Content: "# A", Source: models.SourceManual,
+		Content: "# A",
 	})
 	if err != nil {
 		t.Fatalf("create a: %v", err)
@@ -963,7 +954,7 @@ func TestMoveByPrefixUpdatesWikiLinkRawTargets(t *testing.T) {
 	// Create source that references paths under /old-dir/
 	src, err := docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/source.md",
-		Content: "# Source\n\nSee [[/old-dir/a.md]].", Source: models.SourceManual,
+		Content: "# Source\n\nSee [[/old-dir/a.md]].",
 	})
 	if err != nil {
 		t.Fatalf("create source: %v", err)
@@ -1022,14 +1013,14 @@ func TestProcessRelatesToDeleteThenRecreate(t *testing.T) {
 	// Create target docs
 	_, err = docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/target-a.md",
-		Content: "# Target A", Source: models.SourceManual,
+		Content: "# Target A",
 	})
 	if err != nil {
 		t.Fatalf("create target-a: %v", err)
 	}
 	_, err = docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/target-b.md",
-		Content: "# Target B", Source: models.SourceManual,
+		Content: "# Target B",
 	})
 	if err != nil {
 		t.Fatalf("create target-b: %v", err)
@@ -1042,7 +1033,6 @@ func TestProcessRelatesToDeleteThenRecreate(t *testing.T) {
 	src, err := docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/relto-src.md",
 		Content: "---\ntitle: Source\nrelates_to:\n  - Target A\n---\n# Source",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create source: %v", err)
@@ -1065,7 +1055,6 @@ func TestProcessRelatesToDeleteThenRecreate(t *testing.T) {
 	_, err = docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/relto-src.md",
 		Content: "---\ntitle: Source\nrelates_to:\n  - Target B\n---\n# Source Updated",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("update source: %v", err)
@@ -1087,7 +1076,6 @@ func TestProcessRelatesToDeleteThenRecreate(t *testing.T) {
 	_, err = docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/relto-src.md",
 		Content: "---\ntitle: Source\n---\n# Source No Relations",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("update source no rels: %v", err)
@@ -1134,7 +1122,6 @@ func TestLabelGraph(t *testing.T) {
 	doc1, err := docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/labeled-1.md",
 		Content: "---\nlabels: [go, backend]\n---\n# Doc 1",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create doc1: %v", err)
@@ -1144,7 +1131,6 @@ func TestLabelGraph(t *testing.T) {
 	doc2, err := docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/labeled-2.md",
 		Content: "---\nlabels: [go, frontend]\n---\n# Doc 2",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create doc2: %v", err)
@@ -1195,7 +1181,6 @@ func TestLabelGraph(t *testing.T) {
 	_, err = docSvc.Create(ctx, models.DocumentInput{
 		VaultID: vaultID, Path: "/labeled-1.md",
 		Content: "---\nlabels: [go, infra]\n---\n# Doc 1 Updated",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("update doc1: %v", err)
@@ -1266,7 +1251,6 @@ func TestSyncChunks_PreservesUnchangedChunks(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/sync-test.md",
 		Content: "# Title\n\nFirst paragraph content.\n\nSecond paragraph content.",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create doc: %v", err)
@@ -1301,7 +1285,6 @@ func TestSyncChunks_PreservesUnchangedChunks(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/sync-test.md",
 		Content: "# Title\n\nFirst paragraph content.\n\nSecond paragraph content.",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("upsert same content: %v", err)
@@ -1333,7 +1316,6 @@ func TestSyncChunks_PreservesUnchangedChunks(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/sync-test.md",
 		Content: "# New Title\n\nCompletely different content here.",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("upsert new content: %v", err)
@@ -1392,7 +1374,6 @@ func TestSyncChunks_PartialUpdate(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/partial-sync.md",
 		Content: longContent,
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create doc: %v", err)
@@ -1417,7 +1398,6 @@ func TestSyncChunks_PartialUpdate(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/partial-sync.md",
 		Content: updatedContent,
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("update doc: %v", err)

--- a/internal/integration/processing_test.go
+++ b/internal/integration/processing_test.go
@@ -53,7 +53,6 @@ func TestCreate_DefersChunksAndWikiLinks(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/deferred-test.md",
 		Content: wikiContent,
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create: %v", err)
@@ -139,7 +138,6 @@ func TestProcessAllPending_ProcessesMultipleDocuments(t *testing.T) {
 			VaultID: vaultID,
 			Path:    fmt.Sprintf("/multi-%d.md", i),
 			Content: fmt.Sprintf("# Doc %d\n\nContent for document %d.", i, i),
-			Source:  models.SourceManual,
 		})
 		if err != nil {
 			t.Fatalf("create doc %d: %v", i, err)
@@ -180,7 +178,6 @@ func TestUpdate_ResetsProcessedFlag(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/reset-test.md",
 		Content: "# Original\n\nOriginal content.",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create: %v", err)
@@ -206,7 +203,6 @@ func TestUpdate_ResetsProcessedFlag(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/reset-test.md",
 		Content: "# Updated\n\nNew content after update.",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("update: %v", err)
@@ -235,7 +231,6 @@ func TestProcessDocument_Idempotent(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/idempotent-test.md",
 		Content: longContent,
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create: %v", err)

--- a/internal/integration/version_test.go
+++ b/internal/integration/version_test.go
@@ -52,7 +52,6 @@ func TestVersionLifecycle(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/docs/versioned.md",
 		Content: "# Version 1\n\nOriginal content.\n",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create doc: %v", err)
@@ -76,7 +75,6 @@ func TestVersionLifecycle(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/docs/versioned.md",
 		Content: "# Version 2\n\nUpdated content.\n",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("update doc v2: %v", err)
@@ -102,7 +100,6 @@ func TestVersionLifecycle(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/docs/versioned.md",
 		Content: "# Version 3\n\nThird revision.\n",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("update doc v3: %v", err)
@@ -122,7 +119,6 @@ func TestVersionLifecycle(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/docs/versioned.md",
 		Content: "# Version 3\n\nThird revision.\n",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("no-op update: %v", err)
@@ -151,9 +147,6 @@ func TestVersionLifecycle(t *testing.T) {
 	}
 	if restored.Content != v1.Content {
 		t.Errorf("rollback content mismatch:\ngot:  %q\nwant: %q", restored.Content, v1.Content)
-	}
-	if restored.Source != models.SourceRollback {
-		t.Errorf("rollback source: got %q, want %q", restored.Source, models.SourceRollback)
 	}
 
 	// Should have 3 versions now (v1=original, v2=first update, v3=pre-rollback)
@@ -225,7 +218,6 @@ func TestVersionCoalescing(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/docs/coalesce.md",
 		Content: "v1\n",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create: %v", err)
@@ -245,7 +237,6 @@ func TestVersionCoalescing(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/docs/coalesce.md",
 		Content: "v2\n",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("update v2: %v", err)
@@ -264,7 +255,6 @@ func TestVersionCoalescing(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/docs/coalesce.md",
 		Content: "v3\n",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("update v3: %v", err)
@@ -322,7 +312,6 @@ func TestVersionRetention(t *testing.T) {
 		VaultID: vaultID,
 		Path:    "/docs/retention.md",
 		Content: "v0\n",
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		t.Fatalf("create: %v", err)
@@ -343,7 +332,6 @@ func TestVersionRetention(t *testing.T) {
 			VaultID: vaultID,
 			Path:    "/docs/retention.md",
 			Content: "v" + itoa(i) + "\n",
-			Source:  models.SourceManual,
 		})
 		if err != nil {
 			t.Fatalf("update v%d: %v", i, err)

--- a/internal/memory/service.go
+++ b/internal/memory/service.go
@@ -58,7 +58,6 @@ func (s *Service) Create(ctx context.Context, vaultID, project, title, content s
 		VaultID: vaultID,
 		Path:    path,
 		Content: fullContent,
-		Source:  models.SourceMCP,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create: %w", err)
@@ -262,7 +261,6 @@ func (s *Service) consolidate(ctx context.Context, vaultID string, memories []Sc
 			VaultID: vaultID,
 			Path:    path,
 			Content: fullContent,
-			Source:  models.SourceMCP,
 		})
 		if err != nil {
 			logger.Warn("consolidation create merged doc", "error", err)

--- a/internal/models/document.go
+++ b/internal/models/document.go
@@ -6,26 +6,6 @@ import (
 	surrealmodels "github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
-type DocumentSource string
-
-const (
-	SourceManual      DocumentSource = "manual"
-	SourceScrape      DocumentSource = "scrape"
-	SourceCP          DocumentSource = "cp"
-	SourceMCP         DocumentSource = "mcp"
-	SourceAIGenerated DocumentSource = "ai_generated"
-	SourceRollback    DocumentSource = "rollback"
-)
-
-// Valid returns true if the DocumentSource is a known value.
-func (s DocumentSource) Valid() bool {
-	switch s {
-	case SourceManual, SourceScrape, SourceCP, SourceMCP, SourceAIGenerated, SourceRollback:
-		return true
-	}
-	return false
-}
-
 type Document struct {
 	ID             surrealmodels.RecordID `json:"id"`
 	Vault          surrealmodels.RecordID `json:"vault"`
@@ -36,8 +16,6 @@ type Document struct {
 	ContentLength  int                    `json:"content_length"`
 	Labels         []string               `json:"labels"`
 	DocType        *string                `json:"doc_type,omitempty"`
-	Source         DocumentSource         `json:"source"`
-	SourcePath     *string                `json:"source_path,omitempty"`
 	ContentHash    *string                `json:"content_hash,omitempty"`
 	Metadata       map[string]any         `json:"metadata,omitempty"`
 	Processed      bool                   `json:"processed"`
@@ -53,8 +31,6 @@ type DocumentInput struct {
 	Title       string         `json:"title"`
 	Content     string         `json:"content"`
 	ContentBody string         `json:"content_body"`
-	Source      DocumentSource `json:"source"`
-	SourcePath  *string        `json:"source_path,omitempty"`
 	ContentHash *string        `json:"content_hash,omitempty"`
 	Labels      []string       `json:"labels,omitempty"`
 	DocType     *string        `json:"doc_type,omitempty"`

--- a/internal/models/version.go
+++ b/internal/models/version.go
@@ -16,7 +16,6 @@ type DocumentVersion struct {
 	Content     string                 `json:"content"`
 	ContentHash string                 `json:"content_hash"`
 	Title       string                 `json:"title"`
-	Source      DocumentSource         `json:"source"`
 	CreatedAt   time.Time              `json:"created_at"`
 }
 
@@ -27,5 +26,4 @@ type DocumentVersionInput struct {
 	Content     string
 	ContentHash string
 	Title       string
-	Source      DocumentSource
 }

--- a/internal/parser/queryblock.go
+++ b/internal/parser/queryblock.go
@@ -47,11 +47,11 @@ type QueryBlock struct {
 
 var (
 	knowBlockRegex = regexp.MustCompile("(?s)```know\\n(.*?)```")
-	whereRegex        = regexp.MustCompile(`(?i)^WHERE\s+(.+)$`)
-	fromRegex         = regexp.MustCompile(`(?i)^FROM\s+(\S+)$`)
-	showRegex         = regexp.MustCompile(`(?i)^SHOW\s+(.+)$`)
-	sortRegex         = regexp.MustCompile(`(?i)^SORT\s+(\S+)(?:\s+(ASC|DESC))?$`)
-	limitRegex        = regexp.MustCompile(`(?i)^LIMIT\s+(\d+)$`)
+	whereRegex     = regexp.MustCompile(`(?i)^WHERE\s+(.+)$`)
+	fromRegex      = regexp.MustCompile(`(?i)^FROM\s+(\S+)$`)
+	showRegex      = regexp.MustCompile(`(?i)^SHOW\s+(.+)$`)
+	sortRegex      = regexp.MustCompile(`(?i)^SORT\s+(\S+)(?:\s+(ASC|DESC))?$`)
+	limitRegex     = regexp.MustCompile(`(?i)^LIMIT\s+(\d+)$`)
 
 	// WHERE condition patterns
 	condContainRegex  = regexp.MustCompile(`(?i)^(\w+)\s+CONTAIN\s+"([^"]+)"$`)

--- a/internal/remote/executor.go
+++ b/internal/remote/executor.go
@@ -245,7 +245,6 @@ func (e *Executor) execUpsertDocument(ctx context.Context, vaultID, arguments, v
 		VaultID: vaultID,
 		Path:    input.Path,
 		Content: input.Content,
-		Source:  "ai_generated",
 	})
 	durationMs := time.Since(start).Milliseconds()
 	if err != nil {
@@ -284,7 +283,6 @@ func (e *Executor) execCreateMemory(ctx context.Context, vaultID, arguments stri
 		VaultID: vaultID,
 		Path:    path,
 		Content: fullContent,
-		Source:  "mcp",
 	})
 	durationMs := time.Since(start).Milliseconds()
 	if err != nil {
@@ -335,7 +333,6 @@ func (e *Executor) execGetDocumentVersions(ctx context.Context, vaultID, argumen
 			fmt.Fprintf(&sb, "### Version %d\n", v.Version)
 			fmt.Fprintf(&sb, "- Title: %s\n", v.Title)
 			fmt.Fprintf(&sb, "- Created: %s\n", v.CreatedAt.Format(time.RFC3339))
-			fmt.Fprintf(&sb, "- Source: %s\n", v.Source)
 			fmt.Fprintf(&sb, "- Hash: %s\n\n", v.ContentHash)
 		}
 	}

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/joho/godotenv"
 	"github.com/cloudwego/eino/components/tool"
+	"github.com/joho/godotenv"
 	"github.com/raphi011/know/internal/agent"
 	"github.com/raphi011/know/internal/asset"
 	"github.com/raphi011/know/internal/auth"

--- a/internal/sshd/handler.go
+++ b/internal/sshd/handler.go
@@ -438,7 +438,6 @@ func (w *writeBuffer) Close() error {
 		VaultID: w.vaultID,
 		Path:    w.path,
 		Content: content,
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		slog.Error("sftp: failed to save document on close",

--- a/internal/tools/multivault.go
+++ b/internal/tools/multivault.go
@@ -210,8 +210,8 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 		},
 		{
 			info: &schema.ToolInfo{
-				Name: "list_labels",
-				Desc: "List all labels/categories used across documents in all vaults",
+				Name:        "list_labels",
+				Desc:        "List all labels/categories used across documents in all vaults",
 				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{}),
 			},
 			merge: mergeDedupCSV,

--- a/internal/tools/tool_create_document.go
+++ b/internal/tools/tool_create_document.go
@@ -68,7 +68,6 @@ func (t *CreateDocumentTool) InvokableRun(ctx context.Context, argumentsInJSON s
 		VaultID: o.VaultID,
 		Path:    args.Path,
 		Content: args.Content,
-		Source:  models.SourceAIGenerated,
 	})
 	durationMs := time.Since(start).Milliseconds()
 	if err != nil {

--- a/internal/tools/tool_create_memory.go
+++ b/internal/tools/tool_create_memory.go
@@ -87,7 +87,6 @@ func (t *CreateMemoryTool) InvokableRun(ctx context.Context, argumentsInJSON str
 		VaultID: o.VaultID,
 		Path:    path,
 		Content: fullContent,
-		Source:  models.SourceMCP,
 	})
 	durationMs := time.Since(start).Milliseconds()
 	if err != nil {

--- a/internal/tools/tool_edit_document.go
+++ b/internal/tools/tool_edit_document.go
@@ -76,7 +76,6 @@ func (t *EditDocumentTool) InvokableRun(ctx context.Context, argumentsInJSON str
 		VaultID: o.VaultID,
 		Path:    args.Path,
 		Content: args.Content,
-		Source:  models.SourceAIGenerated,
 	})
 	durationMs := time.Since(start).Milliseconds()
 	if err != nil {

--- a/internal/tools/tool_edit_document_section.go
+++ b/internal/tools/tool_edit_document_section.go
@@ -125,7 +125,6 @@ func (t *EditDocumentSectionTool) InvokableRun(ctx context.Context, argumentsInJ
 		VaultID: o.VaultID,
 		Path:    args.Path,
 		Content: newContent,
-		Source:  models.SourceAIGenerated,
 	})
 	durationMs := time.Since(start).Milliseconds()
 	if err != nil {

--- a/internal/tools/tool_get_document_versions.go
+++ b/internal/tools/tool_get_document_versions.go
@@ -98,7 +98,6 @@ func (t *GetDocumentVersionsTool) InvokableRun(ctx context.Context, argumentsInJ
 			fmt.Fprintf(&sb, "### Version %d\n", v.Version)
 			fmt.Fprintf(&sb, "- Title: %s\n", v.Title)
 			fmt.Fprintf(&sb, "- Created: %s\n", v.CreatedAt.Format(time.RFC3339))
-			fmt.Fprintf(&sb, "- Source: %s\n", v.Source)
 			fmt.Fprintf(&sb, "- Hash: %s\n\n", v.ContentHash)
 		}
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -62,7 +62,7 @@ type Model struct {
 	spinner  spinner.Model
 
 	// Streaming state
-	streaming bool
+	streaming   bool
 	streamParts []ContentPart
 	dialog      *approvalDialog // non-nil when diff dialog is active
 	errMsg      string

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -372,10 +372,7 @@ func renderHunks(hunks []diff.Hunk) string {
 			}
 		}
 	}
-	gutterWidth := len(fmt.Sprintf("%d", maxLineNo))
-	if gutterWidth < 2 {
-		gutterWidth = 2
-	}
+	gutterWidth := max(len(fmt.Sprintf("%d", maxLineNo)), 2)
 
 	for i, h := range hunks {
 		if i > 0 {
@@ -418,10 +415,7 @@ func renderNewDocPreview(content string) string {
 	var sb strings.Builder
 	lines := strings.Split(content, "\n")
 
-	gutterWidth := len(fmt.Sprintf("%d", len(lines)))
-	if gutterWidth < 2 {
-		gutterWidth = 2
-	}
+	gutterWidth := max(len(fmt.Sprintf("%d", len(lines))), 2)
 
 	for i, line := range lines {
 		lineNo := fmt.Sprintf("%*d", gutterWidth, i+1)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -82,8 +82,8 @@ var (
 	fileListSelectedStyle = lipgloss.NewStyle().Foreground(primaryColor).Bold(true).PaddingLeft(2)
 
 	// Diff styles
-	diffAddStyle        = lipgloss.NewStyle().Foreground(accentColor)  // green for added lines
-	diffDeleteStyle     = lipgloss.NewStyle().Foreground(errorColor)   // red for deleted lines
+	diffAddStyle        = lipgloss.NewStyle().Foreground(accentColor)               // green for added lines
+	diffDeleteStyle     = lipgloss.NewStyle().Foreground(errorColor)                // red for deleted lines
 	diffHunkHeaderStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#60A5FA")) // blue for @@ headers
 	diffGutterStyle     = lipgloss.NewStyle().Foreground(mutedColor)
 	diffSeparatorStyle  = lipgloss.NewStyle().Foreground(mutedColor)

--- a/internal/webdav/file.go
+++ b/internal/webdav/file.go
@@ -125,7 +125,6 @@ func (f *writeFile) Close() error {
 		VaultID: f.vaultID,
 		Path:    f.name,
 		Content: content,
-		Source:  models.SourceManual,
 	})
 	if err != nil {
 		slog.Error("webdav: failed to save document on close",


### PR DESCRIPTION
## Summary
- Remove `DocumentSource` type, `Source`/`SourcePath` fields from `Document`, `DocumentInput`, `DocumentVersion`, and `DocumentVersionInput` models
- Remove `source`/`source_path` from DB schema, queries, and API layer (REST types, handlers, client)
- Remove `--source` CLI flag from `know cp`
- Add `REMOVE FIELD IF EXISTS` statements to schema for existing database cleanup
- Delete `TestBulkUpload_InvalidSource` (no longer applicable)

## Test plan
- [x] All Go tests pass (`just test`)
- [x] `go vet` clean
- [x] `gofmt` clean
- [ ] Verify `just bootstrap` works with fresh DB
- [ ] Verify `just bootstrap` works with existing DB (field removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)