### PR TITLE
feat: add vault settings API with validation and CLI command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,8 @@ All env vars use the `KNOW_` prefix: `KNOW_LOG_LEVEL`, `KNOW_LOG_FILE`, etc.
 The server exposes a REST API at `/api/` for CLI and TUI communication:
 
 - `GET /api/vaults` — list accessible vaults
+- `GET /api/vaults/{name}/settings` — get vault settings (with defaults)
+- `PATCH /api/vaults/{name}/settings` — update vault settings (partial)
 - `GET /api/conversations?vault={id}` — list conversations
 - `GET /api/conversations/{id}` — get conversation with messages
 - `POST /api/conversations` — create conversation

--- a/cmd/know/cmd_note.go
+++ b/cmd/know/cmd_note.go
@@ -16,12 +16,10 @@ import (
 )
 
 var (
-	noteAPI            *apiFlags
-	noteVaultID        *string
-	noteDate           string
-	noteFolder         string
-	noteTemplateFolder string
-	noteEdit           bool
+	noteAPI     *apiFlags
+	noteVaultID *string
+	noteDate    string
+	noteEdit    bool
 )
 
 var noteCmd = &cobra.Command{
@@ -36,11 +34,10 @@ Modes:
   know note                  Print today's note to stdout
 
 The daily note is created automatically on first use with a daily-note label.
+Folder paths are configured via vault settings (see: know vault settings).
 
 Environment variables:
-  KNOW_VAULT             vault name (alternative to --vault flag)
-  KNOW_DAILY_FOLDER      folder path for daily notes (alternative to --folder flag)
-  KNOW_TEMPLATE_FOLDER   folder path for templates (alternative to --template-folder flag)`,
+  KNOW_VAULT    vault name (alternative to --vault flag)`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runNote,
 }
@@ -49,8 +46,6 @@ func init() {
 	noteAPI = addAPIFlags(noteCmd)
 	noteVaultID = addVaultFlag(noteCmd)
 	noteCmd.Flags().StringVarP(&noteDate, "date", "d", "", "target date in YYYY-MM-DD format (default: today)")
-	noteCmd.Flags().StringVar(&noteFolder, "folder", envOrDefault("KNOW_DAILY_FOLDER", "/daily/"), "folder path for daily notes (env: KNOW_DAILY_FOLDER)")
-	noteCmd.Flags().StringVar(&noteTemplateFolder, "template-folder", envOrDefault("KNOW_TEMPLATE_FOLDER", "/templates"), "folder path for templates (env: KNOW_TEMPLATE_FOLDER)")
 	noteCmd.Flags().BoolVarP(&noteEdit, "edit", "e", false, "open daily note in $EDITOR")
 }
 
@@ -64,8 +59,17 @@ func runNote(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid date %q (expected YYYY-MM-DD): %w", date, err)
 	}
 
+	ctx := context.Background()
+	client := noteAPI.newClient()
+
+	// Fetch folder paths from vault settings.
+	settings, err := client.GetVaultSettings(ctx, *noteVaultID)
+	if err != nil {
+		return fmt.Errorf("fetch vault settings: %w", err)
+	}
+
 	// Normalize folder path.
-	folder := noteFolder
+	folder := settings.DailyNotePath
 	if !strings.HasPrefix(folder, "/") {
 		folder = "/" + folder
 	}
@@ -79,11 +83,8 @@ func runNote(_ *cobra.Command, args []string) error {
 		prompt = args[0]
 	}
 
-	ctx := context.Background()
-	client := noteAPI.newClient()
-
 	// Ensure daily note exists.
-	doc, err := ensureDailyNote(ctx, client, *noteVaultID, docPath, date)
+	doc, err := ensureDailyNote(ctx, client, *noteVaultID, docPath, date, settings.TemplatePath)
 	if err != nil {
 		return err
 	}
@@ -120,7 +121,7 @@ func runNote(_ *cobra.Command, args []string) error {
 // ensureDailyNote fetches the daily note or creates it with a template if it doesn't exist.
 // It tries to read a "daily-note" template from the template folder for the initial content,
 // falling back to a hardcoded default if no template is found.
-func ensureDailyNote(ctx context.Context, client *apiclient.Client, vaultID, path, date string) (*apiclient.Document, error) {
+func ensureDailyNote(ctx context.Context, client *apiclient.Client, vaultID, path, date, templatePath string) (*apiclient.Document, error) {
 	doc, err := client.GetDocument(ctx, vaultID, path)
 	if err == nil {
 		return doc, nil
@@ -131,9 +132,9 @@ func ensureDailyNote(ctx context.Context, client *apiclient.Client, vaultID, pat
 		return nil, fmt.Errorf("check daily note: %w", err)
 	}
 
-	content, err := dailyNoteContent(ctx, client, vaultID, date)
+	content, err := dailyNoteContent(ctx, client, vaultID, date, templatePath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("daily note content: %w", err)
 	}
 	doc, err = client.CreateDocument(ctx, apiclient.CreateDocumentRequest{
 		VaultID: vaultID,
@@ -150,8 +151,8 @@ func ensureDailyNote(ctx context.Context, client *apiclient.Client, vaultID, pat
 // dailyNoteContent returns the initial content for a new daily note.
 // Tries the template folder first, falls back to a hardcoded default if no template exists.
 // Returns an error for non-404 failures (network, auth, server errors).
-func dailyNoteContent(ctx context.Context, client *apiclient.Client, vaultID, date string) (string, error) {
-	tplFolder := strings.TrimSuffix(noteTemplateFolder, "/")
+func dailyNoteContent(ctx context.Context, client *apiclient.Client, vaultID, date, templatePath string) (string, error) {
+	tplFolder := strings.TrimSuffix(templatePath, "/")
 	tplPath := tplFolder + "/daily-note.md"
 
 	tplDoc, err := client.GetDocument(ctx, vaultID, tplPath)

--- a/cmd/know/cmd_vault_settings.go
+++ b/cmd/know/cmd_vault_settings.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/raphi011/know/internal/models"
+	"github.com/spf13/cobra"
+)
+
+var (
+	vaultSettingsAPI     *apiFlags
+	vaultSettingsVaultID *string
+	vaultSettingsJSON    bool
+	vaultSettingsSet     []string
+)
+
+var vaultSettingsCmd = &cobra.Command{
+	Use:   "settings [vault-name]",
+	Short: "View or update vault settings",
+	Long: `View or update per-vault settings such as folder paths and memory parameters.
+
+The vault name can be passed as a positional argument or via --vault flag.
+
+To update settings, use --set key=value (repeatable):
+  know vault settings --set daily_note_path=/notes --set template_path=/tpl
+
+Valid keys:
+  memory_path              folder for memories (default: /memories)
+  memory_merge_threshold   similarity threshold for memory consolidation (default: 0.95)
+  memory_archive_threshold score below which memories are archived (default: 0.2)
+  memory_decay_half_life   days until memory score halves (default: 30)
+  template_path            folder for templates (default: /templates)
+  daily_note_path          folder for daily notes (default: /daily)
+
+Environment variables:
+  KNOW_VAULT    vault name (alternative to --vault flag)`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runVaultSettings,
+}
+
+func init() {
+	vaultSettingsAPI = addAPIFlags(vaultSettingsCmd)
+	vaultSettingsVaultID = addVaultFlag(vaultSettingsCmd)
+	vaultSettingsCmd.Flags().BoolVar(&vaultSettingsJSON, "json", false, "output as JSON")
+	vaultSettingsCmd.Flags().StringArrayVar(&vaultSettingsSet, "set", nil, "set a setting (key=value, repeatable)")
+
+	vaultCmd.AddCommand(vaultSettingsCmd)
+}
+
+func runVaultSettings(_ *cobra.Command, args []string) error {
+	vaultName := *vaultSettingsVaultID
+	if len(args) > 0 {
+		vaultName = args[0]
+	}
+
+	client := vaultSettingsAPI.newClient()
+	ctx := context.Background()
+
+	if len(vaultSettingsSet) > 0 {
+		patch, err := parseSettingsPatch(vaultSettingsSet)
+		if err != nil {
+			return err
+		}
+		settings, err := client.UpdateVaultSettings(ctx, vaultName, patch)
+		if err != nil {
+			return fmt.Errorf("update settings: %w", err)
+		}
+		return printSettings(settings)
+	}
+
+	settings, err := client.GetVaultSettings(ctx, vaultName)
+	if err != nil {
+		return fmt.Errorf("get settings: %w", err)
+	}
+	return printSettings(settings)
+}
+
+func parseSettingsPatch(pairs []string) (models.VaultSettings, error) {
+	var s models.VaultSettings
+	for _, pair := range pairs {
+		key, value, ok := strings.Cut(pair, "=")
+		if !ok {
+			return s, fmt.Errorf("invalid --set format %q, expected key=value", pair)
+		}
+		switch key {
+		case "memory_path":
+			s.MemoryPath = value
+		case "template_path":
+			s.TemplatePath = value
+		case "daily_note_path":
+			s.DailyNotePath = value
+		case "memory_merge_threshold":
+			v, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return s, fmt.Errorf("invalid value for %s: %w", key, err)
+			}
+			s.MemoryMergeThreshold = v
+		case "memory_archive_threshold":
+			v, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return s, fmt.Errorf("invalid value for %s: %w", key, err)
+			}
+			s.MemoryArchiveThreshold = v
+		case "memory_decay_half_life":
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return s, fmt.Errorf("invalid value for %s: %w", key, err)
+			}
+			s.MemoryDecayHalfLife = v
+		default:
+			return s, fmt.Errorf("unknown setting %q", key)
+		}
+	}
+	return s, nil
+}
+
+func printSettings(s *models.VaultSettings) error {
+	if vaultSettingsJSON {
+		out, err := json.MarshalIndent(s, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal json: %w", err)
+		}
+		fmt.Println(string(out))
+		return nil
+	}
+
+	fmt.Printf("%-25s %s\n", "memory_path:", s.MemoryPath)
+	fmt.Printf("%-25s %.2f\n", "memory_merge_threshold:", s.MemoryMergeThreshold)
+	fmt.Printf("%-25s %.2f\n", "memory_archive_threshold:", s.MemoryArchiveThreshold)
+	fmt.Printf("%-25s %d\n", "memory_decay_half_life:", s.MemoryDecayHalfLife)
+	fmt.Printf("%-25s %s\n", "template_path:", s.TemplatePath)
+	fmt.Printf("%-25s %s\n", "daily_note_path:", s.DailyNotePath)
+	return nil
+}

--- a/cmd/know/cmd_vault_settings_test.go
+++ b/cmd/know/cmd_vault_settings_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseSettingsPatch(t *testing.T) {
+	t.Run("string settings", func(t *testing.T) {
+		s, err := parseSettingsPatch([]string{"memory_path=/mem", "template_path=/tpl", "daily_note_path=/daily"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if s.MemoryPath != "/mem" {
+			t.Errorf("MemoryPath = %q, want /mem", s.MemoryPath)
+		}
+		if s.TemplatePath != "/tpl" {
+			t.Errorf("TemplatePath = %q, want /tpl", s.TemplatePath)
+		}
+		if s.DailyNotePath != "/daily" {
+			t.Errorf("DailyNotePath = %q, want /daily", s.DailyNotePath)
+		}
+	})
+
+	t.Run("numeric settings", func(t *testing.T) {
+		s, err := parseSettingsPatch([]string{"memory_merge_threshold=0.8", "memory_archive_threshold=0.1", "memory_decay_half_life=60"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if s.MemoryMergeThreshold != 0.8 {
+			t.Errorf("MemoryMergeThreshold = %f, want 0.8", s.MemoryMergeThreshold)
+		}
+		if s.MemoryArchiveThreshold != 0.1 {
+			t.Errorf("MemoryArchiveThreshold = %f, want 0.1", s.MemoryArchiveThreshold)
+		}
+		if s.MemoryDecayHalfLife != 60 {
+			t.Errorf("MemoryDecayHalfLife = %d, want 60", s.MemoryDecayHalfLife)
+		}
+	})
+
+	errTests := []struct {
+		name  string
+		pairs []string
+	}{
+		{"missing equals", []string{"memory_path"}},
+		{"unknown key", []string{"unknown_key=value"}},
+		{"invalid float", []string{"memory_merge_threshold=abc"}},
+		{"invalid int", []string{"memory_decay_half_life=abc"}},
+	}
+	for _, tt := range errTests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseSettingsPatch(tt.pairs)
+			if err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}

--- a/docs/feature-memory.md
+++ b/docs/feature-memory.md
@@ -102,8 +102,15 @@ Multiplicative (`recency * access_boost`) would mean a memory with zero access b
 
 ### Configuration
 
+All memory settings are configurable per-vault via `know vault settings`:
+
+```bash
+know vault settings --set memory_path=/memories --set memory_decay_half_life=60
+```
+
 | Setting | Default | Description |
 |---------|---------|-------------|
+| `memory_path` | `/memories` | Folder for memory documents (per vault) |
 | `memory_decay_half_life` | 30 | Half-life in days for the recency decay curve (per vault) |
 | `memory_archive_threshold` | 0.2 | Score below which memories are auto-archived (per vault) |
 | `memory_merge_threshold` | 0.95 | Cosine similarity above which memories are merge candidates (per vault) |

--- a/docs/feature-templates.md
+++ b/docs/feature-templates.md
@@ -96,11 +96,23 @@ labels:
 
 ## Configuration
 
-The template folder path is configurable per-vault via the `template_path` field in vault settings (default: `/templates`). This can be set when creating or updating a vault through the REST API.
+The template and daily note folder paths are configurable per-vault via vault settings:
 
-For the `know note` command, the template folder can also be set via:
-- `--template-folder` flag
-- `KNOW_TEMPLATE_FOLDER` environment variable
+```bash
+# View current settings
+know vault settings
+
+# Change template folder
+know vault settings --set template_path=/my-templates
+
+# Change daily note folder
+know vault settings --set daily_note_path=/journal
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `template_path` | `/templates` | Folder for template documents |
+| `daily_note_path` | `/daily` | Folder for daily notes |
 
 ## Example Prompts
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -32,6 +32,8 @@ func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Han
 	// Vaults
 	mux.Handle("GET /api/vaults", authMw(http.HandlerFunc(s.listVaults)))
 	mux.Handle("GET /api/vaults/{name}/info", authMw(http.HandlerFunc(s.getVaultInfo)))
+	mux.Handle("GET /api/vaults/{name}/settings", authMw(http.HandlerFunc(s.getVaultSettings)))
+	mux.Handle("PATCH /api/vaults/{name}/settings", authMw(http.HandlerFunc(s.updateVaultSettings)))
 
 	// Documents
 	mux.Handle("GET /api/ls", authMw(http.HandlerFunc(s.ls)))

--- a/internal/api/vaults.go
+++ b/internal/api/vaults.go
@@ -87,11 +87,14 @@ func (s *Server) listVaults(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, result)
 }
 
-func (s *Server) getVaultInfo(w http.ResponseWriter, r *http.Request) {
+// resolveVault looks up a vault by the "name" path parameter, extracts its ID,
+// and checks that the caller has at least minRole. Returns the vault, its bare ID,
+// and true on success. On failure it writes the HTTP error and returns false.
+func (s *Server) resolveVault(w http.ResponseWriter, r *http.Request, minRole models.VaultRole) (*models.Vault, string, bool) {
 	name := r.PathValue("name")
 	if name == "" {
 		writeError(w, http.StatusBadRequest, "vault name required")
-		return
+		return nil, "", false
 	}
 
 	logger := logutil.FromCtx(r.Context())
@@ -100,29 +103,38 @@ func (s *Server) getVaultInfo(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to resolve vault")
 		logger.Error("get vault by name", "name", name, "error", err)
-		return
+		return nil, "", false
 	}
 	if v == nil {
 		writeError(w, http.StatusNotFound, "vault not found")
-		return
+		return nil, "", false
 	}
 
 	vaultID, err := models.RecordIDString(v.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "invalid vault ID")
 		logger.Error("extract vault ID", "name", name, "error", err)
-		return
+		return nil, "", false
 	}
 
-	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
+	if err := auth.RequireVaultRole(r.Context(), vaultID, minRole); err != nil {
 		writeError(w, http.StatusForbidden, "forbidden")
+		return nil, "", false
+	}
+
+	return v, vaultID, true
+}
+
+func (s *Server) getVaultInfo(w http.ResponseWriter, r *http.Request) {
+	v, vaultID, ok := s.resolveVault(w, r, models.RoleRead)
+	if !ok {
 		return
 	}
 
 	stats, err := s.app.DBClient().GetVaultInfo(r.Context(), vaultID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to get vault info")
-		logger.Error("get vault info", "vault_id", vaultID, "error", err)
+		logutil.FromCtx(r.Context()).Error("get vault info", "vault_id", vaultID, "error", err)
 		return
 	}
 
@@ -150,6 +162,43 @@ func (s *Server) getVaultInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, info)
+}
+
+func (s *Server) getVaultSettings(w http.ResponseWriter, r *http.Request) {
+	v, _, ok := s.resolveVault(w, r, models.RoleRead)
+	if !ok {
+		return
+	}
+
+	writeJSON(w, http.StatusOK, v.Defaults())
+}
+
+func (s *Server) updateVaultSettings(w http.ResponseWriter, r *http.Request) {
+	patch, ok := decodeBody[models.VaultSettings](w, r, 64*1024)
+	if !ok {
+		return
+	}
+
+	if err := patch.Validate(); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	v, vaultID, ok := s.resolveVault(w, r, models.RoleAdmin)
+	if !ok {
+		return
+	}
+
+	merged := v.Defaults().Merge(*patch)
+
+	updated, err := s.app.DBClient().UpdateVaultSettings(r.Context(), vaultID, merged)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update settings")
+		logutil.FromCtx(r.Context()).Error("update vault settings", "vault_id", vaultID, "error", err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, updated.Defaults())
 }
 
 func vaultFromModel(v *models.Vault) Vault {

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -424,6 +424,24 @@ func (c *Client) GetVaultInfo(ctx context.Context, vaultName string) (*VaultInfo
 	return &info, nil
 }
 
+// GetVaultSettings fetches vault settings with defaults applied.
+func (c *Client) GetVaultSettings(ctx context.Context, vaultName string) (*models.VaultSettings, error) {
+	var settings models.VaultSettings
+	if err := c.Get(ctx, "/api/vaults/"+url.PathEscape(vaultName)+"/settings", &settings); err != nil {
+		return nil, fmt.Errorf("get vault settings: %w", err)
+	}
+	return &settings, nil
+}
+
+// UpdateVaultSettings updates vault settings (partial: only non-zero fields are applied).
+func (c *Client) UpdateVaultSettings(ctx context.Context, vaultName string, patch models.VaultSettings) (*models.VaultSettings, error) {
+	var settings models.VaultSettings
+	if err := c.Patch(ctx, "/api/vaults/"+url.PathEscape(vaultName)+"/settings", patch, &settings); err != nil {
+		return nil, fmt.Errorf("update vault settings: %w", err)
+	}
+	return &settings, nil
+}
+
 // DownloadBackup downloads a vault backup archive to the given output path.
 // Returns the number of bytes written.
 func (c *Client) DownloadBackup(ctx context.Context, vaultID, outputPath string) (int64, error) {

--- a/internal/db/queries_vault.go
+++ b/internal/db/queries_vault.go
@@ -115,6 +115,21 @@ func (c *Client) DeleteVault(ctx context.Context, id string) error {
 	return nil
 }
 
+// UpdateVaultSettings replaces the vault's settings with the provided value.
+// The caller is responsible for merging defaults before calling this.
+func (c *Client) UpdateVaultSettings(ctx context.Context, vaultID string, settings models.VaultSettings) (*models.Vault, error) {
+	defer c.logOp(ctx, "vault.update_settings", time.Now())
+	sql := `UPDATE type::record("vault", $id) SET settings = $settings RETURN AFTER`
+	results, err := surrealdb.Query[[]models.Vault](ctx, c.DB(), sql, map[string]any{
+		"id":       bareID("vault", vaultID),
+		"settings": settings,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("update vault settings: %w", err)
+	}
+	return firstResult(results, "update vault settings")
+}
+
 // ListDocumentPaths returns all document paths in a vault (for folder derivation).
 func (c *Client) ListDocumentPaths(ctx context.Context, vaultID string) ([]string, error) {
 	defer c.logOp(ctx, "vault.list_document_paths", time.Now())

--- a/internal/models/vault.go
+++ b/internal/models/vault.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"time"
 
 	surrealmodels "github.com/surrealdb/surrealdb.go/pkg/models"
@@ -23,43 +24,90 @@ type VaultSettings struct {
 	MemoryArchiveThreshold float64 `json:"memory_archive_threshold,omitempty"`
 	MemoryDecayHalfLife    int     `json:"memory_decay_half_life,omitempty"`
 	TemplatePath           string  `json:"template_path,omitempty"`
+	DailyNotePath          string  `json:"daily_note_path,omitempty"`
 }
 
-// DefaultTemplatePath is the default folder for template documents.
-const DefaultTemplatePath = "/templates"
+const (
+	// DefaultTemplatePath is the default folder for template documents.
+	DefaultTemplatePath = "/templates"
+	// DefaultDailyNotePath is the default folder for daily notes.
+	DefaultDailyNotePath = "/daily"
+	// DefaultMemoryPath is the default folder for memories.
+	DefaultMemoryPath = "/memories"
+	// DefaultMemoryMergeThreshold is the cosine similarity above which memories are merge candidates.
+	DefaultMemoryMergeThreshold = 0.95
+	// DefaultMemoryArchiveThreshold is the score below which memories are auto-archived.
+	DefaultMemoryArchiveThreshold = 0.2
+	// DefaultMemoryDecayHalfLife is the half-life in days for memory recency decay.
+	DefaultMemoryDecayHalfLife = 30
+)
 
-// MemoryDefaults returns the vault's memory settings with defaults applied.
-func (v *Vault) MemoryDefaults() VaultSettings {
-	s := VaultSettings{
-		MemoryPath:             "/memories",
-		MemoryMergeThreshold:   0.95,
-		MemoryArchiveThreshold: 0.2,
-		MemoryDecayHalfLife:    30,
+// Validate checks that all non-zero fields in VaultSettings are within valid ranges.
+func (s VaultSettings) Validate() error {
+	if s.MemoryMergeThreshold < 0 || s.MemoryMergeThreshold > 1 {
+		return fmt.Errorf("memory_merge_threshold must be between 0 and 1, got %g", s.MemoryMergeThreshold)
 	}
-	if v.Settings == nil {
-		return s
+	if s.MemoryArchiveThreshold < 0 || s.MemoryArchiveThreshold > 1 {
+		return fmt.Errorf("memory_archive_threshold must be between 0 and 1, got %g", s.MemoryArchiveThreshold)
 	}
-	if v.Settings.MemoryPath != "" {
-		s.MemoryPath = v.Settings.MemoryPath
+	if s.MemoryDecayHalfLife < 0 {
+		return fmt.Errorf("memory_decay_half_life must be non-negative, got %d", s.MemoryDecayHalfLife)
 	}
-	if v.Settings.MemoryMergeThreshold > 0 {
-		s.MemoryMergeThreshold = v.Settings.MemoryMergeThreshold
+	return nil
+}
+
+// Merge overlays non-zero fields from patch onto s and returns the result.
+func (s VaultSettings) Merge(patch VaultSettings) VaultSettings {
+	if patch.MemoryPath != "" {
+		s.MemoryPath = patch.MemoryPath
 	}
-	if v.Settings.MemoryArchiveThreshold > 0 {
-		s.MemoryArchiveThreshold = v.Settings.MemoryArchiveThreshold
+	if patch.MemoryMergeThreshold > 0 {
+		s.MemoryMergeThreshold = patch.MemoryMergeThreshold
 	}
-	if v.Settings.MemoryDecayHalfLife > 0 {
-		s.MemoryDecayHalfLife = v.Settings.MemoryDecayHalfLife
+	if patch.MemoryArchiveThreshold > 0 {
+		s.MemoryArchiveThreshold = patch.MemoryArchiveThreshold
+	}
+	if patch.MemoryDecayHalfLife > 0 {
+		s.MemoryDecayHalfLife = patch.MemoryDecayHalfLife
+	}
+	if patch.TemplatePath != "" {
+		s.TemplatePath = patch.TemplatePath
+	}
+	if patch.DailyNotePath != "" {
+		s.DailyNotePath = patch.DailyNotePath
 	}
 	return s
 }
 
+// Defaults returns the vault's settings with all defaults applied.
+func (v *Vault) Defaults() VaultSettings {
+	s := VaultSettings{
+		MemoryPath:             DefaultMemoryPath,
+		MemoryMergeThreshold:   DefaultMemoryMergeThreshold,
+		MemoryArchiveThreshold: DefaultMemoryArchiveThreshold,
+		MemoryDecayHalfLife:    DefaultMemoryDecayHalfLife,
+		TemplatePath:           DefaultTemplatePath,
+		DailyNotePath:          DefaultDailyNotePath,
+	}
+	if v.Settings == nil {
+		return s
+	}
+	return s.Merge(*v.Settings)
+}
+
+// MemoryDefaults returns the vault's memory settings with defaults applied.
+func (v *Vault) MemoryDefaults() VaultSettings {
+	return v.Defaults()
+}
+
 // TemplatePath returns the vault's configured template path, or the default.
 func (v *Vault) TemplatePath() string {
-	if v.Settings != nil && v.Settings.TemplatePath != "" {
-		return v.Settings.TemplatePath
-	}
-	return DefaultTemplatePath
+	return v.Defaults().TemplatePath
+}
+
+// DailyNotePath returns the vault's configured daily note path, or the default.
+func (v *Vault) DailyNotePath() string {
+	return v.Defaults().DailyNotePath
 }
 
 type VaultInput struct {

--- a/internal/models/vault_test.go
+++ b/internal/models/vault_test.go
@@ -22,3 +22,151 @@ func TestVaultTemplatePath(t *testing.T) {
 		})
 	}
 }
+
+func TestVaultDefaults(t *testing.T) {
+	t.Run("nil settings returns all defaults", func(t *testing.T) {
+		v := &Vault{}
+		d := v.Defaults()
+		if d.MemoryPath != DefaultMemoryPath {
+			t.Errorf("MemoryPath = %q, want %q", d.MemoryPath, DefaultMemoryPath)
+		}
+		if d.TemplatePath != DefaultTemplatePath {
+			t.Errorf("TemplatePath = %q, want %q", d.TemplatePath, DefaultTemplatePath)
+		}
+		if d.DailyNotePath != DefaultDailyNotePath {
+			t.Errorf("DailyNotePath = %q, want %q", d.DailyNotePath, DefaultDailyNotePath)
+		}
+		if d.MemoryDecayHalfLife != 30 {
+			t.Errorf("MemoryDecayHalfLife = %d, want 30", d.MemoryDecayHalfLife)
+		}
+		if d.MemoryMergeThreshold != 0.95 {
+			t.Errorf("MemoryMergeThreshold = %f, want 0.95", d.MemoryMergeThreshold)
+		}
+		if d.MemoryArchiveThreshold != 0.2 {
+			t.Errorf("MemoryArchiveThreshold = %f, want 0.2", d.MemoryArchiveThreshold)
+		}
+	})
+
+	t.Run("custom settings override defaults", func(t *testing.T) {
+		v := &Vault{Settings: &VaultSettings{
+			MemoryPath:             "/custom-mem",
+			TemplatePath:           "/custom-tpl",
+			DailyNotePath:          "/custom-daily",
+			MemoryDecayHalfLife:    60,
+			MemoryMergeThreshold:   0.8,
+			MemoryArchiveThreshold: 0.1,
+		}}
+		d := v.Defaults()
+		if d.MemoryPath != "/custom-mem" {
+			t.Errorf("MemoryPath = %q, want /custom-mem", d.MemoryPath)
+		}
+		if d.TemplatePath != "/custom-tpl" {
+			t.Errorf("TemplatePath = %q, want /custom-tpl", d.TemplatePath)
+		}
+		if d.DailyNotePath != "/custom-daily" {
+			t.Errorf("DailyNotePath = %q, want /custom-daily", d.DailyNotePath)
+		}
+		if d.MemoryDecayHalfLife != 60 {
+			t.Errorf("MemoryDecayHalfLife = %d, want 60", d.MemoryDecayHalfLife)
+		}
+		if d.MemoryMergeThreshold != 0.8 {
+			t.Errorf("MemoryMergeThreshold = %f, want 0.8", d.MemoryMergeThreshold)
+		}
+		if d.MemoryArchiveThreshold != 0.1 {
+			t.Errorf("MemoryArchiveThreshold = %f, want 0.1", d.MemoryArchiveThreshold)
+		}
+	})
+
+	t.Run("MemoryDefaults delegates to Defaults", func(t *testing.T) {
+		v := &Vault{Settings: &VaultSettings{MemoryPath: "/custom"}}
+		md := v.MemoryDefaults()
+		d := v.Defaults()
+		if md != d {
+			t.Errorf("MemoryDefaults() != Defaults()")
+		}
+	})
+}
+
+func TestVaultDailyNotePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings *VaultSettings
+		want     string
+	}{
+		{"nil settings", nil, DefaultDailyNotePath},
+		{"empty daily path", &VaultSettings{}, DefaultDailyNotePath},
+		{"custom path", &VaultSettings{DailyNotePath: "/notes"}, "/notes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Vault{Settings: tt.settings}
+			if got := v.DailyNotePath(); got != tt.want {
+				t.Errorf("DailyNotePath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVaultSettingsValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		s       VaultSettings
+		wantErr bool
+	}{
+		{"valid defaults", VaultSettings{MemoryMergeThreshold: 0.95, MemoryArchiveThreshold: 0.2, MemoryDecayHalfLife: 30}, false},
+		{"zero values", VaultSettings{}, false},
+		{"merge threshold too high", VaultSettings{MemoryMergeThreshold: 1.5}, true},
+		{"merge threshold negative", VaultSettings{MemoryMergeThreshold: -0.1}, true},
+		{"archive threshold too high", VaultSettings{MemoryArchiveThreshold: 2.0}, true},
+		{"archive threshold negative", VaultSettings{MemoryArchiveThreshold: -0.5}, true},
+		{"negative decay half life", VaultSettings{MemoryDecayHalfLife: -1}, true},
+		{"zero decay half life", VaultSettings{MemoryDecayHalfLife: 0}, false},
+		{"boundary merge threshold 0", VaultSettings{MemoryMergeThreshold: 0}, false},
+		{"boundary merge threshold 1", VaultSettings{MemoryMergeThreshold: 1}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.s.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestVaultSettingsMerge(t *testing.T) {
+	base := VaultSettings{
+		MemoryPath:             "/memories",
+		MemoryMergeThreshold:   0.95,
+		MemoryArchiveThreshold: 0.2,
+		MemoryDecayHalfLife:    30,
+		TemplatePath:           "/templates",
+		DailyNotePath:          "/daily",
+	}
+
+	t.Run("empty patch changes nothing", func(t *testing.T) {
+		got := base.Merge(VaultSettings{})
+		if got != base {
+			t.Errorf("Merge(empty) changed values: got %+v", got)
+		}
+	})
+
+	t.Run("patch overrides specific fields", func(t *testing.T) {
+		got := base.Merge(VaultSettings{
+			DailyNotePath:       "/journal",
+			MemoryDecayHalfLife: 60,
+		})
+		if got.DailyNotePath != "/journal" {
+			t.Errorf("DailyNotePath = %q, want /journal", got.DailyNotePath)
+		}
+		if got.MemoryDecayHalfLife != 60 {
+			t.Errorf("MemoryDecayHalfLife = %d, want 60", got.MemoryDecayHalfLife)
+		}
+		// Unchanged fields preserved
+		if got.TemplatePath != "/templates" {
+			t.Errorf("TemplatePath = %q, want /templates", got.TemplatePath)
+		}
+	})
+}


### PR DESCRIPTION
Add GET/PATCH `/api/vaults/{name}/settings` endpoints for per-vault configuration. Move daily note and template folder paths from CLI flags/env vars to server-side vault settings, and add input validation to prevent DB corruption from invalid values.

## New Features
- `GET /api/vaults/{name}/settings` — returns vault settings with defaults applied
- `PATCH /api/vaults/{name}/settings` — partial update with validation
- `know vault settings` CLI command with `--set key=value` support
- `VaultSettings.Validate()` — rejects out-of-range thresholds and negative decay
- `VaultSettings.Merge()` — centralized non-zero field overlay logic
- `resolveVault()` API helper — deduplicates vault lookup across 3 handlers

## Breaking Changes
- Removed `--folder` and `--template-folder` flags from `know note` (now configured via `know vault settings`)
- Removed `KNOW_DAILY_FOLDER` and `KNOW_TEMPLATE_FOLDER` env vars