### PR TITLE
feat: improve MCP tool descriptions, error messages, and validation

### DIFF
--- a/internal/integration/mcp_tools_test.go
+++ b/internal/integration/mcp_tools_test.go
@@ -771,12 +771,16 @@ func TestToolsExecutor_ReadDocument_NotFound(t *testing.T) {
 	exec, vaultID := setupExecutor(t, "read-404")
 	ctx := context.Background()
 
-	result, _, err := exec.ExecuteTool(ctx, vaultID, "read_document", `{"path":"/nonexistent.md"}`)
-	if err != nil {
-		t.Fatalf("read_document: %v", err)
+	_, _, err := exec.ExecuteTool(ctx, vaultID, "read_document", `{"path":"/nonexistent.md"}`)
+	if err == nil {
+		t.Fatal("expected error for reading nonexistent document")
 	}
-	if !strings.Contains(result, "Document not found") {
-		t.Errorf("expected 'Document not found', got: %s", result)
+	var toolErr *tools.ToolError
+	if !errors.As(err, &toolErr) {
+		t.Fatalf("expected ToolError, got %T: %v", err, err)
+	}
+	if !strings.Contains(toolErr.Message, "document not found") {
+		t.Errorf("expected 'document not found' in error, got: %s", toolErr.Message)
 	}
 }
 

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -44,7 +45,7 @@ func (t *mcpTools) register(server *mcp.Server) {
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_documents",
-		Description: "Search documents using full-text and semantic search. Returns titles, paths, scores, and matching snippets.",
+		Description: "Search documents using full-text and semantic search. Returns titles, paths, scores, and matching snippets. Use list_labels first to discover labels for filtering.",
 		Annotations: readOnly,
 	}, t.searchDocuments)
 
@@ -68,7 +69,7 @@ func (t *mcpTools) register(server *mcp.Server) {
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "list_folder_contents",
-		Description: "List documents and subfolders in a specific folder. Returns immediate children only.",
+		Description: "List documents and subfolders in a specific folder. Returns immediate children only. Use list_folders first to discover available folders.",
 		Annotations: readOnly,
 	}, t.listFolderContents)
 
@@ -124,10 +125,10 @@ func (t *mcpTools) register(server *mcp.Server) {
 
 type searchInput struct {
 	Query   string   `json:"query" jsonschema:"Search query text"`
-	Labels  []string `json:"labels,omitempty" jsonschema:"Filter by labels"`
-	DocType *string  `json:"doc_type,omitempty" jsonschema:"Filter by document type"`
-	Folder  *string  `json:"folder,omitempty" jsonschema:"Filter by folder path prefix"`
-	Limit   *int     `json:"limit,omitempty" jsonschema:"Max results (default 20)"`
+	Labels  []string `json:"labels,omitempty" jsonschema:"Filter by labels (call list_labels to discover available labels)"`
+	DocType *string  `json:"doc_type,omitempty" jsonschema:"Filter by document type (from frontmatter, e.g. note, guide, reference)"`
+	Folder  *string  `json:"folder,omitempty" jsonschema:"Filter by folder path prefix (e.g. /guides/)"`
+	Limit   *int     `json:"limit,omitempty" jsonschema:"Max results (default 20, max 100)"`
 }
 
 func (t *mcpTools) searchDocuments(ctx context.Context, req *mcp.CallToolRequest, input searchInput) (*mcp.CallToolResult, any, error) {
@@ -135,7 +136,10 @@ func (t *mcpTools) searchDocuments(ctx context.Context, req *mcp.CallToolRequest
 		return errorResult("query is required"), nil, nil
 	}
 	if input.Limit != nil && *input.Limit < 1 {
-		return errorResult("limit must be positive"), nil, nil
+		return errorResult("limit must be a positive integer (e.g. 10, 20, 50)"), nil, nil
+	}
+	if input.Limit != nil && *input.Limit > 100 {
+		return errorResult("limit must be at most 100"), nil, nil
 	}
 
 	refs, err := t.resolveAllVaults(ctx)
@@ -149,10 +153,12 @@ func (t *mcpTools) searchDocuments(ctx context.Context, req *mcp.CallToolRequest
 	}
 
 	var sb strings.Builder
+	var failedVaults int
 	for _, ref := range refs {
 		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "search", string(argsJSON))
 		if execErr != nil {
 			logutil.FromCtx(ctx).Warn("search failed", "vault", ref.VaultID, "namespace", ref.Namespace, "error", execErr)
+			failedVaults++
 			continue
 		}
 		if result != "" && result != "No results found." {
@@ -164,6 +170,9 @@ func (t *mcpTools) searchDocuments(ctx context.Context, req *mcp.CallToolRequest
 	}
 
 	if sb.Len() == 0 {
+		if failedVaults > 0 && failedVaults == len(refs) {
+			return errorResult(fmt.Sprintf("search failed for all %d vault(s). Check server logs for details", failedVaults)), nil, nil
+		}
 		return textResult("No results found."), nil, nil
 	}
 	return textResult(sb.String()), nil, nil
@@ -192,18 +201,19 @@ func (t *mcpTools) getDocument(ctx context.Context, req *mcp.CallToolRequest, in
 	for _, ref := range refs {
 		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "read_document", string(argsJSON))
 		if execErr != nil {
+			if isToolLevelError(execErr) {
+				continue // not found in this vault, try next
+			}
 			logutil.FromCtx(ctx).Warn("get document failed", "vault", ref.VaultID, "namespace", ref.Namespace, "path", input.Path, "error", execErr)
 			continue
 		}
-		if !strings.HasPrefix(result, "Document not found:") {
-			if ref.IsRemote() {
-				result = fmt.Sprintf("[%s]\n%s", ref.Namespace, result)
-			}
-			return textResult(result), nil, nil
+		if ref.IsRemote() {
+			result = fmt.Sprintf("[%s]\n%s", ref.Namespace, result)
 		}
+		return textResult(result), nil, nil
 	}
 
-	return errorResult(fmt.Sprintf("Document not found: %s. Use search_documents to find it, or list_folder_contents to browse.", input.Path)), nil, nil
+	return errorResult(fmt.Sprintf("document not found: %s. Use search_documents to find it or list_folder_contents to browse", input.Path)), nil, nil
 }
 
 type listLabelsInput struct{}
@@ -319,7 +329,7 @@ func (t *mcpTools) listFolderContents(ctx context.Context, req *mcp.CallToolRequ
 
 type getDocumentVersionsInput struct {
 	Path  string `json:"path" jsonschema:"Document path"`
-	Limit *int   `json:"limit,omitempty" jsonschema:"Max versions to return (default 20)"`
+	Limit *int   `json:"limit,omitempty" jsonschema:"Max versions to return (default 20, max 100)"`
 }
 
 func (t *mcpTools) getDocumentVersions(ctx context.Context, req *mcp.CallToolRequest, input getDocumentVersionsInput) (*mcp.CallToolResult, any, error) {
@@ -327,7 +337,10 @@ func (t *mcpTools) getDocumentVersions(ctx context.Context, req *mcp.CallToolReq
 		return errorResult("path is required"), nil, nil
 	}
 	if input.Limit != nil && *input.Limit < 1 {
-		return errorResult("limit must be positive"), nil, nil
+		return errorResult("limit must be a positive integer (e.g. 5, 10, 20)"), nil, nil
+	}
+	if input.Limit != nil && *input.Limit > 100 {
+		return errorResult("limit must be at most 100"), nil, nil
 	}
 
 	refs, err := t.resolveAllVaults(ctx)
@@ -343,18 +356,19 @@ func (t *mcpTools) getDocumentVersions(ctx context.Context, req *mcp.CallToolReq
 	for _, ref := range refs {
 		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "get_document_versions", string(argsJSON))
 		if execErr != nil {
+			if isToolLevelError(execErr) {
+				continue // not found in this vault, try next
+			}
 			logutil.FromCtx(ctx).Warn("get document versions failed", "vault", ref.VaultID, "namespace", ref.Namespace, "path", input.Path, "error", execErr)
 			continue
 		}
-		if !strings.HasPrefix(result, "Document not found:") {
-			if ref.IsRemote() {
-				result = fmt.Sprintf("[%s]\n%s", ref.Namespace, result)
-			}
-			return textResult(result), nil, nil
+		if ref.IsRemote() {
+			result = fmt.Sprintf("[%s]\n%s", ref.Namespace, result)
 		}
+		return textResult(result), nil, nil
 	}
 
-	return errorResult(fmt.Sprintf("Document not found: %s. Use search_documents to find it, or list_folder_contents to browse.", input.Path)), nil, nil
+	return errorResult(fmt.Sprintf("document not found: %s. Use search_documents to find it or list_folder_contents to browse", input.Path)), nil, nil
 }
 
 // ---------- Write tool handlers (use first vault) ----------
@@ -531,8 +545,13 @@ func (t *mcpTools) editDocumentSection(ctx context.Context, req *mcp.CallToolReq
 	if strings.TrimSpace(input.Path) == "" {
 		return errorResult("path is required"), nil, nil
 	}
-	if strings.TrimSpace(input.Operation) == "" {
-		return errorResult("operation is required. Use one of: replace, insert_after, insert_before, delete, append"), nil, nil
+	validOps := []string{"replace", "insert_after", "insert_before", "delete", "append"}
+	op := strings.TrimSpace(input.Operation)
+	if op == "" {
+		return errorResult("operation is required. Valid operations: " + strings.Join(validOps, ", ")), nil, nil
+	}
+	if !slices.Contains(validOps, op) {
+		return errorResult(fmt.Sprintf("unknown operation: %q. Valid operations: %s", op, strings.Join(validOps, ", "))), nil, nil
 	}
 	return t.executeWriteTool(ctx, "edit_document_section", input.Vault, input)
 }

--- a/internal/tools/multivault.go
+++ b/internal/tools/multivault.go
@@ -91,6 +91,10 @@ func (t *MultiVaultReadTool) runFirstHit(ctx context.Context, refs []VaultRef, a
 	for _, ref := range refs {
 		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, t.toolInfo.Name, argsJSON)
 		if execErr != nil {
+			var toolErr *ToolError
+			if errors.As(execErr, &toolErr) {
+				continue // not found in this vault, try next
+			}
 			logger.Warn("multi-vault tool failed", "tool", t.toolInfo.Name, "vault", ref.VaultID, "namespace", ref.Namespace, "error", execErr)
 			failedVaults++
 			continue
@@ -190,9 +194,13 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 		{
 			info: &schema.ToolInfo{
 				Name: "search",
-				Desc: "Search the knowledge base for relevant documents across all vaults",
+				Desc: "Search documents using full-text and semantic search. Returns titles, paths, scores, and matching snippets. Use list_labels first to discover labels for filtering.",
 				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
-					"query": {Type: schema.String, Desc: "The search query", Required: true},
+					"query":    {Type: schema.String, Desc: "Search query text", Required: true},
+					"labels":   {Type: schema.Array, Desc: "Filter by labels (call list_labels to discover)", ElemInfo: &schema.ParameterInfo{Type: schema.String}},
+					"doc_type": {Type: schema.String, Desc: "Filter by document type (e.g. note, guide)"},
+					"folder":   {Type: schema.String, Desc: "Filter by folder path prefix (e.g. /guides/)"},
+					"limit":    {Type: schema.Integer, Desc: "Max results (default 20, max 100)"},
 				}),
 			},
 			merge: mergeConcat,
@@ -239,10 +247,10 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 		{
 			info: &schema.ToolInfo{
 				Name: "get_document_versions",
-				Desc: "Get version history for a document by path",
+				Desc: "Get version history for a document by path. Returns previous versions with timestamps, sources, and titles.",
 				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 					"path":  {Type: schema.String, Desc: "Document path", Required: true},
-					"limit": {Type: schema.Integer, Desc: "Max versions to return (default 20)"},
+					"limit": {Type: schema.Integer, Desc: "Max versions to return (default 20, max 100)"},
 				}),
 			},
 			merge: mergeFirstHit,
@@ -265,13 +273,13 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 			ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 				"path":          {Type: schema.String, Desc: "Document path of the existing document", Required: true},
 				"content":       {Type: schema.String, Desc: "Complete new markdown content (replaces existing content entirely)", Required: true},
-				"expected_hash": {Type: schema.String, Desc: "Content hash from read_document for optimistic concurrency check"},
+				"expected_hash": {Type: schema.String, Desc: "Content hash from get_document for optimistic concurrency check"},
 				"vault":         {Type: schema.String, Desc: "Target vault (e.g. remote-name/vault-name). Defaults to first local vault."},
 			}),
 		},
 		{
 			Name: "edit_document_section",
-			Desc: "Edit a specific section of a document by heading, without sending the full content. Use read_document with sections=true to see available sections.",
+			Desc: "Edit a specific section of a document by heading, without sending the full content. Use get_document with sections=true to see available sections. Supports replace, insert_after, insert_before, delete, and append operations.",
 			ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 				"path":          {Type: schema.String, Desc: "Document path", Required: true},
 				"operation":     {Type: schema.String, Desc: "One of: replace, insert_after, insert_before, delete, append", Required: true},
@@ -280,18 +288,18 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 				"content":       {Type: schema.String, Desc: "New section body (required for replace, insert, append)"},
 				"new_heading":   {Type: schema.String, Desc: "Heading text for insert/append operations"},
 				"new_level":     {Type: schema.Integer, Desc: "Heading level 1-6 for insert/append operations"},
-				"expected_hash": {Type: schema.String, Desc: "Content hash from read_document for optimistic concurrency check"},
+				"expected_hash": {Type: schema.String, Desc: "Content hash from get_document for optimistic concurrency check"},
 				"vault":         {Type: schema.String, Desc: "Target vault (e.g. remote-name/vault-name). Defaults to first local vault."},
 			}),
 		},
 		{
 			Name: "create_memory",
-			Desc: "Create a memory, optionally scoped to a project",
+			Desc: "Create a memory, optionally scoped to a project. For project memories, use a stable identifier (git remote URL or repo folder name). For global memories, omit project and add descriptive labels. Call list_labels first to reuse existing labels.",
 			ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 				"title":   {Type: schema.String, Desc: "Memory title (used for filename)", Required: true},
 				"content": {Type: schema.String, Desc: "Memory content (markdown)", Required: true},
-				"project": {Type: schema.String, Desc: "Optional project identifier"},
-				"labels":  {Type: schema.Array, Desc: "Additional labels for categorization", ElemInfo: &schema.ParameterInfo{Type: schema.String}},
+				"project": {Type: schema.String, Desc: "Project identifier (git remote URL or repo folder name). Omit for global memories."},
+				"labels":  {Type: schema.Array, Desc: "Labels for categorization (e.g. golang, docker). Call list_labels to discover existing labels.", ElemInfo: &schema.ParameterInfo{Type: schema.String}},
 				"vault":   {Type: schema.String, Desc: "Target vault (e.g. remote-name/vault-name). Defaults to first local vault."},
 			}),
 		},
@@ -324,6 +332,5 @@ func isEmptyResult(result string) bool {
 // isNotFoundResult checks for "not found" responses that indicate the item
 // doesn't exist in this vault (but might exist in another).
 func isNotFoundResult(result string) bool {
-	return isEmptyResult(result) ||
-		strings.HasPrefix(result, "Document not found:")
+	return isEmptyResult(result)
 }

--- a/internal/tools/tool_create_document.go
+++ b/internal/tools/tool_create_document.go
@@ -60,7 +60,7 @@ func (t *CreateDocumentTool) InvokableRun(ctx context.Context, argumentsInJSON s
 		return "", fmt.Errorf("check existing document: %w", err)
 	}
 	if existing != nil {
-		return "", &ToolError{Message: fmt.Sprintf("document already exists at path: %s", args.Path)}
+		return "", &ToolError{Message: fmt.Sprintf("document already exists at path: %s. Use edit_document to update it or choose a different path", args.Path)}
 	}
 
 	start := time.Now()

--- a/internal/tools/tool_create_memory.go
+++ b/internal/tools/tool_create_memory.go
@@ -24,7 +24,7 @@ type CreateMemoryTool struct {
 func (t *CreateMemoryTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
 		Name: "create_memory",
-		Desc: "Create a memory, optionally scoped to a project",
+		Desc: "Create a memory, optionally scoped to a project. For project memories, use a stable identifier (git remote URL or repo folder name). For global memories (e.g. Go patterns, Docker tips), omit project and add descriptive labels. Call list_labels first to reuse existing labels.",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"title": {
 				Type:     schema.String,
@@ -38,11 +38,11 @@ func (t *CreateMemoryTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 			},
 			"project": {
 				Type: schema.String,
-				Desc: "Optional project identifier",
+				Desc: "Project identifier (git remote URL or repo folder name). Omit for global memories.",
 			},
 			"labels": {
 				Type: schema.Array,
-				Desc: "Additional labels for categorization",
+				Desc: "Labels for categorization (e.g. golang, docker). Call list_labels to discover existing labels.",
 				ElemInfo: &schema.ParameterInfo{
 					Type: schema.String,
 				},

--- a/internal/tools/tool_edit_document.go
+++ b/internal/tools/tool_edit_document.go
@@ -65,7 +65,7 @@ func (t *EditDocumentTool) InvokableRun(ctx context.Context, argumentsInJSON str
 		return "", fmt.Errorf("check document: %w", err)
 	}
 	if existing == nil {
-		return "", &ToolError{Message: fmt.Sprintf("document not found: %s", args.Path)}
+		return "", &ToolError{Message: fmt.Sprintf("document not found: %s. Use search_documents to find it or list_folder_contents to browse", args.Path)}
 	}
 	if err := checkContentHash(args.ExpectedHash, existing.ContentHash); err != nil {
 		return "", err

--- a/internal/tools/tool_edit_document_section.go
+++ b/internal/tools/tool_edit_document_section.go
@@ -23,7 +23,7 @@ type EditDocumentSectionTool struct {
 func (t *EditDocumentSectionTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
 		Name: "edit_document_section",
-		Desc: "Edit a specific section of a document by heading, without sending the full content. Use read_document with sections=true first to see the section outline. Operations: replace (update existing section content), insert_after/insert_before (add new section relative to target, requires new_heading), delete (remove a section), append (add new section at end, requires new_heading).",
+		Desc: "Edit a specific section of a document by heading, without sending the full content. Use get_document with sections=true first to see the section outline. Operations: replace (update existing section content), insert_after/insert_before (add new section relative to target, requires new_heading), delete (remove a section), append (add new section at end, requires new_heading).",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"path": {
 				Type:     schema.String,
@@ -90,7 +90,7 @@ func (t *EditDocumentSectionTool) InvokableRun(ctx context.Context, argumentsInJ
 	case parser.OpReplace, parser.OpInsertAfter, parser.OpInsertBefore, parser.OpDelete, parser.OpAppend:
 		// valid
 	default:
-		return "", &ToolError{Message: fmt.Sprintf("unknown operation: %s", args.Operation)}
+		return "", &ToolError{Message: fmt.Sprintf("unknown operation: %q. Valid operations: replace, insert_after, insert_before, delete, append", args.Operation)}
 	}
 
 	existing, err := t.db.GetDocumentByPath(ctx, o.VaultID, args.Path)
@@ -98,7 +98,7 @@ func (t *EditDocumentSectionTool) InvokableRun(ctx context.Context, argumentsInJ
 		return "", fmt.Errorf("check document: %w", err)
 	}
 	if existing == nil {
-		return "", &ToolError{Message: fmt.Sprintf("document not found: %s", args.Path)}
+		return "", &ToolError{Message: fmt.Sprintf("document not found: %s. Use search_documents to find it or list_folder_contents to browse", args.Path)}
 	}
 	if err := checkContentHash(args.ExpectedHash, existing.ContentHash); err != nil {
 		return "", err

--- a/internal/tools/tool_get_document_versions.go
+++ b/internal/tools/tool_get_document_versions.go
@@ -50,7 +50,10 @@ func (t *GetDocumentVersionsTool) InvokableRun(ctx context.Context, argumentsInJ
 		return "", fmt.Errorf("path is required")
 	}
 	if input.Limit != nil && *input.Limit < 1 {
-		return "", fmt.Errorf("limit must be positive")
+		return "", &ToolError{Message: "limit must be a positive integer (e.g. 5, 10, 20)"}
+	}
+	if input.Limit != nil && *input.Limit > 100 {
+		return "", &ToolError{Message: "limit must be at most 100"}
 	}
 
 	limit := 20
@@ -63,7 +66,7 @@ func (t *GetDocumentVersionsTool) InvokableRun(ctx context.Context, argumentsInJ
 		return "", fmt.Errorf("get document for versions: %w", err)
 	}
 	if doc == nil {
-		return fmt.Sprintf("Document not found: %s", input.Path), nil
+		return "", &ToolError{Message: fmt.Sprintf("document not found: %s. Use search_documents to find it or list_folder_contents to browse", input.Path)}
 	}
 
 	docID, err := models.RecordIDString(doc.ID)

--- a/internal/tools/tool_read_document.go
+++ b/internal/tools/tool_read_document.go
@@ -56,7 +56,7 @@ func (t *ReadDocumentTool) InvokableRun(ctx context.Context, argumentsInJSON str
 	}
 	if doc == nil {
 		SetResultMeta(ctx, &ToolResultMeta{DurationMs: durationMs})
-		return fmt.Sprintf("Document not found: %s", input.Path), nil
+		return "", &ToolError{Message: fmt.Sprintf("document not found: %s. Use search_documents to find it or list_folder_contents to browse", input.Path)}
 	}
 
 	var sb strings.Builder

--- a/internal/tools/tool_search.go
+++ b/internal/tools/tool_search.go
@@ -20,9 +20,9 @@ type SearchTool struct {
 func (t *SearchTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
 		Name: "search",
-		Desc: "Search the knowledge base for relevant documents",
+		Desc: "Search documents using full-text and semantic search. Returns titles, paths, scores, and matching snippets.",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
-			"query": {Type: schema.String, Desc: "The search query", Required: true},
+			"query": {Type: schema.String, Desc: "Search query text", Required: true},
 		}),
 	}, nil
 }

--- a/justfile
+++ b/justfile
@@ -61,6 +61,13 @@ run *args: build
 install:
     GOBIN="$HOME/go/bin" CGO_ENABLED=0 go install -buildvcs=false ./cmd/know
 
+# Install git pre-commit hook (auto-fixes: goimports, go fix, go mod tidy)
+install-hooks:
+    @hooks_dir=$(git rev-parse --git-common-dir)/hooks && \
+    cp scripts/pre-commit "$hooks_dir/pre-commit" && \
+    chmod +x "$hooks_dir/pre-commit" && \
+    echo "Pre-commit hook installed to $hooks_dir/pre-commit"
+
 # Build snapshot release locally (requires goreleaser)
 snapshot:
     goreleaser release --snapshot --clean

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook: auto-fix Go files with goimports, go fix, and go mod tidy.
+# These tools only rewrite files — they never fail the commit.
+#
+
+set -o pipefail
+
+# Only run if there are staged Go files
+staged_go=$(git diff --cached --name-only --diff-filter=ACM -- '*.go')
+[ -z "$staged_go" ] && exit 0
+
+# Resolve module root (for worktree setups where .git is a file)
+module_root=$(git rev-parse --show-toplevel)
+
+# Track whether we re-staged anything
+restaged=false
+
+# 1. goimports (superset of gofmt: format + fix imports)
+if command -v goimports &>/dev/null; then
+	echo "$staged_go" | while IFS= read -r f; do
+		[ -f "$module_root/$f" ] && goimports -w "$module_root/$f"
+	done
+	# Re-stage any modified files
+	echo "$staged_go" | while IFS= read -r f; do
+		[ -f "$module_root/$f" ] && git add "$module_root/$f"
+	done
+	restaged=true
+elif command -v gofmt &>/dev/null; then
+	# Fallback to gofmt if goimports not installed
+	echo "$staged_go" | while IFS= read -r f; do
+		[ -f "$module_root/$f" ] && gofmt -w "$module_root/$f"
+	done
+	echo "$staged_go" | while IFS= read -r f; do
+		[ -f "$module_root/$f" ] && git add "$module_root/$f"
+	done
+	restaged=true
+fi
+
+# 2. go fix (Go 1.26+ modernizers)
+goversion=$(go version | grep -oE 'go1\.([0-9]+)' | grep -oE '[0-9]+$')
+if [ "${goversion:-0}" -ge 26 ]; then
+	cd "$module_root" || exit 0
+	go fix ./... 2>/dev/null || true
+	# Re-stage any files that go fix modified
+	echo "$staged_go" | while IFS= read -r f; do
+		[ -f "$module_root/$f" ] && git add "$module_root/$f"
+	done
+	restaged=true
+fi
+
+# 3. go mod tidy
+cd "$module_root" || exit 0
+go mod tidy 2>/dev/null || true
+git add go.mod go.sum 2>/dev/null || true
+
+exit 0


### PR DESCRIPTION
## Summary

- **Actionable error messages** across all tools — not-found errors now suggest recovery tools (e.g. `"Use search_documents to find it or list_folder_contents to browse"`)
- **Pre-requisite guidance** in tool descriptions (e.g. `"Use list_labels first to discover labels for filtering"`)
- **Consistent ToolError for not-found** — `read_document` and `get_document_versions` now return `ToolError` instead of success strings, replacing fragile `strings.HasPrefix` detection with typed error checks
- **Limit validation** — upper bound (max 100) added to `searchDocuments` and `getDocumentVersions` with helpful error messages
- **Operation enum validation** — `edit_document_section` validates operation at the MCP layer before forwarding
- **Description parity** — eino and multivault tool layers updated to match MCP layer quality (search params, create_memory guidance, `read_document` → `get_document` naming)
- **Search all-vaults-failed** — returns distinct error instead of misleading "No results found" when all vaults are unreachable
- **Pre-commit hook** — auto-applies `goimports`, `go fix`, `go mod tidy` on staged Go files (never fails commits)

## Test plan

- [x] `just build` passes
- [x] `just test` passes — all tests green including updated `TestToolsExecutor_ReadDocument_NotFound`
- [x] Pre-commit hook tested manually (`bash scripts/pre-commit`)
- [ ] Manually test MCP tools with an agent to verify error messages surface correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)