### PR TITLE
refactor: deduplicate DB query, API decode, and tool input patterns

### DIFF
--- a/helm/know/Chart.yaml
+++ b/helm/know/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: know
 description: Know - Personal Knowledge RAG Database with REST API and WebDAV
 type: application
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.7.0
+appVersion: "0.7.0"
 keywords:
   - know
   - knowledge-graph

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -208,7 +208,7 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest, emit func(StreamEve
 
 	// 8. Persist, update tokens, emit msg_end (or skip if interrupted)
 	if err := s.finalizeRun(ctx, req.ConversationID, model, &result, emit); err != nil {
-		return err
+		return fmt.Errorf("finalize run: %w", err)
 	}
 
 	// 9. Auto-title if first message

--- a/internal/api/conversations.go
+++ b/internal/api/conversations.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -90,15 +88,8 @@ type createConversationRequest struct {
 }
 
 func (s *Server) createConversation(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, 64*1024) // 64 KB
-	var body createConversationRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
-			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
-			return
-		}
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	body, ok := decodeBody[createConversationRequest](w, r, 64*1024) // 64 KB
+	if !ok {
 		return
 	}
 	if body.VaultID == "" {
@@ -168,20 +159,12 @@ type renameConversationRequest struct {
 }
 
 func (s *Server) renameConversation(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, 64*1024) // 64 KB
-	id := r.PathValue("id")
-	logger := logutil.FromCtx(r.Context())
-
-	var body renameConversationRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
-			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
-			return
-		}
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	body, ok := decodeBody[renameConversationRequest](w, r, 64*1024) // 64 KB
+	if !ok {
 		return
 	}
+	id := r.PathValue("id")
+	logger := logutil.FromCtx(r.Context())
 	if body.Title == "" {
 		writeError(w, http.StatusBadRequest, "title is required")
 		return

--- a/internal/api/documents.go
+++ b/internal/api/documents.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -51,15 +49,8 @@ type upsertDocumentRequest struct {
 }
 
 func (s *Server) upsertDocument(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, 5*1024*1024) // 5 MB
-	var body upsertDocumentRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
-			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
-			return
-		}
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	body, ok := decodeBody[upsertDocumentRequest](w, r, 5*1024*1024) // 5 MB
+	if !ok {
 		return
 	}
 	if body.VaultID == "" || body.Path == "" {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 
+	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/server"
 )
 
@@ -82,4 +84,22 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 // writeError writes a JSON error response.
 func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+// decodeBody reads and JSON-decodes the request body with a size limit.
+// Returns the decoded value and true on success, or writes an error response and returns nil, false.
+func decodeBody[T any](w http.ResponseWriter, r *http.Request, maxBytes int64) (*T, bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+	var v T
+	if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+		} else {
+			logutil.FromCtx(r.Context()).Debug("invalid request body", "error", err)
+			writeError(w, http.StatusBadRequest, "invalid request body")
+		}
+		return nil, false
+	}
+	return &v, true
 }

--- a/internal/db/helpers.go
+++ b/internal/db/helpers.go
@@ -1,6 +1,9 @@
 package db
 
 import (
+	"fmt"
+
+	"github.com/surrealdb/surrealdb.go"
 	surrealmodels "github.com/surrealdb/surrealdb.go/pkg/models"
 
 	"github.com/raphi011/know/internal/models"
@@ -8,6 +11,11 @@ import (
 
 // bareID is a package-local alias for models.BareID.
 var bareID = models.BareID
+
+// newRecordID creates a SurrealDB record ID from a table and bare ID.
+func newRecordID(table, id string) surrealmodels.RecordID {
+	return surrealmodels.RecordID{Table: table, ID: id}
+}
 
 // optionalString returns models.None for nil pointers, otherwise returns the string value.
 func optionalString(s *string) any {
@@ -23,4 +31,39 @@ func optionalObject(m map[string]any) any {
 		return surrealmodels.None
 	}
 	return m
+}
+
+// firstResult returns the first row from a query result, or an error if no rows were returned.
+// Use for CREATE/UPDATE queries that must return exactly one row.
+func firstResult[T any](results *[]surrealdb.QueryResult[[]T], op string) (*T, error) {
+	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
+		return nil, fmt.Errorf("%s: no result returned", op)
+	}
+	return &(*results)[0].Result[0], nil
+}
+
+// firstResultOpt returns the first row from a query result, or nil if no rows were returned.
+// Use for SELECT queries where "not found" is a valid outcome.
+func firstResultOpt[T any](results *[]surrealdb.QueryResult[[]T]) *T {
+	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
+		return nil
+	}
+	return &(*results)[0].Result[0]
+}
+
+// allResults returns all rows from the first statement in a query response, or nil.
+// Use for SELECT queries that return a list of rows.
+func allResults[T any](results *[]surrealdb.QueryResult[[]T]) []T {
+	if results == nil || len(*results) == 0 {
+		return nil
+	}
+	return (*results)[0].Result
+}
+
+// countResults returns the number of rows from the first statement in a query response.
+func countResults[T any](results *[]surrealdb.QueryResult[[]T]) int {
+	if results == nil || len(*results) == 0 {
+		return 0
+	}
+	return len((*results)[0].Result)
 }

--- a/internal/db/queries_asset.go
+++ b/internal/db/queries_asset.go
@@ -77,10 +77,7 @@ func (c *Client) createAsset(ctx context.Context, input models.AssetInput, conte
 	if err != nil {
 		return nil, fmt.Errorf("create asset: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("create asset: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "create asset")
 }
 
 func (c *Client) updateAsset(ctx context.Context, input models.AssetInput, contentHash string, size int) (*models.Asset, error) {
@@ -104,10 +101,7 @@ func (c *Client) updateAsset(ctx context.Context, input models.AssetInput, conte
 	if err != nil {
 		return nil, fmt.Errorf("update asset: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("update asset: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "update asset")
 }
 
 // GetAssetByPath returns the full asset (including data) by vault+path.
@@ -121,10 +115,7 @@ func (c *Client) GetAssetByPath(ctx context.Context, vaultID, path string) (*mod
 	if err != nil {
 		return nil, fmt.Errorf("get asset by path: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 // GetAssetMetaByPath returns lightweight asset metadata (no data bytes).
@@ -138,10 +129,7 @@ func (c *Client) GetAssetMetaByPath(ctx context.Context, vaultID, path string) (
 	if err != nil {
 		return nil, fmt.Errorf("get asset meta by path: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 // ListAssetMetas returns lightweight metadata for assets in a vault, optionally filtered by folder prefix.
@@ -166,10 +154,7 @@ func (c *Client) ListAssetMetas(ctx context.Context, vaultID string, folder *str
 	if err != nil {
 		return nil, fmt.Errorf("list asset metas: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 // DeleteAsset deletes an asset by vault+path.
@@ -197,10 +182,7 @@ func (c *Client) DeleteAssetsByPrefix(ctx context.Context, vaultID, pathPrefix s
 	if err != nil {
 		return 0, fmt.Errorf("delete assets by prefix: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return 0, nil
-	}
-	return len((*results)[0].Result), nil
+	return countResults(results), nil
 }
 
 // MoveAsset updates an asset's path and mime_type.
@@ -239,8 +221,5 @@ func (c *Client) MoveAssetsByPrefix(ctx context.Context, vaultID, oldPrefix, new
 	if err != nil {
 		return 0, fmt.Errorf("move assets by prefix: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return 0, nil
-	}
-	return len((*results)[0].Result), nil
+	return countResults(results), nil
 }

--- a/internal/db/queries_checkpoint.go
+++ b/internal/db/queries_checkpoint.go
@@ -21,10 +21,10 @@ func (c *Client) GetCheckpoint(ctx context.Context, id string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get checkpoint: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
+	if row := firstResultOpt(results); row != nil {
+		return row.Data, nil
 	}
-	return (*results)[0].Result[0].Data, nil
+	return nil, nil
 }
 
 func (c *Client) UpsertCheckpoint(ctx context.Context, id string, data []byte) error {

--- a/internal/db/queries_chunk.go
+++ b/internal/db/queries_chunk.go
@@ -86,10 +86,7 @@ func (c *Client) GetChunks(ctx context.Context, documentID string) ([]models.Chu
 	if err != nil {
 		return nil, fmt.Errorf("get chunks: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 func (c *Client) DeleteChunks(ctx context.Context, documentID string) error {
@@ -150,10 +147,7 @@ func (c *Client) ClaimChunksForEmbedding(ctx context.Context, limit int) ([]mode
 	if err != nil {
 		return nil, fmt.Errorf("claim chunks for embedding: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 // UpdateChunkEmbedding sets the embedding vector on a chunk after the worker embeds it.

--- a/internal/db/queries_conversation.go
+++ b/internal/db/queries_conversation.go
@@ -24,10 +24,7 @@ func (c *Client) CreateConversation(ctx context.Context, vaultID, userID string)
 	if err != nil {
 		return nil, fmt.Errorf("create conversation: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("create conversation: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "create conversation")
 }
 
 func (c *Client) GetConversation(ctx context.Context, id string) (*models.Conversation, error) {
@@ -39,10 +36,7 @@ func (c *Client) GetConversation(ctx context.Context, id string) (*models.Conver
 	if err != nil {
 		return nil, fmt.Errorf("get conversation: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 func (c *Client) ListConversations(ctx context.Context, vaultID, userID string) ([]models.Conversation, error) {
@@ -55,10 +49,7 @@ func (c *Client) ListConversations(ctx context.Context, vaultID, userID string) 
 	if err != nil {
 		return nil, fmt.Errorf("list conversations: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 func (c *Client) UpdateConversationTitle(ctx context.Context, id, title string) error {
@@ -147,10 +138,7 @@ func (c *Client) ReconcileStaleRunningConversations(ctx context.Context) (int, e
 	if err != nil {
 		return 0, fmt.Errorf("reconcile stale running conversations: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return 0, nil
-	}
-	return len((*results)[0].Result), nil
+	return countResults(results), nil
 }
 
 func (c *Client) CreateMessage(ctx context.Context, conversationID string, role models.MessageRole, content string, docRefs []string, toolName, toolInput, toolMeta, toolCallID, toolCalls *string) (*models.Message, error) {
@@ -185,10 +173,7 @@ func (c *Client) CreateMessage(ctx context.Context, conversationID string, role 
 	if err != nil {
 		return nil, fmt.Errorf("create message: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("create message: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "create message")
 }
 
 func (c *Client) ListMessages(ctx context.Context, conversationID string) ([]models.Message, error) {
@@ -200,8 +185,5 @@ func (c *Client) ListMessages(ctx context.Context, conversationID string) ([]mod
 	if err != nil {
 		return nil, fmt.Errorf("list messages: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }

--- a/internal/db/queries_document.go
+++ b/internal/db/queries_document.go
@@ -55,10 +55,7 @@ func (c *Client) ListSyncMetadata(ctx context.Context, vaultID string, since *st
 	if err != nil {
 		return nil, fmt.Errorf("list sync metadata: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 // ListTombstones returns tombstones for deleted documents in a vault since the given time.
@@ -81,10 +78,7 @@ func (c *Client) ListTombstones(ctx context.Context, vaultID string, since strin
 	if err != nil {
 		return nil, fmt.Errorf("list tombstones: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 func (c *Client) CreateDocument(ctx context.Context, input models.DocumentInput) (*models.Document, error) {
@@ -124,10 +118,7 @@ func (c *Client) CreateDocument(ctx context.Context, input models.DocumentInput)
 	if err != nil {
 		return nil, fmt.Errorf("create document: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("create document: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "create document")
 }
 
 func (c *Client) GetDocumentByPath(ctx context.Context, vaultID, path string) (*models.Document, error) {
@@ -140,10 +131,7 @@ func (c *Client) GetDocumentByPath(ctx context.Context, vaultID, path string) (*
 	if err != nil {
 		return nil, fmt.Errorf("get document by path: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 func (c *Client) GetDocumentByID(ctx context.Context, id string) (*models.Document, error) {
@@ -155,10 +143,7 @@ func (c *Client) GetDocumentByID(ctx context.Context, id string) (*models.Docume
 	if err != nil {
 		return nil, fmt.Errorf("get document by id: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 // DocumentOrderBy defines allowed ORDER BY clauses for document queries.
@@ -241,10 +226,7 @@ func (c *Client) ListDocuments(ctx context.Context, filter ListDocumentsFilter) 
 	if err != nil {
 		return nil, fmt.Errorf("list documents: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 func (c *Client) UpdateDocument(ctx context.Context, id string, content, contentBody, title string, labels []string, contentHash *string, metadata map[string]any) (*models.Document, error) {
@@ -278,10 +260,7 @@ func (c *Client) UpdateDocument(ctx context.Context, id string, content, content
 	if err != nil {
 		return nil, fmt.Errorf("update document: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("update document: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "update document")
 }
 
 func (c *Client) DeleteDocument(ctx context.Context, id string) error {
@@ -305,10 +284,7 @@ func (c *Client) DeleteDocumentsByPrefix(ctx context.Context, vaultID, pathPrefi
 	if err != nil {
 		return 0, fmt.Errorf("delete documents by prefix: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return 0, nil
-	}
-	return len((*results)[0].Result), nil
+	return countResults(results), nil
 }
 
 // MoveDocumentsByPrefix updates all documents in a vault whose path starts with oldPrefix,
@@ -330,10 +306,7 @@ func (c *Client) MoveDocumentsByPrefix(ctx context.Context, vaultID, oldPrefix, 
 	if err != nil {
 		return 0, fmt.Errorf("move documents by prefix: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return 0, nil
-	}
-	return len((*results)[0].Result), nil
+	return countResults(results), nil
 }
 
 func (c *Client) MoveDocument(ctx context.Context, id, newPath string) (*models.Document, error) {
@@ -350,10 +323,7 @@ func (c *Client) MoveDocument(ctx context.Context, id, newPath string) (*models.
 	if err != nil {
 		return nil, fmt.Errorf("move document: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("move document: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "move document")
 }
 
 // ListUnprocessedDocuments returns documents that have not yet been processed by the async worker.
@@ -369,10 +339,7 @@ func (c *Client) ListUnprocessedDocuments(ctx context.Context, limit int) ([]mod
 	if err != nil {
 		return nil, fmt.Errorf("list unprocessed: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 // MarkDocumentProcessed sets processed = true on a document.
@@ -439,10 +406,7 @@ func (c *Client) GetDocumentMetaByPath(ctx context.Context, vaultID, path string
 	if err != nil {
 		return nil, fmt.Errorf("get document meta by path: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 // ListDocumentMetas returns lightweight metadata (no content) for documents matching the filter.
@@ -458,10 +422,7 @@ func (c *Client) ListDocumentMetas(ctx context.Context, filter ListDocumentsFilt
 	if err != nil {
 		return nil, fmt.Errorf("list document metas: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 // UpsertDocument creates or updates a document by vault+path.
@@ -556,8 +517,5 @@ func (c *Client) GetDocumentsByAllLabels(ctx context.Context, vaultID string, la
 	if err != nil {
 		return nil, fmt.Errorf("get documents by all labels: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }

--- a/internal/db/queries_folder.go
+++ b/internal/db/queries_folder.go
@@ -32,10 +32,7 @@ func (c *Client) CreateFolder(ctx context.Context, vaultID, folderPath string) (
 	if err != nil {
 		return nil, fmt.Errorf("create folder: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("create folder: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "create folder")
 }
 
 // EnsureFolders idempotently creates all ancestor folders for a document path,
@@ -59,7 +56,7 @@ func (c *Client) EnsureFolders(ctx context.Context, vaultID, docPath string) err
 	}
 
 	if err := c.EnsureFolderPath(ctx, vaultID, dir); err != nil {
-		return err
+		return fmt.Errorf("ensure folders for %s: %w", docPath, err)
 	}
 
 	// Cache for 60 seconds
@@ -114,10 +111,7 @@ func (c *Client) ListFolders(ctx context.Context, vaultID string) ([]models.Fold
 	if err != nil {
 		return nil, fmt.Errorf("list folders: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 // ListChildFolders returns immediate child folders of parentPath in a vault.
@@ -138,13 +132,14 @@ func (c *Client) ListChildFolders(ctx context.Context, vaultID, parentPath strin
 	if err != nil {
 		return nil, fmt.Errorf("list child folders: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
+	all := allResults(results)
+	if all == nil {
 		return nil, nil
 	}
 
 	// Filter to immediate children only (no additional "/" after prefix)
 	var children []models.Folder
-	for _, f := range (*results)[0].Result {
+	for _, f := range all {
 		rel := strings.TrimPrefix(f.Path, prefix)
 		if rel != "" && !strings.Contains(rel, "/") {
 			children = append(children, f)
@@ -164,10 +159,7 @@ func (c *Client) GetFolderByPath(ctx context.Context, vaultID, folderPath string
 	if err != nil {
 		return nil, fmt.Errorf("get folder by path: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 // DeleteFolder deletes a single folder and all its children (paths starting with folderPath + "/").
@@ -291,12 +283,4 @@ func (c *Client) MoveFoldersByPrefix(ctx context.Context, vaultID, oldPath, newP
 	}
 
 	return countResults(r1) + countResults(r2), nil
-}
-
-// countResults returns the number of results from the first statement in a query response.
-func countResults[T any](results *[]surrealdb.QueryResult[[]T]) int {
-	if results == nil || len(*results) == 0 {
-		return 0
-	}
-	return len((*results)[0].Result)
 }

--- a/internal/db/queries_label.go
+++ b/internal/db/queries_label.go
@@ -33,8 +33,8 @@ func (c *Client) EnsureLabel(ctx context.Context, vaultID, name string) (string,
 			return "", fmt.Errorf("ensure label: check existing: %w", err)
 		}
 
-		if existing != nil && len(*existing) > 0 && len((*existing)[0].Result) > 0 {
-			id, err := models.RecordIDString((*existing)[0].Result[0].ID)
+		if found := firstResultOpt(existing); found != nil {
+			id, err := models.RecordIDString(found.ID)
 			if err != nil {
 				return "", fmt.Errorf("ensure label: extract id: %w", err)
 			}
@@ -53,10 +53,11 @@ func (c *Client) EnsureLabel(ctx context.Context, vaultID, name string) (string,
 			}
 			return "", fmt.Errorf("ensure label: create: %w", err)
 		}
-		if created == nil || len(*created) == 0 || len((*created)[0].Result) == 0 {
-			return "", fmt.Errorf("ensure label: no result returned from create")
+		newLabel, labelErr := firstResult(created, "ensure label")
+		if labelErr != nil {
+			return "", labelErr
 		}
-		id, err := models.RecordIDString((*created)[0].Result[0].ID)
+		id, err := models.RecordIDString(newLabel.ID)
 		if err != nil {
 			return "", fmt.Errorf("ensure label: extract id: %w", err)
 		}
@@ -67,34 +68,56 @@ func (c *Client) EnsureLabel(ctx context.Context, vaultID, name string) (string,
 }
 
 // SyncDocumentLabels replaces all has_label edges for a document with edges
-// to the given labels. Labels are upserted as needed.
+// to the given labels. Labels are upserted and edges are created in a single
+// database round-trip to avoid N+1 query overhead.
 func (c *Client) SyncDocumentLabels(ctx context.Context, docID, vaultID string, labels []string) error {
 	defer c.logOp(ctx, "label.sync", time.Now())
-	// Delete existing edges from this document
-	sql := `DELETE FROM has_label WHERE in = type::record("document", $doc_id)`
-	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
+
+	// Normalize labels in Go
+	normalized := make([]string, 0, len(labels))
+	for _, name := range labels {
+		name = strings.ToLower(strings.TrimSpace(name))
+		if name != "" {
+			normalized = append(normalized, name)
+		}
+	}
+
+	// Delete old edges first; if no labels remain we're done
+	deleteSQL := `DELETE FROM has_label WHERE in = type::record("document", $doc_id)`
+	if _, err := surrealdb.Query[any](ctx, c.DB(), deleteSQL, map[string]any{
 		"doc_id": bareID("document", docID),
 	}); err != nil {
 		return fmt.Errorf("sync document labels: delete old edges: %w", err)
 	}
 
-	for _, name := range labels {
-		labelID, err := c.EnsureLabel(ctx, vaultID, name)
-		if err != nil {
-			return fmt.Errorf("sync document labels: %w", err)
-		}
+	if len(normalized) == 0 {
+		return nil
+	}
 
-		relateSql := `
-			LET $doc = type::record("document", $doc_id);
-			LET $lbl = type::record("label", $label_id);
-			RELATE $doc->has_label->$lbl RETURN NONE
-		`
-		if _, err := surrealdb.Query[any](ctx, c.DB(), relateSql, map[string]any{
-			"doc_id":   bareID("document", docID),
-			"label_id": bareID("label", labelID),
-		}); err != nil {
-			return fmt.Errorf("sync document labels: create edge for %q: %w", name, err)
+	// Build label row objects for batch INSERT
+	vaultRef := bareID("vault", vaultID)
+	labelRows := make([]map[string]any, len(normalized))
+	for i, name := range normalized {
+		labelRows[i] = map[string]any{
+			"name":  name,
+			"vault": newRecordID("vault", vaultRef),
 		}
+	}
+
+	// Single query: upsert all labels, then create all edges.
+	// LET $doc outside the FOR loop because type::record() isn't allowed inside FOR.
+	sql := `
+		LET $doc = type::record("document", $doc_id);
+		LET $labels = INSERT INTO label $label_rows ON DUPLICATE KEY UPDATE id = id RETURN AFTER;
+		FOR $lbl IN $labels {
+			RELATE $doc->has_label->$lbl.id;
+		};
+	`
+	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
+		"doc_id":     bareID("document", docID),
+		"label_rows": labelRows,
+	}); err != nil {
+		return fmt.Errorf("sync document labels: upsert and relate %v: %w", normalized, err)
 	}
 
 	return nil
@@ -116,10 +139,7 @@ func (c *Client) GetDocumentsByLabel(ctx context.Context, vaultID, labelName str
 	if err != nil {
 		return nil, fmt.Errorf("get documents by label: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 // GetLabelsForDocument returns all label names for a document using graph traversal.

--- a/internal/db/queries_relation.go
+++ b/internal/db/queries_relation.go
@@ -44,10 +44,7 @@ func (c *Client) GetRelations(ctx context.Context, documentID string) ([]models.
 	if err != nil {
 		return nil, fmt.Errorf("get relations: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 func (c *Client) GetRelationByID(ctx context.Context, id string) (*models.DocRelation, error) {
@@ -59,10 +56,7 @@ func (c *Client) GetRelationByID(ctx context.Context, id string) (*models.DocRel
 	if err != nil {
 		return nil, fmt.Errorf("get relation by id: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 // DeleteRelationsBySource removes all doc_relations originating from a document with the given source.

--- a/internal/db/queries_remote.go
+++ b/internal/db/queries_remote.go
@@ -30,10 +30,7 @@ func (c *Client) CreateRemote(ctx context.Context, userID string, input models.R
 	if err != nil {
 		return nil, fmt.Errorf("create remote: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("create remote: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "create remote")
 }
 
 // GetRemoteByName returns a remote by its unique name.
@@ -47,10 +44,7 @@ func (c *Client) GetRemoteByName(ctx context.Context, name string) (*models.Remo
 	if err != nil {
 		return nil, fmt.Errorf("get remote by name: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 // ListRemotes returns all configured remotes.

--- a/internal/db/queries_search.go
+++ b/internal/db/queries_search.go
@@ -84,10 +84,7 @@ func (c *Client) BM25ChunkSearch(ctx context.Context, query string, filter Searc
 	if err != nil {
 		return nil, fmt.Errorf("bm25 chunk search: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 // HybridSearch performs hybrid BM25+vector search using SurrealDB's search::rrf()
@@ -131,10 +128,7 @@ func (c *Client) HybridSearch(ctx context.Context, query string, embedding []flo
 	if err != nil {
 		return nil, fmt.Errorf("hybrid search: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 // GetDocumentsByIDs fetches multiple documents by ID in a single query.
@@ -156,8 +150,5 @@ func (c *Client) GetDocumentsByIDs(ctx context.Context, ids []string) ([]models.
 	if err != nil {
 		return nil, fmt.Errorf("get documents by ids: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }

--- a/internal/db/queries_search_query.go
+++ b/internal/db/queries_search_query.go
@@ -21,10 +21,7 @@ func (c *Client) LookupQueryEmbedding(ctx context.Context, normalizedQuery strin
 	if err != nil {
 		return nil, fmt.Errorf("lookup query embedding: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 // UpsertQueryEmbedding inserts a new search query cache entry or updates hit_count

--- a/internal/db/queries_share_link.go
+++ b/internal/db/queries_share_link.go
@@ -39,10 +39,7 @@ func (c *Client) CreateShareLink(ctx context.Context, vaultID, tokenHash, path s
 	if err != nil {
 		return nil, fmt.Errorf("create share link: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("create share link: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "create share link")
 }
 
 // GetShareLinkByHash looks up a share link by its token hash.
@@ -55,10 +52,7 @@ func (c *Client) GetShareLinkByHash(ctx context.Context, hash string) (*models.S
 	if err != nil {
 		return nil, fmt.Errorf("get share link by hash: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 // GetShareLink looks up a share link by ID.
@@ -71,10 +65,7 @@ func (c *Client) GetShareLink(ctx context.Context, id string) (*models.ShareLink
 	if err != nil {
 		return nil, fmt.Errorf("get share link: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 // ListShareLinks returns all share links for a vault.
@@ -87,10 +78,7 @@ func (c *Client) ListShareLinks(ctx context.Context, vaultID string) ([]models.S
 	if err != nil {
 		return nil, fmt.Errorf("list share links: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 // DeleteShareLink removes a share link by ID.

--- a/internal/db/queries_token.go
+++ b/internal/db/queries_token.go
@@ -26,10 +26,7 @@ func (c *Client) CreateToken(ctx context.Context, userID, tokenHash, name string
 	if err != nil {
 		return nil, fmt.Errorf("create token: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("create token: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "create token")
 }
 
 func (c *Client) GetTokenByHash(ctx context.Context, hash string) (*models.APIToken, error) {
@@ -41,10 +38,7 @@ func (c *Client) GetTokenByHash(ctx context.Context, hash string) (*models.APITo
 	if err != nil {
 		return nil, fmt.Errorf("get token by hash: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 func (c *Client) UpdateTokenLastUsed(ctx context.Context, tokenID string) error {
@@ -65,10 +59,7 @@ func (c *Client) ListTokens(ctx context.Context, userID string) ([]models.APITok
 	if err != nil {
 		return nil, fmt.Errorf("list tokens: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 func (c *Client) DeleteToken(ctx context.Context, id string) error {

--- a/internal/db/queries_user.go
+++ b/internal/db/queries_user.go
@@ -24,10 +24,7 @@ func (c *Client) CreateUser(ctx context.Context, input models.UserInput) (*model
 	if err != nil {
 		return nil, fmt.Errorf("create user: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("create user: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "create user")
 }
 
 func (c *Client) CreateUserWithID(ctx context.Context, userID string, input models.UserInput) (*models.User, error) {
@@ -46,10 +43,7 @@ func (c *Client) CreateUserWithID(ctx context.Context, userID string, input mode
 	if err != nil {
 		return nil, fmt.Errorf("create user with id: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("create user with id: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "create user with id")
 }
 
 func (c *Client) GetUser(ctx context.Context, id string) (*models.User, error) {
@@ -61,10 +55,7 @@ func (c *Client) GetUser(ctx context.Context, id string) (*models.User, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get user: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 func (c *Client) GetUserByName(ctx context.Context, name string) (*models.User, error) {
@@ -76,10 +67,7 @@ func (c *Client) GetUserByName(ctx context.Context, name string) (*models.User, 
 	if err != nil {
 		return nil, fmt.Errorf("get user by name: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 // UpdateUserSystemAdmin sets the is_system_admin flag on a user.

--- a/internal/db/queries_vault.go
+++ b/internal/db/queries_vault.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/raphi011/know/internal/models"
 	"github.com/surrealdb/surrealdb.go"
-	surrealmodels "github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
 func (c *Client) CreateVault(ctx context.Context, userID string, input models.VaultInput) (*models.Vault, error) {
@@ -28,10 +27,7 @@ func (c *Client) CreateVault(ctx context.Context, userID string, input models.Va
 	if err != nil {
 		return nil, fmt.Errorf("create vault: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("create vault: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "create vault")
 }
 
 func (c *Client) CreateVaultWithID(ctx context.Context, vaultID string, userID string, input models.VaultInput) (*models.Vault, error) {
@@ -52,10 +48,7 @@ func (c *Client) CreateVaultWithID(ctx context.Context, vaultID string, userID s
 	if err != nil {
 		return nil, fmt.Errorf("create vault with id: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("create vault with id: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "create vault with id")
 }
 
 func (c *Client) GetVault(ctx context.Context, id string) (*models.Vault, error) {
@@ -67,10 +60,7 @@ func (c *Client) GetVault(ctx context.Context, id string) (*models.Vault, error)
 	if err != nil {
 		return nil, fmt.Errorf("get vault: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 func (c *Client) GetVaultByName(ctx context.Context, name string) (*models.Vault, error) {
@@ -82,10 +72,7 @@ func (c *Client) GetVaultByName(ctx context.Context, name string) (*models.Vault
 	if err != nil {
 		return nil, fmt.Errorf("get vault by name: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 func (c *Client) ListVaults(ctx context.Context) ([]models.Vault, error) {
@@ -95,10 +82,7 @@ func (c *Client) ListVaults(ctx context.Context) ([]models.Vault, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list vaults: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 func (c *Client) DeleteVault(ctx context.Context, id string) error {
@@ -143,18 +127,15 @@ func (c *Client) ListDocumentPaths(ctx context.Context, vaultID string) ([]strin
 	if err != nil {
 		return nil, fmt.Errorf("list document paths: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
+	rows := allResults(results)
+	if rows == nil {
 		return nil, nil
 	}
-	paths := make([]string, len((*results)[0].Result))
-	for i, r := range (*results)[0].Result {
+	paths := make([]string, len(rows))
+	for i, r := range rows {
 		paths[i] = r.Path
 	}
 	return paths, nil
-}
-
-func newRecordID(table, id string) surrealmodels.RecordID {
-	return surrealmodels.RecordID{Table: table, ID: id}
 }
 
 // VaultInfoStats holds aggregated vault statistics from a batch query.

--- a/internal/db/queries_vault_member.go
+++ b/internal/db/queries_vault_member.go
@@ -27,10 +27,7 @@ func (c *Client) CreateVaultMember(ctx context.Context, userID, vaultID string, 
 	if err != nil {
 		return nil, fmt.Errorf("create vault member: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("create vault member: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "create vault member")
 }
 
 // GetVaultMemberships returns all vault memberships for a user.
@@ -43,10 +40,7 @@ func (c *Client) GetVaultMemberships(ctx context.Context, userID string) ([]mode
 	if err != nil {
 		return nil, fmt.Errorf("get vault memberships: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 // GetVaultMembers returns all members of a vault.
@@ -59,10 +53,7 @@ func (c *Client) GetVaultMembers(ctx context.Context, vaultID string) ([]models.
 	if err != nil {
 		return nil, fmt.Errorf("get vault members: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 // UpdateVaultMemberRole updates the role of a vault member.

--- a/internal/db/queries_version.go
+++ b/internal/db/queries_version.go
@@ -34,10 +34,7 @@ func (c *Client) CreateVersion(ctx context.Context, input models.DocumentVersion
 	if err != nil {
 		return nil, fmt.Errorf("create version: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, fmt.Errorf("create version: no result returned")
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResult(results, "create version")
 }
 
 // GetVersion retrieves a single version by its ID.
@@ -51,10 +48,7 @@ func (c *Client) GetVersion(ctx context.Context, id string) (*models.DocumentVer
 	if err != nil {
 		return nil, fmt.Errorf("get version: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 // GetVersionByNumber retrieves a specific version by document ID and version number.
@@ -69,10 +63,7 @@ func (c *Client) GetVersionByNumber(ctx context.Context, documentID string, vers
 	if err != nil {
 		return nil, fmt.Errorf("get version by number: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 // ListVersions returns versions for a document, paginated, newest first.
@@ -110,10 +101,7 @@ func (c *Client) GetLatestVersion(ctx context.Context, documentID string) (*mode
 	if err != nil {
 		return nil, fmt.Errorf("get latest version: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return nil, nil
-	}
-	return &(*results)[0].Result[0], nil
+	return firstResultOpt(results), nil
 }
 
 // CountVersions returns the total number of versions for a document.
@@ -158,10 +146,7 @@ func (c *Client) DeleteOldestVersions(ctx context.Context, documentID string, ke
 	if err != nil {
 		return 0, fmt.Errorf("delete oldest versions: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return 0, nil
-	}
-	return len((*results)[0].Result), nil
+	return countResults(results), nil
 }
 
 // NextVersionNumber returns the next version number for a document.

--- a/internal/db/queries_wikilink.go
+++ b/internal/db/queries_wikilink.go
@@ -61,10 +61,7 @@ func (c *Client) GetWikiLinks(ctx context.Context, fromDocID string) ([]models.W
 	if err != nil {
 		return nil, fmt.Errorf("get wiki links: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 // GetBacklinks returns wiki-links pointing to a document.
@@ -77,10 +74,7 @@ func (c *Client) GetBacklinks(ctx context.Context, toDocID string) ([]models.Wik
 	if err != nil {
 		return nil, fmt.Errorf("get backlinks: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return nil, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 // DeleteWikiLinks removes all wiki-links originating from a document.
@@ -106,10 +100,7 @@ func (c *Client) UnresolveWikiLinksToDoc(ctx context.Context, docID string) (int
 	if err != nil {
 		return 0, fmt.Errorf("unresolve wiki links to doc: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return 0, nil
-	}
-	return len((*results)[0].Result), nil
+	return countResults(results), nil
 }
 
 // UpdateWikiLinkRawTargets updates raw_target for all wiki_links in a vault matching oldTarget.
@@ -125,10 +116,7 @@ func (c *Client) UpdateWikiLinkRawTargets(ctx context.Context, vaultID, oldTarge
 	if err != nil {
 		return 0, fmt.Errorf("update wiki link raw targets: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return 0, nil
-	}
-	return len((*results)[0].Result), nil
+	return countResults(results), nil
 }
 
 // UpdateWikiLinkRawTargetsByPrefix updates raw_target for all wiki_links in a vault
@@ -145,10 +133,7 @@ func (c *Client) UpdateWikiLinkRawTargetsByPrefix(ctx context.Context, vaultID, 
 	if err != nil {
 		return 0, fmt.Errorf("update wiki link raw targets by prefix: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return 0, nil
-	}
-	return len((*results)[0].Result), nil
+	return countResults(results), nil
 }
 
 // ResolveDanglingLinks finds dangling wiki-links in a vault matching a target
@@ -169,8 +154,5 @@ func (c *Client) ResolveDanglingLinks(ctx context.Context, vaultID, rawTarget, t
 	if err != nil {
 		return 0, fmt.Errorf("resolve dangling links: %w", err)
 	}
-	if results == nil || len(*results) == 0 {
-		return 0, nil
-	}
-	return len((*results)[0].Result), nil
+	return countResults(results), nil
 }

--- a/internal/document/process_worker.go
+++ b/internal/document/process_worker.go
@@ -2,10 +2,12 @@ package document
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"runtime/debug"
 	"time"
 
+	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
 
@@ -43,7 +45,7 @@ func NewProcessingWorker(service *Service, interval time.Duration, batchSize int
 // Run starts the processing worker loop. It blocks until the context is cancelled.
 // If the worker panics, it logs the stack trace and restarts after a short delay.
 func (w *ProcessingWorker) Run(ctx context.Context) {
-	slog.Info("document processing worker started", "interval", w.interval, "batch_size", w.batch)
+	logutil.FromCtx(ctx).Info("document processing worker started", "interval", w.interval, "batch_size", w.batch)
 
 	for {
 		stopped := w.runLoop(ctx)
@@ -52,10 +54,10 @@ func (w *ProcessingWorker) Run(ctx context.Context) {
 		}
 		select {
 		case <-ctx.Done():
-			slog.Info("document processing worker stopped")
+			logutil.FromCtx(ctx).Info("document processing worker stopped")
 			return
 		case <-time.After(5 * time.Second):
-			slog.Info("document processing worker restarting after panic")
+			logutil.FromCtx(ctx).Info("document processing worker restarting after panic")
 		}
 	}
 }
@@ -63,7 +65,7 @@ func (w *ProcessingWorker) Run(ctx context.Context) {
 func (w *ProcessingWorker) runLoop(ctx context.Context) (stopped bool) {
 	defer func() {
 		if p := recover(); p != nil {
-			slog.Error("document processing worker panicked",
+			logutil.FromCtx(ctx).Error("document processing worker panicked",
 				"error", p, "stack", string(debug.Stack()))
 			stopped = false
 		}
@@ -78,7 +80,7 @@ func (w *ProcessingWorker) runLoop(ctx context.Context) (stopped bool) {
 	for {
 		select {
 		case <-ctx.Done():
-			slog.Info("document processing worker stopped")
+			logutil.FromCtx(ctx).Info("document processing worker stopped")
 			return true
 		case <-ticker.C:
 			w.tick(ctx)
@@ -89,7 +91,7 @@ func (w *ProcessingWorker) runLoop(ctx context.Context) (stopped bool) {
 func (w *ProcessingWorker) tick(ctx context.Context) {
 	docs, err := w.service.db.ListUnprocessedDocuments(ctx, w.batch)
 	if err != nil {
-		slog.Error("document processing worker: list unprocessed", "error", err)
+		logutil.FromCtx(ctx).Error("document processing worker: list unprocessed", "error", err)
 		return
 	}
 
@@ -105,12 +107,12 @@ func (w *ProcessingWorker) tick(ctx context.Context) {
 
 		docID, err := models.RecordIDString(doc.ID)
 		if err != nil {
-			slog.Warn("failed to extract doc ID in processing tick", "path", doc.Path, "error", err)
+			logutil.FromCtx(ctx).Warn("failed to extract doc ID in processing tick", "path", doc.Path, "error", err)
 			continue
 		}
 
 		if w.failures[docID] >= w.maxRetries {
-			slog.Warn("skipping poison-pill document", "path", doc.Path, "id", docID, "failures", w.failures[docID])
+			logutil.FromCtx(ctx).Warn("skipping poison-pill document", "path", doc.Path, "id", docID, "failures", w.failures[docID])
 			continue
 		}
 
@@ -120,7 +122,7 @@ func (w *ProcessingWorker) tick(ctx context.Context) {
 			if w.failures[docID] >= w.maxRetries {
 				level = slog.LevelError
 			}
-			slog.Log(ctx, level, "failed to process document",
+			logutil.FromCtx(ctx).Log(ctx, level, "failed to process document",
 				"path", doc.Path, "attempt", w.failures[docID],
 				"max_retries", w.maxRetries, "error", err)
 			continue
@@ -131,7 +133,7 @@ func (w *ProcessingWorker) tick(ctx context.Context) {
 	}
 
 	if processed > 0 {
-		slog.Info("document processing worker processed documents", "count", processed)
+		logutil.FromCtx(ctx).Info("document processing worker processed documents", "count", processed)
 	}
 }
 
@@ -139,12 +141,12 @@ func (w *ProcessingWorker) processOne(ctx context.Context, doc *models.Document)
 	// Re-fetch to get the latest version (another write may have happened)
 	docID, err := models.RecordIDString(doc.ID)
 	if err != nil {
-		return err
+		return fmt.Errorf("extract document ID: %w", err)
 	}
 
 	latest, err := w.service.db.GetDocumentByID(ctx, docID)
 	if err != nil {
-		return err
+		return fmt.Errorf("process document %s: %w", docID, err)
 	}
 	if latest == nil {
 		// Document was deleted between listing and processing — skip

--- a/internal/nfs/fs.go
+++ b/internal/nfs/fs.go
@@ -114,7 +114,7 @@ func (f *FS) OpenFile(filename string, flag int, _ os.FileMode) (billy.File, err
 
 	vaultID, err := f.resolveVault(ctx, vaultName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("open %s: %w", filename, err)
 	}
 
 	// Vault root
@@ -171,7 +171,7 @@ func (f *FS) Stat(filename string) (os.FileInfo, error) {
 
 	vaultID, err := f.resolveVault(ctx, vaultName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("stat %s: %w", filename, err)
 	}
 
 	// Vault root
@@ -224,7 +224,7 @@ func (f *FS) Rename(oldpath, newpath string) error {
 
 	vaultID, err := f.resolveVault(ctx, oldVault)
 	if err != nil {
-		return err
+		return fmt.Errorf("rename %s: %w", oldpath, err)
 	}
 
 	// Try as document
@@ -269,7 +269,7 @@ func (f *FS) Remove(filename string) error {
 
 	vaultID, err := f.resolveVault(ctx, vaultName)
 	if err != nil {
-		return err
+		return fmt.Errorf("remove %s: %w", filename, err)
 	}
 
 	if docPath == "/" {
@@ -320,7 +320,7 @@ func (f *FS) ReadDir(dirname string) ([]os.FileInfo, error) {
 
 	vaultID, err := f.resolveVault(ctx, vaultName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("readdir %s: %w", dirname, err)
 	}
 
 	return f.listDirEntries(ctx, vaultID, docPath)
@@ -337,7 +337,7 @@ func (f *FS) MkdirAll(filename string, _ os.FileMode) error {
 
 	vaultID, err := f.resolveVault(ctx, vaultName)
 	if err != nil {
-		return err
+		return fmt.Errorf("mkdir %s: %w", filename, err)
 	}
 
 	if docPath == "/" {

--- a/internal/tools/helpers.go
+++ b/internal/tools/helpers.go
@@ -1,0 +1,14 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func parseInput[T any](argumentsInJSON string, toolName string) (*T, error) {
+	var input T
+	if err := json.Unmarshal([]byte(argumentsInJSON), &input); err != nil {
+		return nil, fmt.Errorf("parse %s input: %w", toolName, err)
+	}
+	return &input, nil
+}

--- a/internal/tools/tool_create_document.go
+++ b/internal/tools/tool_create_document.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -41,12 +40,12 @@ func (t *CreateDocumentTool) Info(ctx context.Context) (*schema.ToolInfo, error)
 func (t *CreateDocumentTool) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
 	o := getToolOptions(opts...)
 
-	var args struct {
+	args, err := parseInput[struct {
 		Path    string `json:"path"`
 		Content string `json:"content"`
-	}
-	if err := json.Unmarshal([]byte(argumentsInJSON), &args); err != nil {
-		return "", fmt.Errorf("parse create_document input: %w", err)
+	}](argumentsInJSON, "create_document")
+	if err != nil {
+		return "", err
 	}
 	if args.Path == "" {
 		return "", fmt.Errorf("path is required")

--- a/internal/tools/tool_create_memory.go
+++ b/internal/tools/tool_create_memory.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -54,14 +53,14 @@ func (t *CreateMemoryTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 func (t *CreateMemoryTool) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
 	o := getToolOptions(opts...)
 
-	var input struct {
+	input, err := parseInput[struct {
 		Title   string   `json:"title"`
 		Content string   `json:"content"`
 		Project string   `json:"project"`
 		Labels  []string `json:"labels"`
-	}
-	if err := json.Unmarshal([]byte(argumentsInJSON), &input); err != nil {
-		return "", fmt.Errorf("parse create_memory input: %w", err)
+	}](argumentsInJSON, "create_memory")
+	if err != nil {
+		return "", err
 	}
 	if strings.TrimSpace(input.Title) == "" {
 		return "", fmt.Errorf("title is required")

--- a/internal/tools/tool_edit_document.go
+++ b/internal/tools/tool_edit_document.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -45,13 +44,13 @@ func (t *EditDocumentTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 func (t *EditDocumentTool) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
 	o := getToolOptions(opts...)
 
-	var args struct {
+	args, err := parseInput[struct {
 		Path         string  `json:"path"`
 		Content      string  `json:"content"`
 		ExpectedHash *string `json:"expected_hash"`
-	}
-	if err := json.Unmarshal([]byte(argumentsInJSON), &args); err != nil {
-		return "", fmt.Errorf("parse edit_document input: %w", err)
+	}](argumentsInJSON, "edit_document")
+	if err != nil {
+		return "", err
 	}
 	if args.Path == "" {
 		return "", fmt.Errorf("path is required")

--- a/internal/tools/tool_edit_document_section.go
+++ b/internal/tools/tool_edit_document_section.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -66,7 +65,7 @@ func (t *EditDocumentSectionTool) Info(ctx context.Context) (*schema.ToolInfo, e
 func (t *EditDocumentSectionTool) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
 	o := getToolOptions(opts...)
 
-	var args struct {
+	args, err := parseInput[struct {
 		Path         string  `json:"path"`
 		Operation    string  `json:"operation"`
 		Heading      *string `json:"heading"`
@@ -75,9 +74,9 @@ func (t *EditDocumentSectionTool) InvokableRun(ctx context.Context, argumentsInJ
 		NewHeading   *string `json:"new_heading"`
 		NewLevel     *int    `json:"new_level"`
 		ExpectedHash *string `json:"expected_hash"`
-	}
-	if err := json.Unmarshal([]byte(argumentsInJSON), &args); err != nil {
-		return "", fmt.Errorf("parse edit_document_section input: %w", err)
+	}](argumentsInJSON, "edit_document_section")
+	if err != nil {
+		return "", err
 	}
 	if args.Path == "" {
 		return "", fmt.Errorf("path is required")

--- a/internal/tools/tool_get_document_versions.go
+++ b/internal/tools/tool_get_document_versions.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -39,12 +38,12 @@ func (t *GetDocumentVersionsTool) Info(ctx context.Context) (*schema.ToolInfo, e
 func (t *GetDocumentVersionsTool) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
 	o := getToolOptions(opts...)
 
-	var input struct {
+	input, err := parseInput[struct {
 		Path  string `json:"path"`
 		Limit *int   `json:"limit"`
-	}
-	if err := json.Unmarshal([]byte(argumentsInJSON), &input); err != nil {
-		return "", fmt.Errorf("parse get_document_versions input: %w", err)
+	}](argumentsInJSON, "get_document_versions")
+	if err != nil {
+		return "", err
 	}
 	if strings.TrimSpace(input.Path) == "" {
 		return "", fmt.Errorf("path is required")

--- a/internal/tools/tool_list_folder_contents.go
+++ b/internal/tools/tool_list_folder_contents.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -35,11 +34,11 @@ func (t *ListFolderContentsTool) Info(ctx context.Context) (*schema.ToolInfo, er
 func (t *ListFolderContentsTool) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
 	o := getToolOptions(opts...)
 
-	var input struct {
+	input, err := parseInput[struct {
 		Folder string `json:"folder"`
-	}
-	if err := json.Unmarshal([]byte(argumentsInJSON), &input); err != nil {
-		return "", fmt.Errorf("parse list_folder_contents input: %w", err)
+	}](argumentsInJSON, "list_folder_contents")
+	if err != nil {
+		return "", err
 	}
 	if input.Folder == "" {
 		return "", fmt.Errorf("folder is required")

--- a/internal/tools/tool_list_folders.go
+++ b/internal/tools/tool_list_folders.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -35,11 +34,11 @@ func (t *ListFoldersTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 func (t *ListFoldersTool) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
 	o := getToolOptions(opts...)
 
-	var input struct {
+	input, err := parseInput[struct {
 		Parent *string `json:"parent"`
-	}
-	if err := json.Unmarshal([]byte(argumentsInJSON), &input); err != nil {
-		return "", fmt.Errorf("parse list_folders input: %w", err)
+	}](argumentsInJSON, "list_folders")
+	if err != nil {
+		return "", err
 	}
 
 	start := time.Now()

--- a/internal/tools/tool_read_document.go
+++ b/internal/tools/tool_read_document.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -40,12 +39,12 @@ func (t *ReadDocumentTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 func (t *ReadDocumentTool) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
 	o := getToolOptions(opts...)
 
-	var input struct {
+	input, err := parseInput[struct {
 		Path     string `json:"path"`
 		Sections bool   `json:"sections"`
-	}
-	if err := json.Unmarshal([]byte(argumentsInJSON), &input); err != nil {
-		return "", fmt.Errorf("parse read_document input: %w", err)
+	}](argumentsInJSON, "read_document")
+	if err != nil {
+		return "", err
 	}
 
 	start := time.Now()

--- a/internal/tools/tool_search.go
+++ b/internal/tools/tool_search.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -30,11 +29,11 @@ func (t *SearchTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 func (t *SearchTool) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
 	o := getToolOptions(opts...)
 
-	var input struct {
+	input, err := parseInput[struct {
 		Query string `json:"query"`
-	}
-	if err := json.Unmarshal([]byte(argumentsInJSON), &input); err != nil {
-		return "", fmt.Errorf("parse search input: %w", err)
+	}](argumentsInJSON, "search")
+	if err != nil {
+		return "", err
 	}
 
 	start := time.Now()


### PR DESCRIPTION
Introduce generic helpers to eliminate repetitive boilerplate across 35 files (-157 net lines):
- `firstResult`, `firstResultOpt`, `allResults`, `countResults` in `db/helpers.go` for SurrealDB query result extraction
- `decodeBody` in `api/server.go` for JSON request decoding with size limits and error logging
- `parseInput` in `tools/helpers.go` for MCP tool input unmarshalling
- Batch `SyncDocumentLabels` to eliminate N+1 label queries via `INSERT ... ON DUPLICATE KEY UPDATE`
- Migrate `process_worker.go` to `logutil.FromCtx(ctx)` structured logging
- Improve error wrapping context across agent, document, and nfs packages

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)