### PR TITLE
docs: document NFS auth constraints and roadmap

### DIFF
--- a/docs/feature-nfs.md
+++ b/docs/feature-nfs.md
@@ -107,17 +107,46 @@ Once mounted, vaults appear as top-level directories:
 
 ## Authentication
 
-The NFS server uses NFSv3 null authentication — there is no per-user auth. For security:
+The NFS server uses NFSv3 null authentication — there is no per-user auth. All connected clients get system admin access to every vault. For security, the server always binds to `127.0.0.1` (localhost only).
 
-- The server always binds to `127.0.0.1` (localhost only)
-- All vaults accessible to the server are visible
-- Network access from other machines is blocked
+> **Docker warning**: The `127.0.0.1` binding only protects bare-metal/VM setups. In Docker, `-p 2049:2049` forwards external traffic into the container, bypassing the localhost restriction. **Never map the NFS port externally** — anyone who can reach it gets unauthenticated admin access to all vaults. If you need remote file access, use WebDAV or SFTP which support token-based authentication.
 
-This matches the local development use case. For remote access, use WebDAV or SFTP which support token-based authentication.
+### Why no per-user auth?
+
+NFSv3 was designed for trusted LANs and has limited authentication options:
+
+| Auth Flavor | How it works | Security | go-nfs support |
+|-------------|-------------|----------|----------------|
+| AUTH_NULL | No credentials | None | Yes (current) |
+| AUTH_UNIX (AUTH_SYS) | Client self-reports UID/GID | Trivially spoofable — client picks any UID | Header is parsed, but not exposed to handler |
+| AUTH_DES | DES + Diffie-Hellman key exchange | Obsolete, rarely implemented | No |
+| RPCSEC_GSS (Kerberos) | Kerberos tickets, mutual auth, optional encryption | Strong | No |
+
+None of these support bearer tokens like Know's other protocols (REST API, WebDAV, SSH/SFTP). The RPC credential field (`Auth{Flavor, Body}`) is an opaque byte slice — theoretically usable for custom auth, but no standard NFS client would populate it with a Know token.
+
+### Authentication roadmap
+
+When remote NFS access is needed, these are the viable approaches (ranked by recommendation):
+
+1. **HTTP pre-auth + mount secret**: Client POSTs their Know token to a REST endpoint, which registers a time-limited session and returns a mount secret. The NFS mount path includes this secret (`mount server:/session-abc123`). The server extracts it during the MOUNT RPC, validates the session, and scopes the filesystem to the token's vault permissions. The Know token never touches the NFS protocol.
+
+2. **Token in mount path**: Embed the Know token directly in the NFS Dirpath (`mount server:/kh_abc123...`). The server extracts it in `Mount()`, calls `auth.Authenticate()`, and scopes vaults accordingly. Simpler than pre-auth but the token is visible in `mount` output and process listings.
+
+3. **AUTH_UNIX UID mapping**: Configure UID-to-user mappings on the server. Standard NFS mount experience, but UIDs are trivially spoofable by any client on the network — only suitable for trusted LANs.
+
+4. **Connection-scoped IP registration**: A sidecar mechanism registers a client IP via authenticated HTTP. The NFS server checks the remote IP on `Mount()` (available via `net.Conn`) and grants the associated permissions. Time-limited, but relies on IP-based trust.
+
+### Implementation notes for future work
+
+The plumbing for scoped auth already exists — the NFS filesystem is parameterized by `AuthContext`. Key extension points:
+
+- **`Mount()` handler** (`internal/nfs/server.go`): Receives `MountRequest` (includes `Header.Cred` with auth credentials) and `net.Conn` (remote IP). This is where auth validation would happen.
+- **`AuthContext` scoping** (`internal/nfs/fs.go`): The filesystem already filters vaults based on `AuthContext`. Replacing the hardcoded `IsSystemAdmin: true` with a token-derived context would immediately scope vault visibility.
+- **`auth.Authenticate()`** (`internal/auth/validate.go`): The same function used by REST/WebDAV/SSH — returns an `AuthContext` with vault permissions. Any NFS auth scheme just needs to extract a token and call this.
 
 ## Limitations
 
-- **Localhost only**: NFS server binds to 127.0.0.1, not accessible from other machines
+- **Localhost only**: NFS server binds to 127.0.0.1, not accessible from other machines (but see Docker warning in Authentication section)
 - **No file locking**: NLM (Network Lock Manager) is not implemented; concurrent edits may conflict
 - **Markdown only**: Only `.md` files can be created or edited; other file types are read-only
 - **No portmap**: The server does not register with portmap/rpcbind; you must specify the port explicitly when mounting


### PR DESCRIPTION
Expand the NFS authentication docs with protocol-level analysis of why NFSv3 can't support bearer tokens, a Docker security warning, and a ranked roadmap of future auth approaches for when remote access is needed.

## New Features
- Docker security warning for NFS port mapping
- NFSv3 auth flavor comparison table (AUTH_NULL, AUTH_UNIX, AUTH_DES, RPCSEC_GSS)
- Authentication roadmap with 4 ranked approaches (HTTP pre-auth, token-in-path, UID mapping, IP registration)
- Implementation notes pointing to key extension points in the codebase

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)