### PR TITLE
feat: improve ingestion pipeline with batch embedding and event-driven workers

### DIFF
--- a/internal/db/helpers.go
+++ b/internal/db/helpers.go
@@ -33,6 +33,16 @@ func optionalObject(m map[string]any) any {
 	return m
 }
 
+// optionalJSONString returns NONE for nil, otherwise returns the string.
+// Used for fields stored as JSON strings in SurrealDB to avoid strict-mode
+// schema validation of nested object fields.
+func optionalJSONString(s *string) any {
+	if s == nil {
+		return surrealmodels.None
+	}
+	return *s
+}
+
 // firstResult returns the first row from a query result, or an error if no rows were returned.
 // Use for CREATE/UPDATE queries that must return exactly one row.
 func firstResult[T any](results *[]surrealdb.QueryResult[[]T], op string) (*T, error) {

--- a/internal/db/queries_chunk.go
+++ b/internal/db/queries_chunk.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/raphi011/know/internal/models"
@@ -159,6 +160,38 @@ func (c *Client) UpdateChunkEmbedding(ctx context.Context, id string, embedding 
 		"embedding": embedding,
 	}); err != nil {
 		return fmt.Errorf("update chunk embedding: %w", err)
+	}
+	return nil
+}
+
+// ChunkEmbeddingUpdate pairs a chunk ID with its embedding vector for batch updates.
+type ChunkEmbeddingUpdate struct {
+	ID        string
+	Embedding []float32
+}
+
+// BatchUpdateChunkEmbeddings updates multiple chunk embeddings in a single transaction.
+func (c *Client) BatchUpdateChunkEmbeddings(ctx context.Context, updates []ChunkEmbeddingUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+	defer c.logOp(ctx, "chunk.batch_update_embedding", time.Now())
+
+	// Build a single transaction with one UPDATE per chunk
+	var b strings.Builder
+	vars := make(map[string]any, len(updates)*2)
+	b.WriteString("BEGIN TRANSACTION;\n")
+	for i, u := range updates {
+		idKey := fmt.Sprintf("id_%d", i)
+		embKey := fmt.Sprintf("emb_%d", i)
+		fmt.Fprintf(&b, "UPDATE type::record(\"chunk\", $%s) SET embedding = $%s;\n", idKey, embKey)
+		vars[idKey] = u.ID
+		vars[embKey] = u.Embedding
+	}
+	b.WriteString("COMMIT TRANSACTION;")
+
+	if _, err := surrealdb.Query[any](ctx, c.DB(), b.String(), vars); err != nil {
+		return fmt.Errorf("batch update embeddings: %w", err)
 	}
 	return nil
 }

--- a/internal/db/queries_document.go
+++ b/internal/db/queries_document.go
@@ -100,6 +100,7 @@ func (c *Client) CreateDocument(ctx context.Context, input models.DocumentInput)
 			doc_type = $doc_type,
 			content_hash = $content_hash,
 			metadata = $metadata,
+			sections = $sections,
 			processed = false
 		RETURN AFTER
 	`
@@ -114,6 +115,7 @@ func (c *Client) CreateDocument(ctx context.Context, input models.DocumentInput)
 		"doc_type":       optionalString(input.DocType),
 		"content_hash":   optionalString(input.ContentHash),
 		"metadata":       optionalObject(input.Metadata),
+		"sections":       optionalJSONString(input.Sections),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create document: %w", err)
@@ -229,8 +231,9 @@ func (c *Client) ListDocuments(ctx context.Context, filter ListDocumentsFilter) 
 	return allResults(results), nil
 }
 
-func (c *Client) UpdateDocument(ctx context.Context, id string, content, contentBody, title string, labels []string, contentHash *string, metadata map[string]any) (*models.Document, error) {
+func (c *Client) UpdateDocument(ctx context.Context, id string, input models.DocumentInput) (*models.Document, error) {
 	defer c.logOp(ctx, "document.update", time.Now())
+	labels := input.Labels
 	if labels == nil {
 		labels = []string{}
 	}
@@ -244,18 +247,20 @@ func (c *Client) UpdateDocument(ctx context.Context, id string, content, content
 			labels = $labels,
 			content_hash = $content_hash,
 			metadata = $metadata,
+			sections = $sections,
 			processed = false
 		RETURN AFTER
 	`
 	results, err := surrealdb.Query[[]models.Document](ctx, c.DB(), sql, map[string]any{
 		"id":             id,
-		"content":        content,
-		"content_body":   contentBody,
-		"content_length": len(content),
-		"title":          title,
+		"content":        input.Content,
+		"content_body":   input.ContentBody,
+		"content_length": len(input.Content),
+		"title":          input.Title,
 		"labels":         labels,
-		"content_hash":   optionalString(contentHash),
-		"metadata":       optionalObject(metadata),
+		"content_hash":   optionalString(input.ContentHash),
+		"metadata":       optionalObject(input.Metadata),
+		"sections":       optionalJSONString(input.Sections),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("update document: %w", err)
@@ -460,7 +465,7 @@ func (c *Client) UpsertDocument(ctx context.Context, input models.DocumentInput)
 			return nil, false, nil, fmt.Errorf("extract document id: %w", err)
 		}
 
-		doc, err = c.UpdateDocument(ctx, idStr, input.Content, input.ContentBody, input.Title, input.Labels, input.ContentHash, input.Metadata)
+		doc, err = c.UpdateDocument(ctx, idStr, input)
 		if err != nil {
 			return nil, false, nil, err
 		}

--- a/internal/db/queries_document_test.go
+++ b/internal/db/queries_document_test.go
@@ -140,7 +140,12 @@ func TestUpdateDocument(t *testing.T) {
 	}
 	docID := models.MustRecordIDString(doc.ID)
 
-	updated, err := testDB.UpdateDocument(ctx, docID, "new content", "new content", "Updated Title", []string{"new"}, nil, nil)
+	updated, err := testDB.UpdateDocument(ctx, docID, models.DocumentInput{
+		Content:     "new content",
+		ContentBody: "new content",
+		Title:       "Updated Title",
+		Labels:      []string{"new"},
+	})
 	if err != nil {
 		t.Fatalf("UpdateDocument failed: %v", err)
 	}

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -54,6 +54,7 @@ func SchemaSQL(dimension int) string {
     DEFINE FIELD IF NOT EXISTS doc_type     ON document TYPE option<string>;
     DEFINE FIELD IF NOT EXISTS content_hash ON document TYPE option<string>;
     DEFINE FIELD IF NOT EXISTS metadata   ON document TYPE option<object> FLEXIBLE;
+    DEFINE FIELD IF NOT EXISTS sections ON document TYPE option<string>;
     REMOVE FIELD IF EXISTS source ON document;
     REMOVE FIELD IF EXISTS source_path ON document;
     DEFINE FIELD IF NOT EXISTS processed       ON document TYPE bool DEFAULT false;

--- a/internal/document/process_worker.go
+++ b/internal/document/process_worker.go
@@ -4,26 +4,30 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"runtime/debug"
 	"time"
 
+	"github.com/raphi011/know/internal/event"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
 
 // ProcessingWorker polls for unprocessed documents and runs the deferred
-// pipeline (chunks, wiki-links, relations). Mirrors the EmbeddingWorker pattern.
+// pipeline (chunks, wiki-links, relations). Uses WorkerLoop for the
+// run/restart/tick pattern. When an event bus is provided, also wakes
+// immediately on document.created/document.updated events.
 type ProcessingWorker struct {
 	service    *Service
-	interval   time.Duration
 	batch      int
+	interval   time.Duration
+	bus        *event.Bus
 	failures   map[string]int // docID → consecutive failure count
 	maxRetries int
 }
 
 // NewProcessingWorker creates a worker that polls for unprocessed documents.
+// If bus is non-nil, the worker also wakes immediately on document create/update events.
 // Panics if service is nil, interval <= 0, or batchSize <= 0 (programmer errors).
-func NewProcessingWorker(service *Service, interval time.Duration, batchSize int) *ProcessingWorker {
+func NewProcessingWorker(service *Service, interval time.Duration, batchSize int, bus *event.Bus) *ProcessingWorker {
 	if service == nil {
 		panic("ProcessingWorker: nil service")
 	}
@@ -33,59 +37,25 @@ func NewProcessingWorker(service *Service, interval time.Duration, batchSize int
 	if batchSize <= 0 {
 		panic("ProcessingWorker: batchSize must be positive")
 	}
+
 	return &ProcessingWorker{
 		service:    service,
-		interval:   interval,
 		batch:      batchSize,
+		interval:   interval,
+		bus:        bus,
 		failures:   make(map[string]int),
 		maxRetries: 5,
 	}
 }
 
 // Run starts the processing worker loop. It blocks until the context is cancelled.
-// If the worker panics, it logs the stack trace and restarts after a short delay.
+// Subscribes to bus events here (not in constructor) to avoid goroutine leaks
+// if the worker is constructed but never started.
 func (w *ProcessingWorker) Run(ctx context.Context) {
-	logutil.FromCtx(ctx).Info("document processing worker started", "interval", w.interval, "batch_size", w.batch)
-
-	for {
-		stopped := w.runLoop(ctx)
-		if stopped {
-			return
-		}
-		select {
-		case <-ctx.Done():
-			logutil.FromCtx(ctx).Info("document processing worker stopped")
-			return
-		case <-time.After(5 * time.Second):
-			logutil.FromCtx(ctx).Info("document processing worker restarting after panic")
-		}
-	}
-}
-
-func (w *ProcessingWorker) runLoop(ctx context.Context) (stopped bool) {
-	defer func() {
-		if p := recover(); p != nil {
-			logutil.FromCtx(ctx).Error("document processing worker panicked",
-				"error", p, "stack", string(debug.Stack()))
-			stopped = false
-		}
-	}()
-
-	// Process any pending documents immediately on startup
-	w.tick(ctx)
-
-	ticker := time.NewTicker(w.interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			logutil.FromCtx(ctx).Info("document processing worker stopped")
-			return true
-		case <-ticker.C:
-			w.tick(ctx)
-		}
-	}
+	notify, unsub := eventNotify(w.bus, "document.created", "document.updated")
+	defer unsub()
+	loop := NewWorkerLoop("document processing worker", w.interval, w.tick, notify)
+	loop.Run(ctx)
 }
 
 func (w *ProcessingWorker) tick(ctx context.Context) {
@@ -116,7 +86,7 @@ func (w *ProcessingWorker) tick(ctx context.Context) {
 			continue
 		}
 
-		if err := w.processOne(ctx, &doc); err != nil {
+		if err := w.processOne(ctx, docID, &doc); err != nil {
 			w.failures[docID]++
 			level := slog.LevelWarn
 			if w.failures[docID] >= w.maxRetries {
@@ -137,13 +107,8 @@ func (w *ProcessingWorker) tick(ctx context.Context) {
 	}
 }
 
-func (w *ProcessingWorker) processOne(ctx context.Context, doc *models.Document) error {
+func (w *ProcessingWorker) processOne(ctx context.Context, docID string, doc *models.Document) error {
 	// Re-fetch to get the latest version (another write may have happened)
-	docID, err := models.RecordIDString(doc.ID)
-	if err != nil {
-		return fmt.Errorf("extract document ID: %w", err)
-	}
-
 	latest, err := w.service.db.GetDocumentByID(ctx, docID)
 	if err != nil {
 		return fmt.Errorf("process document %s: %w", docID, err)

--- a/internal/document/service.go
+++ b/internal/document/service.go
@@ -2,6 +2,7 @@ package document
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -14,9 +15,9 @@ import (
 
 	"github.com/raphi011/know/internal/db"
 	"github.com/raphi011/know/internal/event"
-	"github.com/raphi011/know/internal/models"
-
 	"github.com/raphi011/know/internal/llm"
+	"github.com/raphi011/know/internal/logutil"
+	"github.com/raphi011/know/internal/models"
 	"github.com/raphi011/know/internal/parser"
 )
 
@@ -180,10 +181,21 @@ func (s *Service) Create(ctx context.Context, input models.DocumentInput) (*mode
 	contentBody := parsed.Content
 	contentHash := models.ContentHash(input.Content)
 
-	// 7. Normalize path
+	// 7. Marshal parsed sections for deferred processing (avoids re-parsing)
+	var sectionsStr *string
+	if len(parsed.Sections) > 0 {
+		b, err := json.Marshal(parsed.Sections)
+		if err != nil {
+			return nil, fmt.Errorf("marshal sections: %w", err)
+		}
+		str := string(b)
+		sectionsStr = &str
+	}
+
+	// 8. Normalize path
 	path := models.NormalizePath(input.Path)
 
-	// 8. Store document
+	// 9. Store document
 	dbInput := models.DocumentInput{
 		VaultID:     input.VaultID,
 		Path:        path,
@@ -194,6 +206,7 @@ func (s *Service) Create(ctx context.Context, input models.DocumentInput) (*mode
 		Labels:      allLabels,
 		DocType:     docType,
 		Metadata:    metadata,
+		Sections:    sectionsStr,
 	}
 
 	// Auto-create parent folders before document upsert
@@ -210,7 +223,7 @@ func (s *Service) Create(ctx context.Context, input models.DocumentInput) (*mode
 	if !created && previousDoc != nil {
 		docID, idErr := models.RecordIDString(doc.ID)
 		if idErr != nil {
-			slog.Warn("failed to extract doc ID for versioning", "error", idErr)
+			logutil.FromCtx(ctx).Warn("failed to extract doc ID for versioning", "error", idErr)
 		} else {
 			s.maybeCreateVersion(ctx, docID, input.VaultID, previousDoc, contentHash)
 		}
@@ -257,9 +270,24 @@ func (s *Service) ProcessDocument(ctx context.Context, doc *models.Document) err
 		return nil
 	}
 
-	parsed, err := parser.ParseMarkdown(doc.Content)
+	// Reconstruct MarkdownDoc from stored fields — avoids expensive re-parse.
+	// Sections are stored as a JSON string during Create(); frontmatter is extracted cheaply.
+	var sections []parser.Section
+	if doc.Sections != nil && *doc.Sections != "" {
+		if err := json.Unmarshal([]byte(*doc.Sections), &sections); err != nil {
+			return fmt.Errorf("unmarshal stored sections for %s: %w", doc.Path, err)
+		}
+	}
+	fm, _, err := parser.ExtractFrontmatter(doc.Content)
 	if err != nil {
-		return fmt.Errorf("parse markdown: %w", err)
+		logutil.FromCtx(ctx).Warn("malformed frontmatter, proceeding with empty metadata", "path", doc.Path, "error", err)
+		fm = make(map[string]any)
+	}
+	parsed := &parser.MarkdownDoc{
+		Frontmatter: fm,
+		Content:     doc.ContentBody,
+		Sections:    sections,
+		Title:       doc.Title,
 	}
 
 	// 1. Sync chunks (with smart diffing — only re-embed changed chunks)
@@ -317,9 +345,16 @@ func (s *Service) ProcessAllPending(ctx context.Context) error {
 	}
 }
 
+// embeddingTask pairs a chunk ID with its embedding text.
+type embeddingTask struct {
+	chunkID string
+	text    string
+}
+
 // EmbedPendingChunks claims chunks that are due for embedding and embeds them.
 // Uses contextual retrieval: prepends document title and section path to chunk
 // content before embedding, improving semantic precision without altering stored content.
+// Attempts batch embedding first for efficiency; falls back to one-at-a-time on batch failure.
 // Returns the number of chunks successfully embedded.
 func (s *Service) EmbedPendingChunks(ctx context.Context, limit int) (int, error) {
 	embedder := s.getEmbedder()
@@ -331,47 +366,114 @@ func (s *Service) EmbedPendingChunks(ctx context.Context, limit int) (int, error
 	if err != nil {
 		return 0, fmt.Errorf("claim chunks for embedding: %w", err)
 	}
+	if len(chunks) == 0 {
+		return 0, nil
+	}
 
 	// Batch-fetch document titles for contextual embedding
 	docTitles := s.fetchDocTitles(ctx, chunks)
 
-	embedded := 0
+	// Build embedding texts for all chunks
+	logger := logutil.FromCtx(ctx)
+	var pending []embeddingTask
 	for _, chunk := range chunks {
 		chunkID, err := models.RecordIDString(chunk.ID)
 		if err != nil {
-			slog.Warn("failed to extract chunk ID for embedding", "error", err)
+			logger.Warn("failed to extract chunk ID for embedding", "error", err)
 			continue
 		}
-
 		docID, err := models.RecordIDString(chunk.Document)
 		if err != nil {
-			slog.Warn("failed to extract document ID for contextual embedding", "chunk_id", chunkID, "error", err)
+			logger.Warn("failed to extract document ID for contextual embedding", "chunk_id", chunkID, "error", err)
 			continue
 		}
-		embeddingText := buildEmbeddingContext(chunk, docTitles[docID], s.embedMaxInputChars)
-
-		emb, err := embedder.Embed(ctx, embeddingText)
-		if err != nil {
-			slog.Warn("failed to embed chunk", "chunk_id", chunkID, "error", err)
-			s.rescheduleChunk(chunkID)
-			continue
-		}
-
-		if err := s.db.UpdateChunkEmbedding(ctx, chunkID, emb); err != nil {
-			slog.Warn("failed to store chunk embedding", "chunk_id", chunkID, "error", err)
-			s.rescheduleChunk(chunkID)
-			continue
-		}
-
-		embedded++
+		pending = append(pending, embeddingTask{
+			chunkID: chunkID,
+			text:    buildEmbeddingContext(chunk, docTitles[docID], s.embedMaxInputChars),
+		})
+	}
+	if len(pending) == 0 {
+		return 0, nil
 	}
 
-	return embedded, nil
+	// Try batch embedding first
+	texts := make([]string, len(pending))
+	for i, p := range pending {
+		texts[i] = p.text
+	}
+
+	vectors, batchErr := embedder.EmbedBatch(ctx, texts)
+	if batchErr != nil {
+		logger.Warn("batch embedding failed, falling back to one-at-a-time", "batch_size", len(texts), "error", batchErr)
+		return s.embedChunksOneByOne(ctx, embedder, pending)
+	}
+
+	// Guard against embedder returning wrong number of vectors
+	if len(vectors) != len(pending) {
+		logger.Error("batch embedding returned wrong vector count", "expected", len(pending), "got", len(vectors))
+		return s.embedChunksOneByOne(ctx, embedder, pending)
+	}
+
+	// Batch succeeded — store all embeddings in a single transaction
+	updates := make([]db.ChunkEmbeddingUpdate, len(vectors))
+	for i, vec := range vectors {
+		updates[i] = db.ChunkEmbeddingUpdate{
+			ID:        pending[i].chunkID,
+			Embedding: vec,
+		}
+	}
+
+	if err := s.db.BatchUpdateChunkEmbeddings(ctx, updates); err != nil {
+		logger.Warn("batch store failed, falling back to individual updates", "error", err)
+		return s.storeEmbeddings(ctx, updates), nil
+	}
+
+	return len(vectors), nil
+}
+
+// storeEmbeddings stores pre-computed embeddings one-by-one, rescheduling
+// failed chunks. Returns the number of successfully stored embeddings.
+func (s *Service) storeEmbeddings(ctx context.Context, updates []db.ChunkEmbeddingUpdate) int {
+	logger := logutil.FromCtx(ctx)
+	stored := 0
+	for _, u := range updates {
+		if err := s.db.UpdateChunkEmbedding(ctx, u.ID, u.Embedding); err != nil {
+			logger.Warn("failed to store chunk embedding", "chunk_id", u.ID, "error", err)
+			s.rescheduleChunk(logger, u.ID)
+			continue
+		}
+		stored++
+	}
+	return stored
+}
+
+// embedChunksOneByOne embeds and stores chunks individually as a fallback
+// when batch embedding fails.
+func (s *Service) embedChunksOneByOne(ctx context.Context, embedder *llm.Embedder, pending []embeddingTask) (int, error) {
+	logger := logutil.FromCtx(ctx)
+	var updates []db.ChunkEmbeddingUpdate
+	var lastErr error
+	for _, p := range pending {
+		emb, err := embedder.Embed(ctx, p.text)
+		if err != nil {
+			logger.Warn("failed to embed chunk", "chunk_id", p.chunkID, "error", err)
+			lastErr = err
+			s.rescheduleChunk(logger, p.chunkID)
+			continue
+		}
+		updates = append(updates, db.ChunkEmbeddingUpdate{ID: p.chunkID, Embedding: emb})
+	}
+	stored := s.storeEmbeddings(ctx, updates)
+	if stored == 0 && lastErr != nil {
+		return 0, fmt.Errorf("all %d chunks failed to embed: %w", len(pending), lastErr)
+	}
+	return stored, nil
 }
 
 // fetchDocTitles collects unique document IDs from a batch of chunks and
 // batch-fetches their titles. Returns a map of docID → title.
 func (s *Service) fetchDocTitles(ctx context.Context, chunks []models.Chunk) map[string]string {
+	logger := logutil.FromCtx(ctx)
 	titles := make(map[string]string)
 
 	// Collect unique doc IDs
@@ -379,7 +481,7 @@ func (s *Service) fetchDocTitles(ctx context.Context, chunks []models.Chunk) map
 	for _, chunk := range chunks {
 		docID, err := models.RecordIDString(chunk.Document)
 		if err != nil {
-			slog.Warn("failed to extract document ID for title lookup", "error", err)
+			logger.Warn("failed to extract document ID for title lookup", "error", err)
 			continue
 		}
 		docIDSet[docID] = struct{}{}
@@ -395,14 +497,14 @@ func (s *Service) fetchDocTitles(ctx context.Context, chunks []models.Chunk) map
 
 	docs, err := s.db.GetDocumentsByIDs(ctx, docIDs)
 	if err != nil {
-		slog.Warn("failed to fetch document titles for contextual embedding", "error", err)
+		logger.Warn("failed to fetch document titles for contextual embedding", "error", err)
 		return titles
 	}
 
 	for _, doc := range docs {
 		docID, err := models.RecordIDString(doc.ID)
 		if err != nil {
-			slog.Warn("failed to extract document ID from fetched doc", "error", err)
+			logger.Warn("failed to extract document ID from fetched doc", "error", err)
 			continue
 		}
 		titles[docID] = doc.Title
@@ -477,11 +579,12 @@ func stripMarkdownHeadingPrefixes(path string) string {
 // rescheduleChunk re-schedules a chunk for embedding after a failure, using a
 // background context so it succeeds even if the parent context is cancelled.
 // Uses a 30s backoff to avoid tight retry storms during outages.
-func (s *Service) rescheduleChunk(chunkID string) {
+// Accepts the caller's logger to preserve request-scoped context fields.
+func (s *Service) rescheduleChunk(logger *slog.Logger, chunkID string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := s.db.RescheduleChunkEmbedding(ctx, chunkID); err != nil {
-		slog.Error("failed to reschedule chunk embedding — chunk will not be retried",
+		logger.Error("failed to reschedule chunk embedding — chunk will not be retried",
 			"chunk_id", chunkID, "error", err)
 	}
 }
@@ -655,6 +758,8 @@ func (s *Service) Move(ctx context.Context, vaultID, oldPath, newPath string) (*
 }
 
 func (s *Service) processWikiLinks(ctx context.Context, docID, vaultID, content string) error {
+	logger := logutil.FromCtx(ctx)
+
 	// Delete existing links from this doc
 	if err := s.db.DeleteWikiLinks(ctx, docID); err != nil {
 		return fmt.Errorf("delete old wiki-links: %w", err)
@@ -670,11 +775,11 @@ func (s *Service) processWikiLinks(ctx context.Context, docID, vaultID, content 
 		var toDocID *string
 		resolved, err := s.resolver.Resolve(ctx, vaultID, target)
 		if err != nil {
-			slog.Warn("failed to resolve wiki-link", "target", target, "error", err)
+			logger.Warn("failed to resolve wiki-link", "target", target, "error", err)
 		} else if resolved != nil {
 			id, err := models.RecordIDString(resolved.ID)
 			if err != nil {
-				slog.Warn("failed to extract resolved document ID for wiki-link", "target", target, "error", err)
+				logger.Warn("failed to extract resolved document ID for wiki-link", "target", target, "error", err)
 			} else {
 				toDocID = &id
 			}
@@ -689,6 +794,8 @@ func (s *Service) processWikiLinks(ctx context.Context, docID, vaultID, content 
 }
 
 func (s *Service) resolveDanglingForDoc(ctx context.Context, vaultID string, doc *models.Document) error {
+	logger := logutil.FromCtx(ctx)
+
 	docID, err := models.RecordIDString(doc.ID)
 	if err != nil {
 		return fmt.Errorf("extract document id: %w", err)
@@ -701,7 +808,7 @@ func (s *Service) resolveDanglingForDoc(ctx context.Context, vaultID string, doc
 			return fmt.Errorf("resolve by title %q: %w", doc.Title, err)
 		}
 		if n > 0 {
-			slog.Info("resolved dangling wiki-links", "title", doc.Title, "count", n)
+			logger.Info("resolved dangling wiki-links", "title", doc.Title, "count", n)
 		}
 	}
 
@@ -711,7 +818,7 @@ func (s *Service) resolveDanglingForDoc(ctx context.Context, vaultID string, doc
 		return fmt.Errorf("resolve by path %q: %w", doc.Path, err)
 	}
 	if n > 0 {
-		slog.Info("resolved dangling wiki-links", "path", doc.Path, "count", n)
+		logger.Info("resolved dangling wiki-links", "path", doc.Path, "count", n)
 	}
 
 	return nil
@@ -721,6 +828,7 @@ func (s *Service) resolveDanglingForDoc(ctx context.Context, vaultID string, doc
 // by content, preserving embeddings for unchanged chunks and scheduling embedding
 // only for new/changed chunks.
 func (s *Service) syncChunks(ctx context.Context, docID string, parsed *parser.MarkdownDoc, labels []string) error {
+	logger := logutil.FromCtx(ctx)
 	newChunkResults := parser.ChunkMarkdown(parsed, s.chunkConfig)
 
 	oldChunks, err := s.db.GetChunks(ctx, docID)
@@ -739,7 +847,7 @@ func (s *Service) syncChunks(ctx context.Context, docID string, parsed *parser.M
 	for _, c := range oldChunks {
 		id, err := models.RecordIDString(c.ID)
 		if err != nil {
-			slog.Warn("failed to extract chunk ID during sync", "error", err)
+			logger.Warn("failed to extract chunk ID during sync", "error", err)
 			continue
 		}
 		allOldIDs = append(allOldIDs, id)
@@ -759,7 +867,7 @@ func (s *Service) syncChunks(ctx context.Context, docID string, parsed *parser.M
 			// Update position if it changed
 			if entry.chunk.Position != i {
 				if err := s.db.UpdateChunkPosition(ctx, entry.id, i); err != nil {
-					slog.Warn("failed to update chunk position", "chunk_id", entry.id, "error", err)
+					logger.Warn("failed to update chunk position", "chunk_id", entry.id, "error", err)
 				}
 			}
 		} else {
@@ -792,7 +900,7 @@ func (s *Service) syncChunks(ctx context.Context, docID string, parsed *parser.M
 	for _, id := range allOldIDs {
 		if !matchedOldIDs[id] {
 			if err := s.db.DeleteChunkByID(ctx, id); err != nil {
-				slog.Warn("failed to delete removed chunk", "chunk_id", id, "error", err)
+				logger.Warn("failed to delete removed chunk", "chunk_id", id, "error", err)
 			}
 		}
 	}
@@ -836,7 +944,7 @@ func (s *Service) processRelatesTo(ctx context.Context, docID, vaultID string, f
 			return fmt.Errorf("resolve relates_to target %q: %w", target, err)
 		}
 		if resolved == nil {
-			slog.Info("relates_to target not found", "target", target)
+			logutil.FromCtx(ctx).Info("relates_to target not found", "target", target)
 			continue
 		}
 		toDocID, err := models.RecordIDString(resolved.ID)

--- a/internal/document/worker.go
+++ b/internal/document/worker.go
@@ -2,21 +2,25 @@ package document
 
 import (
 	"context"
-	"log/slog"
-	"runtime/debug"
 	"time"
+
+	"github.com/raphi011/know/internal/event"
+	"github.com/raphi011/know/internal/logutil"
 )
 
 // EmbeddingWorker processes pending chunk embeddings in the background.
+// When an event bus is provided, wakes immediately on document.processed events.
 type EmbeddingWorker struct {
 	service  *Service
-	interval time.Duration
 	batch    int
+	interval time.Duration
+	bus      *event.Bus
 }
 
 // NewEmbeddingWorker creates a worker that polls for pending chunk embeddings.
+// If bus is non-nil, the worker also wakes immediately on document.processed events.
 // Panics if service is nil, interval <= 0, or batchSize <= 0 (programmer errors).
-func NewEmbeddingWorker(service *Service, interval time.Duration, batchSize int) *EmbeddingWorker {
+func NewEmbeddingWorker(service *Service, interval time.Duration, batchSize int, bus *event.Bus) *EmbeddingWorker {
 	if service == nil {
 		panic("EmbeddingWorker: nil service")
 	}
@@ -26,69 +30,32 @@ func NewEmbeddingWorker(service *Service, interval time.Duration, batchSize int)
 	if batchSize <= 0 {
 		panic("EmbeddingWorker: batchSize must be positive")
 	}
+
 	return &EmbeddingWorker{
 		service:  service,
-		interval: interval,
 		batch:    batchSize,
+		interval: interval,
+		bus:      bus,
 	}
 }
 
 // Run starts the embedding worker loop. It blocks until the context is cancelled.
-// If the worker panics, it logs the stack trace and restarts after a short delay.
+// Subscribes to bus events here (not in constructor) to avoid goroutine leaks
+// if the worker is constructed but never started.
 func (w *EmbeddingWorker) Run(ctx context.Context) {
-	slog.Info("embedding worker started", "interval", w.interval, "batch_size", w.batch)
-
-	for {
-		stopped := w.runLoop(ctx)
-		if stopped {
-			return
-		}
-		// Panic recovery — wait before restarting to avoid a tight loop
-		select {
-		case <-ctx.Done():
-			slog.Info("embedding worker stopped")
-			return
-		case <-time.After(5 * time.Second):
-			slog.Info("embedding worker restarting after panic")
-		}
-	}
-}
-
-// runLoop runs the tick loop, returning true if the context was cancelled (clean stop)
-// or false if a panic occurred and the worker should restart.
-func (w *EmbeddingWorker) runLoop(ctx context.Context) (stopped bool) {
-	defer func() {
-		if p := recover(); p != nil {
-			slog.Error("embedding worker panicked",
-				"error", p, "stack", string(debug.Stack()))
-			stopped = false
-		}
-	}()
-
-	// Process any pending embeddings immediately on startup
-	w.tick(ctx)
-
-	ticker := time.NewTicker(w.interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			slog.Info("embedding worker stopped")
-			return true
-		case <-ticker.C:
-			w.tick(ctx)
-		}
-	}
+	notify, unsub := eventNotify(w.bus, "document.processed")
+	defer unsub()
+	loop := NewWorkerLoop("embedding worker", w.interval, w.tick, notify)
+	loop.Run(ctx)
 }
 
 func (w *EmbeddingWorker) tick(ctx context.Context) {
 	n, err := w.service.EmbedPendingChunks(ctx, w.batch)
 	if err != nil {
-		slog.Error("embedding worker error", "error", err)
+		logutil.FromCtx(ctx).Error("embedding worker error", "error", err)
 		return
 	}
 	if n > 0 {
-		slog.Info("embedding worker processed chunks", "count", n)
+		logutil.FromCtx(ctx).Info("embedding worker processed chunks", "count", n)
 	}
 }

--- a/internal/document/worker_loop.go
+++ b/internal/document/worker_loop.go
@@ -1,0 +1,114 @@
+package document
+
+import (
+	"context"
+	"runtime/debug"
+	"time"
+
+	"github.com/raphi011/know/internal/event"
+	"github.com/raphi011/know/internal/logutil"
+)
+
+// WorkerLoop encapsulates the common run/restart/tick pattern shared by
+// ProcessingWorker and EmbeddingWorker.
+type WorkerLoop struct {
+	name     string
+	interval time.Duration
+	tick     func(ctx context.Context)
+	notify   <-chan struct{} // optional event-driven wake-up (nil = poll only)
+}
+
+// NewWorkerLoop creates a worker loop that calls tick on each interval.
+// If notify is non-nil, the loop also wakes on signals from that channel.
+func NewWorkerLoop(name string, interval time.Duration, tick func(ctx context.Context), notify <-chan struct{}) *WorkerLoop {
+	return &WorkerLoop{
+		name:     name,
+		interval: interval,
+		tick:     tick,
+		notify:   notify,
+	}
+}
+
+// Run starts the worker loop. It blocks until ctx is cancelled.
+// If the loop panics, it logs the stack trace and restarts after a short delay.
+func (w *WorkerLoop) Run(ctx context.Context) {
+	logutil.FromCtx(ctx).Info(w.name+" started", "interval", w.interval)
+
+	for {
+		stopped := w.runLoop(ctx)
+		if stopped {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			logutil.FromCtx(ctx).Info(w.name + " stopped")
+			return
+		case <-time.After(5 * time.Second):
+			logutil.FromCtx(ctx).Info(w.name + " restarting after panic")
+		}
+	}
+}
+
+func (w *WorkerLoop) runLoop(ctx context.Context) (stopped bool) {
+	defer func() {
+		if p := recover(); p != nil {
+			logutil.FromCtx(ctx).Error(w.name+" panicked",
+				"error", p, "stack", string(debug.Stack()))
+			stopped = false
+		}
+	}()
+
+	// Process any pending work immediately on startup
+	w.tick(ctx)
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			logutil.FromCtx(ctx).Info(w.name + " stopped")
+			return true
+		case <-ticker.C:
+			w.tick(ctx)
+		case <-w.notify:
+			w.tick(ctx)
+		}
+	}
+}
+
+// eventNotify subscribes globally to the bus and returns a coalescing notification
+// channel plus an unsubscribe function. The channel receives a signal whenever an
+// event matching one of the given types is published on any vault.
+// If bus is nil, returns (nil, no-op) — the worker falls back to polling only.
+// The caller must eventually call the returned unsubscribe function (or close the
+// bus) to stop the internal goroutine.
+//
+// Must be called from Run (not from a constructor) to avoid goroutine leaks if
+// the worker is constructed but never started.
+func eventNotify(bus *event.Bus, eventTypes ...string) (<-chan struct{}, func()) {
+	if bus == nil {
+		return nil, func() {}
+	}
+
+	typeSet := make(map[string]struct{}, len(eventTypes))
+	for _, t := range eventTypes {
+		typeSet[t] = struct{}{}
+	}
+
+	events, unsub := bus.SubscribeGlobal()
+	notify := make(chan struct{}, 1)
+
+	go func() {
+		for evt := range events {
+			if _, ok := typeSet[evt.Type]; ok {
+				select {
+				case notify <- struct{}{}:
+				default: // already signaled, coalesce
+				}
+			}
+		}
+	}()
+
+	return notify, unsub
+}

--- a/internal/document/worker_loop_test.go
+++ b/internal/document/worker_loop_test.go
@@ -1,0 +1,90 @@
+package document
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWorkerLoop_ImmediateTick(t *testing.T) {
+	var ticked atomic.Bool
+
+	loop := NewWorkerLoop("test", 10*time.Second, func(ctx context.Context) {
+		ticked.Store(true)
+	}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		loop.Run(ctx)
+		close(done)
+	}()
+
+	// Cancel quickly — well before the 10s interval
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	if !ticked.Load() {
+		t.Fatal("expected tick to run immediately on startup")
+	}
+}
+
+func TestWorkerLoop_PanicRecovery(t *testing.T) {
+	var count atomic.Int32
+
+	loop := NewWorkerLoop("test", 50*time.Millisecond, func(ctx context.Context) {
+		n := count.Add(1)
+		if n == 1 {
+			panic("test panic")
+		}
+	}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		loop.Run(ctx)
+		close(done)
+	}()
+
+	// Wait for restart + at least one more tick
+	time.Sleep(6 * time.Second)
+	cancel()
+	<-done
+
+	if count.Load() < 2 {
+		t.Fatalf("expected at least 2 ticks (panic + recovery), got %d", count.Load())
+	}
+}
+
+func TestWorkerLoop_NotifyWake(t *testing.T) {
+	var ticks atomic.Int32
+	notify := make(chan struct{}, 1)
+
+	loop := NewWorkerLoop("test", 10*time.Second, func(ctx context.Context) {
+		ticks.Add(1)
+	}, notify)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		loop.Run(ctx)
+		close(done)
+	}()
+
+	// Wait for the immediate startup tick
+	time.Sleep(50 * time.Millisecond)
+
+	// Send a notify signal — should trigger another tick without waiting 10s
+	notify <- struct{}{}
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+	<-done
+
+	// Expect at least 2 ticks: immediate startup + notify-triggered
+	if ticks.Load() < 2 {
+		t.Fatalf("expected at least 2 ticks, got %d", ticks.Load())
+	}
+}

--- a/internal/document/worker_test.go
+++ b/internal/document/worker_test.go
@@ -9,7 +9,7 @@ import (
 func TestEmbeddingWorker_StopsOnContextCancel(t *testing.T) {
 	// Use a nil-embedder service — EmbedPendingChunks returns 0 immediately
 	svc := &Service{}
-	worker := NewEmbeddingWorker(svc, 50*time.Millisecond, 10)
+	worker := NewEmbeddingWorker(svc, 50*time.Millisecond, 10, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -33,8 +33,8 @@ func TestEmbeddingWorker_StopsOnContextCancel(t *testing.T) {
 func TestEmbeddingWorker_TicksImmediatelyOnStartup(t *testing.T) {
 	// Verify that the worker processes a tick immediately before entering the ticker loop,
 	// not waiting for the first interval to elapse.
-	svc := &Service{}                                     // nil embedder → EmbedPendingChunks returns (0, nil)
-	worker := NewEmbeddingWorker(svc, 10*time.Second, 10) // very long interval
+	svc := &Service{}                                          // nil embedder → EmbedPendingChunks returns (0, nil)
+	worker := NewEmbeddingWorker(svc, 10*time.Second, 10, nil) // very long interval
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -59,7 +59,7 @@ func TestEmbeddingWorker_TicksImmediatelyOnStartup(t *testing.T) {
 func TestProcessingWorker_StopsOnContextCancel(t *testing.T) {
 	// nil db → tick panics → restart loop catches it → context cancel stops it
 	svc := &Service{}
-	worker := NewProcessingWorker(svc, 50*time.Millisecond, 10)
+	worker := NewProcessingWorker(svc, 50*time.Millisecond, 10, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -82,7 +82,7 @@ func TestProcessingWorker_StopsOnContextCancel(t *testing.T) {
 func TestEmbeddingWorker_RestartsAfterPanic(t *testing.T) {
 	// Create a service that will panic on the first call
 	svc := &Service{}
-	worker := NewEmbeddingWorker(svc, 50*time.Millisecond, 10)
+	worker := NewEmbeddingWorker(svc, 50*time.Millisecond, 10, nil)
 
 	// We test the restart behavior indirectly: runLoop should recover from panics
 	// and Run should continue. Since we can't easily inject a panic through the

--- a/internal/event/bus.go
+++ b/internal/event/bus.go
@@ -23,16 +23,18 @@ type DocumentPayload struct {
 // Bus is an in-process pub/sub event bus that fans out change events
 // to subscribers grouped by vault ID.
 type Bus struct {
-	mu     sync.Mutex
-	subs   map[string]map[uint64]chan ChangeEvent // vaultID → subID → channel
-	next   uint64
-	closed bool
+	mu         sync.Mutex
+	subs       map[string]map[uint64]chan ChangeEvent // vaultID → subID → channel
+	globalSubs map[uint64]chan ChangeEvent            // cross-vault subscribers
+	next       uint64
+	closed     bool
 }
 
 // New creates a new event bus.
 func New() *Bus {
 	return &Bus{
-		subs: make(map[string]map[uint64]chan ChangeEvent),
+		subs:       make(map[string]map[uint64]chan ChangeEvent),
+		globalSubs: make(map[uint64]chan ChangeEvent),
 	}
 }
 
@@ -74,6 +76,41 @@ func (b *Bus) Subscribe(vaultID string) (ch <-chan ChangeEvent, unsubscribe func
 				if len(b.subs[vaultID]) == 0 {
 					delete(b.subs, vaultID)
 				}
+			}
+		})
+	}
+
+	return c, unsubscribe
+}
+
+// SubscribeGlobal registers a subscriber that receives events from all vaults.
+// Same buffering and slow-consumer eviction rules as Subscribe.
+// Returns a closed channel and a no-op unsubscribe if the bus is closed.
+func (b *Bus) SubscribeGlobal() (ch <-chan ChangeEvent, unsubscribe func()) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		c := make(chan ChangeEvent)
+		close(c)
+		return c, func() {}
+	}
+
+	id := b.next
+	b.next++
+
+	c := make(chan ChangeEvent, 64)
+	b.globalSubs[id] = c
+
+	var once sync.Once
+	unsubscribe = func() {
+		once.Do(func() {
+			b.mu.Lock()
+			defer b.mu.Unlock()
+
+			if _, ok := b.globalSubs[id]; ok {
+				close(c)
+				delete(b.globalSubs, id)
 			}
 		})
 	}
@@ -126,7 +163,7 @@ func (b *Bus) SubscribeByPath(vaultID, docPath string) (ch <-chan ChangeEvent, u
 	return filtered, unsubscribe
 }
 
-// Publish fans out the event to all subscribers registered for the event's VaultID.
+// Publish fans out the event to all vault-scoped and global subscribers.
 // If a subscriber's channel buffer is full, the channel is closed and the subscriber
 // is evicted (slow consumer eviction). No-ops if the bus is closed.
 func (b *Bus) Publish(event ChangeEvent) {
@@ -137,27 +174,34 @@ func (b *Bus) Publish(event ChangeEvent) {
 		return
 	}
 
-	vaultSubs, ok := b.subs[event.VaultID]
-	if !ok {
-		return
-	}
-
-	for id, ch := range vaultSubs {
-		select {
-		case ch <- event:
-		default:
-			// Slow consumer: close channel and remove subscription.
-			slog.Warn("evicting slow consumer",
-				"vaultID", event.VaultID,
-				"subID", id,
-			)
-			close(ch)
-			delete(vaultSubs, id)
+	// Fan out to vault-scoped subscribers
+	if vaultSubs, ok := b.subs[event.VaultID]; ok {
+		for id, ch := range vaultSubs {
+			select {
+			case ch <- event:
+			default:
+				slog.Warn("evicting slow consumer",
+					"vaultID", event.VaultID,
+					"subID", id,
+				)
+				close(ch)
+				delete(vaultSubs, id)
+			}
+		}
+		if len(vaultSubs) == 0 {
+			delete(b.subs, event.VaultID)
 		}
 	}
 
-	if len(vaultSubs) == 0 {
-		delete(b.subs, event.VaultID)
+	// Fan out to global subscribers
+	for id, ch := range b.globalSubs {
+		select {
+		case ch <- event:
+		default:
+			slog.Warn("evicting slow global consumer", "subID", id)
+			close(ch)
+			delete(b.globalSubs, id)
+		}
 	}
 }
 
@@ -180,5 +224,10 @@ func (b *Bus) Close() {
 			delete(vaultSubs, id)
 		}
 		delete(b.subs, vaultID)
+	}
+
+	for id, ch := range b.globalSubs {
+		close(ch)
+		delete(b.globalSubs, id)
 	}
 }

--- a/internal/event/bus_test.go
+++ b/internal/event/bus_test.go
@@ -304,6 +304,82 @@ func TestBus_ConcurrentPublish(t *testing.T) {
 	}
 }
 
+func TestBus_SubscribeGlobal(t *testing.T) {
+	bus := New()
+
+	ch, unsub := bus.SubscribeGlobal()
+	defer unsub()
+
+	// Publish to two different vaults
+	bus.Publish(ChangeEvent{
+		Type:    "document.created",
+		VaultID: "vault:a",
+		Payload: DocumentPayload{DocID: "doc:1", Path: "a.md", ContentHash: "x"},
+	})
+	bus.Publish(ChangeEvent{
+		Type:    "document.updated",
+		VaultID: "vault:b",
+		Payload: DocumentPayload{DocID: "doc:2", Path: "b.md", ContentHash: "y"},
+	})
+
+	// Global subscriber should receive both events
+	for _, want := range []string{"vault:a", "vault:b"} {
+		select {
+		case got := <-ch:
+			if got.VaultID != want {
+				t.Errorf("VaultID = %q, want %q", got.VaultID, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for event from %s", want)
+		}
+	}
+}
+
+func TestBus_SubscribeGlobal_Unsubscribe(t *testing.T) {
+	bus := New()
+
+	ch, unsub := bus.SubscribeGlobal()
+	unsub()
+
+	// Channel should be closed
+	_, ok := <-ch
+	if ok {
+		t.Fatal("expected channel to be closed after unsubscribe")
+	}
+
+	// Publish after unsubscribe should not panic
+	bus.Publish(ChangeEvent{
+		Type:    "document.created",
+		VaultID: "vault:a",
+		Payload: DocumentPayload{DocID: "doc:1", Path: "a.md", ContentHash: "x"},
+	})
+
+	// Double unsubscribe is safe
+	unsub()
+}
+
+func TestBus_Close_GlobalSubs(t *testing.T) {
+	bus := New()
+
+	ch, _ := bus.SubscribeGlobal()
+
+	bus.Close()
+
+	// Channel should be closed
+	_, ok := <-ch
+	if ok {
+		t.Error("global subscriber channel should be closed after Close")
+	}
+
+	// SubscribeGlobal after Close returns a closed channel
+	ch2, unsub2 := bus.SubscribeGlobal()
+	defer unsub2()
+	_, ok = <-ch2
+	if ok {
+		t.Error("global subscriber channel should be closed when subscribing to a closed bus")
+	}
+}
+
 func TestBus_Close(t *testing.T) {
 	bus := New()
 

--- a/internal/models/document.go
+++ b/internal/models/document.go
@@ -18,6 +18,7 @@ type Document struct {
 	DocType        *string                `json:"doc_type,omitempty"`
 	ContentHash    *string                `json:"content_hash,omitempty"`
 	Metadata       map[string]any         `json:"metadata,omitempty"`
+	Sections       *string                `json:"sections,omitempty"`
 	Processed      bool                   `json:"processed"`
 	LastAccessedAt *time.Time             `json:"last_accessed_at,omitempty"`
 	AccessCount    int                    `json:"access_count"`
@@ -35,6 +36,7 @@ type DocumentInput struct {
 	Labels      []string       `json:"labels,omitempty"`
 	DocType     *string        `json:"doc_type,omitempty"`
 	Metadata    map[string]any `json:"metadata,omitempty"`
+	Sections    *string        `json:"sections,omitempty"`
 }
 
 // DocumentMeta is a lightweight projection of a document for metadata-only

--- a/internal/parser/markdown.go
+++ b/internal/parser/markdown.go
@@ -2,7 +2,7 @@
 package parser
 
 import (
-	"log/slog"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -37,35 +37,42 @@ type Section struct {
 	CodeBlock bool   // True if section is primarily a code block (treat as atomic)
 }
 
-// ParseMarkdown parses a Markdown document into structured form.
-func ParseMarkdown(content string) (*MarkdownDoc, error) {
-	doc := &MarkdownDoc{
-		Frontmatter: make(map[string]any),
-	}
+// ExtractFrontmatter parses only the YAML frontmatter from markdown content,
+// returning the frontmatter map and the remaining content after the frontmatter
+// block. This is cheaper than ParseMarkdown because it skips goldmark AST parsing.
+// Returns an error if YAML frontmatter is present but malformed.
+func ExtractFrontmatter(content string) (fm map[string]any, remaining string, err error) {
+	fm = make(map[string]any)
+	remaining = content
 
-	// Parse frontmatter if present
-	remaining := content
 	if strings.HasPrefix(content, "---\n") {
 		endIdx := strings.Index(content[4:], "\n---")
 		if endIdx > 0 {
 			frontmatterYAML := content[4 : 4+endIdx]
 			remaining = strings.TrimPrefix(content[4+endIdx+4:], "\n")
 
-			if err := yaml.Unmarshal([]byte(frontmatterYAML), &doc.Frontmatter); err != nil {
-				// Log YAML parse error but continue with empty frontmatter
-				slog.Warn("failed to parse frontmatter YAML", "error", err)
-				doc.Frontmatter = make(map[string]any)
+			if err := yaml.Unmarshal([]byte(frontmatterYAML), &fm); err != nil {
+				return nil, remaining, fmt.Errorf("parse frontmatter YAML: %w", err)
 			}
 		}
 	}
 
-	doc.Content = remaining
+	return fm, remaining, nil
+}
 
-	// Extract title
-	doc.Title = extractTitle(doc.Frontmatter, remaining)
+// ParseMarkdown parses a Markdown document into structured form.
+func ParseMarkdown(content string) (*MarkdownDoc, error) {
+	fm, remaining, err := ExtractFrontmatter(content)
+	if err != nil {
+		return nil, err
+	}
 
-	// Parse sections
-	doc.Sections = parseSections(remaining)
+	doc := &MarkdownDoc{
+		Frontmatter: fm,
+		Content:     remaining,
+		Title:       extractTitle(fm, remaining),
+		Sections:    parseSections(remaining),
+	}
 
 	return doc, nil
 }

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -514,7 +514,7 @@ func (a *App) syncEmbeddingWorker(cfg config.Config, embedder *llm.Embedder) {
 	a.mu.Unlock()
 
 	interval := time.Duration(cfg.EmbedWorkerInterval) * time.Second
-	worker := document.NewEmbeddingWorker(a.documentService, interval, cfg.EmbedWorkerBatch)
+	worker := document.NewEmbeddingWorker(a.documentService, interval, cfg.EmbedWorkerBatch, a.bus)
 	go func() {
 		defer close(done)
 		worker.Run(workerCtx)
@@ -543,7 +543,7 @@ func (a *App) startProcessingWorker() {
 	a.processingWorkerDone = done
 	a.mu.Unlock()
 
-	worker := document.NewProcessingWorker(a.documentService, a.processingWorkerInterval, a.processingWorkerBatch)
+	worker := document.NewProcessingWorker(a.documentService, a.processingWorkerInterval, a.processingWorkerBatch, a.bus)
 	go func() {
 		defer close(done)
 		worker.Run(workerCtx)


### PR DESCRIPTION
Refactor the document ingestion pipeline for better performance, reliability, and observability.

## New Features
- **Batch embedding**: Embeds chunks in batches with automatic fallback to one-at-a-time on provider failure
- **Event-driven workers**: Global event bus subscriptions wake workers immediately on relevant changes instead of waiting for the next poll interval
- **Sections caching**: Stores parsed sections as JSON during Create() to avoid expensive re-parsing in ProcessDocument
- **WorkerLoop abstraction**: Shared run/restart/tick pattern with panic recovery, eliminating duplication between ProcessingWorker and EmbeddingWorker
- **BatchUpdateChunkEmbeddings**: New DB method stores multiple embeddings in a single transaction

## Breaking Changes
- `parser.ExtractFrontmatter` now returns 3 values `(map, string, error)` instead of 2 — callers must handle the error
- `document` table schema adds `sections` field (`option<string>`)

## Code Quality Fixes
- `ExtractFrontmatter` returns errors instead of silently swallowing malformed YAML
- Moved `eventNotify` goroutine from constructors to `Run()` to prevent goroutine leaks
- Migrated bare `slog` calls to `logutil.FromCtx(ctx)` for request-scoped logging context
- `rescheduleChunk` accepts caller's logger to preserve request-scoped fields
- Moved `logOp` after empty-slice guard in `BatchUpdateChunkEmbeddings` to avoid metric inflation
- Extracted `storeEmbeddings` helper to deduplicate batch-store fallback logic
- Removed trivial `notifyCh()` passthrough method

🤖 Generated with [Claude Code](https://claude.com/claude-code)