### PR TITLE
feat: add Obsidian-style quick picker for iOS/macOS

### DIFF
--- a/docs/superpowers/specs/2026-03-15-quick-picker-design.md
+++ b/docs/superpowers/specs/2026-03-15-quick-picker-design.md
@@ -1,0 +1,68 @@
+# Quick Picker — Obsidian-Style File Finder
+
+## Problem
+
+Navigating to a document requires either browsing the sidebar tree or typing a full-text search query. Neither is fast for "I know roughly what it's called" — the most common navigation pattern.
+
+## Solution
+
+An Obsidian-style quick picker: a modal overlay triggered by `Cmd+O` that fuzzy-matches document paths from the local SwiftData cache. Instant, works offline.
+
+## Requirements
+
+- **Trigger**: `Cmd+O` (macOS), toolbar button (iOS)
+- **Matching**: Client-side fuzzy match on document paths
+- **Initial state**: Show recently accessed documents
+- **Select**: Navigate to document
+- **Create**: Allow creating new document at typed path when no exact match
+- **iOS**: Full-screen sheet
+- **macOS**: Sheet (~600x400)
+
+## Architecture
+
+### Data Flow
+
+```
+User types query
+    ↓
+FuzzyMatch against [CachedDocument] from SwiftData
+    ↓
+Ranked results with matched character indices
+    ↓
+QuickPickerView renders highlighted rows
+    ↓
+User selects → selectedDocumentId set → sheet dismissed
+```
+
+### Components
+
+1. **FuzzyMatch** — pure function, scored character-order matching
+2. **RecentDocument** — SwiftData model tracking last 50 accessed docs
+3. **QuickPickerViewModel** — @Observable, holds query/results/selection state
+4. **QuickPickerView** — search field + results list + keyboard hints
+5. **QuickPickerRow** — path with fuzzy highlight + metadata badges
+
+### Fuzzy Matching Scoring
+
+- Characters must appear in order (not contiguous)
+- +consecutive bonus for adjacent matches
+- +boundary bonus for matches after `/`, `-`, `_`, space
+- +start bonus for matches at beginning of path segments
+- Case-insensitive
+- Returns nil for no match
+
+### Platform Behavior
+
+| Aspect | macOS | iOS |
+|--------|-------|-----|
+| Trigger | Cmd+O | Toolbar button |
+| Presentation | .sheet (600x400) | .sheet (full screen) |
+| Navigation | Arrow keys + Enter | Tap |
+| Create | Shift+Enter | "Create" row tap |
+| Dismiss | Esc | Swipe down / X button |
+
+### Integration Points
+
+- `MainSplitView`: adds sheet, keyboard shortcut, recents tracking
+- `KnowApp`: registers `RecentDocument` in ModelContainer
+- `KnowService`: adds `createDocument(vaultId:path:)` method

--- a/ios/KnowApp.swift
+++ b/ios/KnowApp.swift
@@ -13,7 +13,7 @@ struct KnowApp: App {
 
     init() {
         do {
-            modelContainer = try ModelContainer(for: CachedDocument.self, SyncState.self)
+            modelContainer = try ModelContainer(for: CachedDocument.self, SyncState.self, RecentDocument.self)
         } catch {
             fatalError("Failed to create ModelContainer: \(error)")
         }

--- a/ios/Models/RecentDocument.swift
+++ b/ios/Models/RecentDocument.swift
@@ -1,0 +1,74 @@
+import Foundation
+import OSLog
+import SwiftData
+
+private let logger = Logger(subsystem: "Know", category: "RecentDocument")
+
+@Model
+final class RecentDocument {
+    static let maxEntries = 50
+
+    @Attribute(.unique) var compositeId: String
+    var vaultId: String
+    var path: String
+    var title: String
+    var accessedAt: Date
+
+    init(vaultId: String, path: String, title: String, accessedAt: Date = .now) {
+        self.compositeId = Self.compositeId(vaultId: vaultId, path: path)
+        self.vaultId = vaultId
+        self.path = path
+        self.title = title
+        self.accessedAt = accessedAt
+    }
+
+    static func compositeId(vaultId: String, path: String) -> String {
+        "\(vaultId):\(path)"
+    }
+
+    /// Records a document access, creating or updating the recent entry and pruning old entries.
+    @MainActor
+    static func recordAccess(
+        vaultId: String,
+        path: String,
+        title: String,
+        modelContext: ModelContext
+    ) {
+        let id = compositeId(vaultId: vaultId, path: path)
+
+        let predicate = #Predicate<RecentDocument> { $0.compositeId == id }
+        let descriptor = FetchDescriptor(predicate: predicate)
+
+        do {
+            if let existing = try modelContext.fetch(descriptor).first {
+                existing.accessedAt = .now
+                existing.title = title
+            } else {
+                let entry = RecentDocument(
+                    vaultId: vaultId,
+                    path: path,
+                    title: title
+                )
+                modelContext.insert(entry)
+            }
+        } catch {
+            logger.error("Failed to record access for \(path): \(error)")
+            return
+        }
+
+        // Prune beyond maxEntries
+        let allDescriptor = FetchDescriptor<RecentDocument>(
+            sortBy: [SortDescriptor(\.accessedAt, order: .reverse)]
+        )
+        do {
+            let all = try modelContext.fetch(allDescriptor)
+            if all.count > maxEntries {
+                for entry in all.dropFirst(maxEntries) {
+                    modelContext.delete(entry)
+                }
+            }
+        } catch {
+            logger.error("Failed to prune recent documents: \(error)")
+        }
+    }
+}

--- a/ios/Services/KnowService.swift
+++ b/ios/Services/KnowService.swift
@@ -35,6 +35,18 @@ final class KnowService: Sendable {
 		return try await client.get(path: "api/ls", query: query)
 	}
 
+	func createDocument(vaultId: String, path: String, content: String = "") async throws -> Document {
+		struct Body: Encodable {
+			let vaultId: String
+			let path: String
+			let content: String
+		}
+		return try await client.post(
+			path: "api/documents",
+			body: Body(vaultId: vaultId, path: path, content: content)
+		)
+	}
+
 	func search(vaultId: String, query: String, labels: [String]? = nil, limit: Int? = nil) async throws -> [SearchResult] {
 		var params = ["vault": vaultId, "query": query]
 		if let labels, !labels.isEmpty {

--- a/ios/Tests/FuzzyMatchTests.swift
+++ b/ios/Tests/FuzzyMatchTests.swift
@@ -1,0 +1,104 @@
+import Testing
+@testable import Know
+
+@Test func matchesExactSubstring() {
+    let result = fuzzyMatch(query: "config", target: "/app/config.md")
+    #expect(result != nil)
+    #expect(result!.matchedIndices.count == 6)
+}
+
+@Test func matchesFuzzyCharacters() {
+    let result = fuzzyMatch(query: "acd", target: "abcdef")
+    #expect(result != nil)
+    #expect(result!.matchedIndices == [0, 2, 3])
+}
+
+@Test func returnsNilForNoMatch() {
+    let result = fuzzyMatch(query: "xyz", target: "abcdef")
+    #expect(result == nil)
+}
+
+@Test func emptyQueryReturnsNil() {
+    let result = fuzzyMatch(query: "", target: "anything")
+    #expect(result == nil)
+}
+
+@Test func caseInsensitive() {
+    let result = fuzzyMatch(query: "ABC", target: "aXbXc")
+    #expect(result != nil)
+}
+
+@Test func boundaryMatchScoresHigher() {
+    guard let pathResult = fuzzyMatch(query: "conf", target: "/app/config.md"),
+          let midResult = fuzzyMatch(query: "conf", target: "/appXconfigX.md") else {
+        Issue.record("Expected non-nil results")
+        return
+    }
+    #expect(pathResult.score > midResult.score)
+}
+
+@Test func consecutiveMatchScoresHigher() {
+    guard let consecutive = fuzzyMatch(query: "abc", target: "abcdef"),
+          let scattered = fuzzyMatch(query: "abc", target: "aXXbXXc") else {
+        Issue.record("Expected non-nil results")
+        return
+    }
+    #expect(consecutive.score > scattered.score)
+}
+
+@Test func queryLongerThanTargetReturnsNil() {
+    let result = fuzzyMatch(query: "longquery", target: "short")
+    #expect(result == nil)
+}
+
+@Test func matchesPathSegments() {
+    let result = fuzzyMatch(query: "nai", target: "/Notes/AI/doc.md")
+    #expect(result != nil)
+}
+
+@Test func prefersShorterPaths() {
+    guard let short = fuzzyMatch(query: "doc", target: "/doc.md"),
+          let long = fuzzyMatch(query: "doc", target: "/very/deeply/nested/path/to/doc.md") else {
+        Issue.record("Expected non-nil results")
+        return
+    }
+    #expect(short.score > long.score)
+}
+
+@Test func camelCaseBoundaryScoresHigher() {
+    guard let camelResult = fuzzyMatch(query: "gv", target: "getVault"),
+          let midResult = fuzzyMatch(query: "gv", target: "groovy") else {
+        Issue.record("Expected non-nil results")
+        return
+    }
+    #expect(camelResult.score > midResult.score)
+}
+
+@Test func separatorBoundaryBonus() {
+    // All separators should give a boundary bonus
+    for separator in ["/", "-", "_", " ", "."] {
+        let target = "x\(separator)abc"
+        guard let result = fuzzyMatch(query: "a", target: target) else {
+            Issue.record("Expected match for separator '\(separator)'")
+            continue
+        }
+        // Match after separator should score higher than mid-word
+        guard let midResult = fuzzyMatch(query: "a", target: "xzabc") else {
+            Issue.record("Expected match for mid-word")
+            continue
+        }
+        #expect(result.score > midResult.score, "Separator '\(separator)' should give bonus")
+    }
+}
+
+@Test func singleCharacterQuery() {
+    let result = fuzzyMatch(query: "a", target: "abc")
+    #expect(result != nil)
+    #expect(result!.matchedIndices == [0])
+}
+
+@Test func exactLengthMatch() {
+    let result = fuzzyMatch(query: "abc", target: "abc")
+    #expect(result != nil)
+    #expect(result!.matchedIndices == [0, 1, 2])
+}

--- a/ios/Utilities/FuzzyMatch.swift
+++ b/ios/Utilities/FuzzyMatch.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+struct FuzzyMatchResult {
+    let score: Int
+    let matchedIndices: [Int]
+}
+
+/// Performs fuzzy matching of a query against a target string.
+///
+/// Characters must appear in order but not contiguously. Scores higher for
+/// consecutive matches, word-boundary matches, and path-segment-start matches.
+func fuzzyMatch(query: String, target: String) -> FuzzyMatchResult? {
+    guard !query.isEmpty else { return nil }
+
+    let queryChars = Array(query.lowercased())
+    let targetChars = Array(target.lowercased())
+    let originalChars = Array(target)
+
+    guard queryChars.count <= targetChars.count else { return nil }
+
+    var matchedIndices: [Int] = []
+    var score = 0
+    var queryIndex = 0
+    var previousMatchIndex = -2 // sentinel for "no previous match"
+
+    for targetIndex in targetChars.indices {
+        guard queryIndex < queryChars.count else { break }
+
+        if targetChars[targetIndex] == queryChars[queryIndex] {
+            matchedIndices.append(targetIndex)
+
+            // Consecutive match bonus
+            if targetIndex == previousMatchIndex + 1 {
+                score += 8
+            }
+
+            // Boundary bonus: match right after a separator
+            if targetIndex == 0 {
+                score += 10
+            } else {
+                let prev = originalChars[targetIndex - 1]
+                if prev == "/" || prev == "-" || prev == "_" || prev == " " || prev == "." {
+                    score += 8
+                }
+                // CamelCase boundary
+                if prev.isLowercase && originalChars[targetIndex].isUppercase {
+                    score += 6
+                }
+            }
+
+            // Base score for any match
+            score += 1
+
+            previousMatchIndex = targetIndex
+            queryIndex += 1
+        }
+    }
+
+    // All query characters must be matched
+    guard queryIndex == queryChars.count else { return nil }
+
+    // Penalty for longer targets (prefer shorter paths)
+    score -= targetChars.count / 10
+
+    return FuzzyMatchResult(score: score, matchedIndices: matchedIndices)
+}

--- a/ios/ViewModels/QuickPickerViewModel.swift
+++ b/ios/ViewModels/QuickPickerViewModel.swift
@@ -1,0 +1,131 @@
+import Foundation
+import OSLog
+import SwiftData
+
+private let logger = Logger(subsystem: "Know", category: "QuickPicker")
+
+struct QuickPickerItem: Identifiable {
+    let path: String
+    let title: String
+    let labels: [String]
+    let docType: String?
+    let score: Int
+    let matchedIndices: [Int]
+    let isRecent: Bool
+
+    var id: String { path }
+}
+
+@MainActor
+@Observable
+final class QuickPickerViewModel {
+    var query = "" {
+        didSet { updateResults() }
+    }
+    private(set) var results: [QuickPickerItem] = []
+    private(set) var selectedIndex = 0
+    private(set) var loadError: String?
+
+    private var allDocuments: [CachedDocument] = []
+    private var recentDocuments: [RecentDocument] = []
+
+    private var normalizedQuery: String? {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed.hasPrefix("/") ? trimmed : "/\(trimmed)"
+    }
+
+    var canCreate: Bool {
+        guard let path = normalizedQuery else { return false }
+        let withMd = path.hasSuffix(".md") ? path : "\(path).md"
+        return !allDocuments.contains { $0.path == path || $0.path == withMd }
+    }
+
+    var createPath: String {
+        guard let path = normalizedQuery else { return "" }
+        return path.hasSuffix(".md") ? path : "\(path).md"
+    }
+
+    func load(vaultId: String, modelContext: ModelContext) {
+        loadError = nil
+
+        let docPredicate = #Predicate<CachedDocument> { $0.vaultId == vaultId }
+        let docDescriptor = FetchDescriptor(
+            predicate: docPredicate,
+            sortBy: [SortDescriptor(\.path)]
+        )
+
+        let recentPredicate = #Predicate<RecentDocument> { $0.vaultId == vaultId }
+        let recentDescriptor = FetchDescriptor(
+            predicate: recentPredicate,
+            sortBy: [SortDescriptor(\.accessedAt, order: .reverse)]
+        )
+
+        do {
+            allDocuments = try modelContext.fetch(docDescriptor)
+            recentDocuments = try modelContext.fetch(recentDescriptor)
+        } catch {
+            logger.warning("Failed to load documents: \(error)")
+            loadError = error.localizedDescription
+            allDocuments = []
+            recentDocuments = []
+        }
+        updateResults()
+    }
+
+    func moveSelection(by offset: Int) {
+        let maxIndex = results.count + (canCreate ? 1 : 0) - 1
+        guard maxIndex >= 0 else { return }
+        selectedIndex = min(max(selectedIndex + offset, 0), maxIndex)
+    }
+
+    func selectedItem() -> QuickPickerItem? {
+        guard selectedIndex >= 0 && selectedIndex < results.count else { return nil }
+        return results[selectedIndex]
+    }
+
+    var isCreateSelected: Bool {
+        canCreate && selectedIndex == results.count
+    }
+
+    private func updateResults() {
+        selectedIndex = 0
+
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            // Show recents, filtered to documents that still exist
+            let docPaths = Set(allDocuments.map(\.path))
+            results = recentDocuments.compactMap { recent in
+                guard docPaths.contains(recent.path) else { return nil }
+                return QuickPickerItem(
+                    path: recent.path,
+                    title: recent.title,
+                    labels: [],
+                    docType: nil,
+                    score: 0,
+                    matchedIndices: [],
+                    isRecent: true
+                )
+            }
+            return
+        }
+
+        results = allDocuments.compactMap { doc in
+            guard let match = fuzzyMatch(query: trimmed, target: doc.path) else {
+                return nil
+            }
+            return QuickPickerItem(
+                path: doc.path,
+                title: doc.title,
+                labels: doc.labels,
+                docType: doc.docType,
+                score: match.score,
+                matchedIndices: match.matchedIndices,
+                isRecent: false
+            )
+        }
+        .sorted { $0.score > $1.score }
+        .prefix(50)
+        .map { $0 }
+    }
+}

--- a/ios/Views/MainSplitView.swift
+++ b/ios/Views/MainSplitView.swift
@@ -16,6 +16,9 @@ struct MainSplitView: View {
 	@State private var vaultLoadError: String?
 	@State private var columnVisibility = NavigationSplitViewVisibility.automatic
 
+	// Quick picker
+	@State private var showQuickPicker = false
+
 	// Search state
 	@State private var searchQuery = ""
 	@State private var isSearchPresented = false
@@ -68,6 +71,43 @@ struct MainSplitView: View {
 			} else if case .error(let message) = syncEngine.status {
 				SyncErrorBanner(message: message)
 			}
+		}
+		.sheet(isPresented: $showQuickPicker) {
+			if let vaultId = vaults.first?.id {
+				QuickPickerView(
+					vaultId: vaultId,
+					service: service,
+					onSelect: { path in
+						selectedDocumentId = path
+						showQuickPicker = false
+					},
+					onDismiss: {
+						showQuickPicker = false
+					}
+				)
+			} else {
+				ContentUnavailableView("No Vault", systemImage: "tray")
+			}
+		}
+		.toolbar {
+			ToolbarItem(placement: .automatic) {
+				Button {
+					showQuickPicker = true
+				} label: {
+					Image(systemName: "magnifyingglass")
+				}
+				.keyboardShortcut("o", modifiers: .command)
+			}
+		}
+		.onChange(of: selectedDocumentId) { _, newId in
+			guard let newId, let vaultId = vaults.first?.id else { return }
+			let title = CachedDocument.titleFromPath(newId)
+			RecentDocument.recordAccess(
+				vaultId: vaultId,
+				path: newId,
+				title: title,
+				modelContext: modelContext
+			)
 		}
 	}
 
@@ -216,6 +256,7 @@ private struct SidebarVaultSection: View {
 	@Environment(\.modelContext) private var modelContext
 	@Query private var allDocuments: [CachedDocument]
 	@Query private var syncStates: [SyncState]
+	@State private var expandedFolders: Set<String> = []
 
 	init(
 		service: KnowService,
@@ -247,7 +288,8 @@ private struct SidebarVaultSection: View {
 			} else {
 				SidebarFolderTree(
 					documents: allDocuments,
-					folder: "/"
+					folder: "/",
+					expandedFolders: $expandedFolders
 				)
 			}
 		}
@@ -263,6 +305,7 @@ private struct SidebarVaultSection: View {
 private struct SidebarFolderTree: View {
 	let documents: [CachedDocument]
 	let folder: String
+	@Binding var expandedFolders: Set<String>
 
 	private var documentsInFolder: [CachedDocument] {
 		documents.filter { parentFolder(of: $0.path) == folder }
@@ -289,10 +332,11 @@ private struct SidebarFolderTree: View {
 
 	var body: some View {
 		ForEach(subfolders, id: \.path) { subfolder in
-			DisclosureGroup {
+			DisclosureGroup(isExpanded: binding(for: subfolder.path)) {
 				SidebarFolderTree(
 					documents: documents,
-					folder: subfolder.path
+					folder: subfolder.path,
+					expandedFolders: $expandedFolders
 				)
 			} label: {
 				Label(subfolder.name, systemImage: "folder")
@@ -304,6 +348,19 @@ private struct SidebarFolderTree: View {
 				.tag(doc.path)
 				.lineLimit(1)
 		}
+	}
+
+	private func binding(for path: String) -> Binding<Bool> {
+		Binding(
+			get: { expandedFolders.contains(path) },
+			set: { isExpanded in
+				if isExpanded {
+					expandedFolders.insert(path)
+				} else {
+					expandedFolders.remove(path)
+				}
+			}
+		)
 	}
 
 	private func parentFolder(of path: String) -> String {

--- a/ios/Views/QuickPickerRow.swift
+++ b/ios/Views/QuickPickerRow.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct QuickPickerRow: View {
+    let item: QuickPickerItem
+    let isSelected: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            highlightedPath
+                .font(.body)
+                .lineLimit(1)
+
+            if item.title != filename {
+                Text(item.title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            if !item.labels.isEmpty || item.docType != nil {
+                HStack(spacing: 6) {
+                    if let docType = item.docType {
+                        Text(docType)
+                            .font(.caption2)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(.fill.tertiary)
+                            .clipShape(Capsule())
+                    }
+                    if !item.labels.isEmpty {
+                        Text(item.labels.joined(separator: ", "))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(isSelected ? Color.accentColor.opacity(0.15) : .clear)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private var filename: String {
+        let name = item.path.components(separatedBy: "/").last ?? item.path
+        if name.hasSuffix(".md") {
+            return String(name.dropLast(3))
+        }
+        return name
+    }
+
+    private var highlightedPath: Text {
+        if item.isRecent || item.matchedIndices.isEmpty {
+            return Text(item.path)
+        }
+
+        let chars = Array(item.path)
+        let matchedSet = Set(item.matchedIndices)
+        var result = Text("")
+
+        for (index, char) in chars.enumerated() {
+            let segment = Text(String(char))
+            if matchedSet.contains(index) {
+                result = result + segment.bold().foregroundColor(.accentColor)
+            } else {
+                result = result + segment
+            }
+        }
+
+        return result
+    }
+}

--- a/ios/Views/QuickPickerView.swift
+++ b/ios/Views/QuickPickerView.swift
@@ -1,0 +1,231 @@
+import SwiftData
+import SwiftUI
+
+struct QuickPickerView: View {
+    let vaultId: String
+    let service: KnowService
+    let onSelect: (String) -> Void
+    let onDismiss: () -> Void
+
+    @Environment(\.modelContext) private var modelContext
+    @State private var viewModel = QuickPickerViewModel()
+    @FocusState private var isSearchFocused: Bool
+    @State private var createError: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            searchField
+            Divider()
+            resultsList
+            #if os(macOS)
+            keyboardHints
+            #endif
+        }
+        #if os(macOS)
+        .frame(width: 600, height: 400)
+        #endif
+        .onAppear {
+            viewModel.load(vaultId: vaultId, modelContext: modelContext)
+            isSearchFocused = true
+        }
+        .overlay {
+            if let error = viewModel.loadError {
+                ContentUnavailableView {
+                    Label("Error", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(error)
+                }
+            }
+        }
+    }
+
+    // MARK: - Search Field
+
+    private var searchField: some View {
+        HStack {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("Find or create a note...", text: $viewModel.query)
+                .textFieldStyle(.plain)
+                .focused($isSearchFocused)
+                #if os(macOS)
+                .onKeyPress(.upArrow) {
+                    viewModel.moveSelection(by: -1)
+                    return .handled
+                }
+                .onKeyPress(.downArrow) {
+                    viewModel.moveSelection(by: 1)
+                    return .handled
+                }
+                .onKeyPress(.return) {
+                    if NSEvent.modifierFlags.contains(.shift) {
+                        handleCreate()
+                    } else {
+                        handleSelect()
+                    }
+                    return .handled
+                }
+                .onKeyPress(.escape) {
+                    onDismiss()
+                    return .handled
+                }
+                #endif
+            if !viewModel.query.isEmpty {
+                Button {
+                    viewModel.query = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: - Results
+
+    private var resultsList: some View {
+        ScrollViewReader { proxy in
+            List {
+                ForEach(Array(viewModel.results.enumerated()), id: \.element.id) { index, item in
+                    Button {
+                        selectItem(item)
+                    } label: {
+                        QuickPickerRow(
+                            item: item,
+                            isSelected: index == viewModel.selectedIndex
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .id(item.id)
+                    .listRowInsets(EdgeInsets(top: 2, leading: 8, bottom: 2, trailing: 8))
+                }
+
+                if viewModel.canCreate {
+                    Button {
+                        handleCreate()
+                    } label: {
+                        createRow
+                    }
+                    .buttonStyle(.plain)
+                    .id("__create__")
+                    .listRowInsets(EdgeInsets(top: 2, leading: 8, bottom: 2, trailing: 8))
+                }
+
+                if let createError {
+                    Text(createError)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .listRowInsets(EdgeInsets(top: 2, leading: 16, bottom: 2, trailing: 8))
+                }
+            }
+            .listStyle(.plain)
+            .onChange(of: viewModel.selectedIndex) { _, newIndex in
+                if newIndex < viewModel.results.count {
+                    proxy.scrollTo(viewModel.results[newIndex].id, anchor: .center)
+                } else if viewModel.canCreate {
+                    proxy.scrollTo("__create__", anchor: .center)
+                }
+            }
+        }
+    }
+
+    private var createRow: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "plus.circle")
+                .foregroundStyle(Color.accentColor)
+            Text("Create ")
+                .foregroundStyle(.secondary)
+            + Text(viewModel.createPath)
+                .foregroundStyle(Color.accentColor)
+                .bold()
+
+            Spacer()
+
+            #if os(macOS)
+            Text("shift ↵")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(.fill.quaternary)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+            #endif
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 8)
+        .background(viewModel.isCreateSelected ? Color.accentColor.opacity(0.15) : .clear)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    // MARK: - Keyboard Hints (macOS)
+
+    #if os(macOS)
+    private var keyboardHints: some View {
+        HStack(spacing: 16) {
+            hintLabel("↑↓", "navigate")
+            hintLabel("↵", "open")
+            hintLabel("shift ↵", "create")
+            hintLabel("esc", "dismiss")
+        }
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity)
+        .background(.bar)
+    }
+
+    private func hintLabel(_ key: String, _ action: String) -> some View {
+        HStack(spacing: 4) {
+            Text(key)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(.fill.quaternary)
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+            Text(action)
+        }
+    }
+    #endif
+
+    // MARK: - Actions
+
+    private func selectItem(_ item: QuickPickerItem) {
+        onSelect(item.path)
+    }
+
+    private func handleSelect() {
+        if viewModel.isCreateSelected {
+            handleCreate()
+        } else if let item = viewModel.selectedItem() {
+            selectItem(item)
+        }
+    }
+
+    private func handleCreate() {
+        guard viewModel.canCreate else { return }
+        let path = viewModel.createPath
+        createError = nil
+
+        Task {
+            do {
+                let doc = try await service.createDocument(vaultId: vaultId, path: path)
+                selectItem(QuickPickerItem(
+                    path: doc.path,
+                    title: doc.title,
+                    labels: [],
+                    docType: nil,
+                    score: 0,
+                    matchedIndices: [],
+                    isRecent: false
+                ))
+            } catch is CancellationError {
+                return
+            } catch {
+                createError = error.localizedDescription
+            }
+        }
+    }
+}

--- a/justfile
+++ b/justfile
@@ -145,3 +145,12 @@ ios-run: ios-build
     xcrun simctl boot {{ios_simulator_id}} 2>/dev/null || true
     xcrun simctl install {{ios_simulator_id}} {{ios_build_dir}}/Build/Products/Debug-iphonesimulator/Know.app
     xcrun simctl launch --console-pty {{ios_simulator_id}} com.know.ios
+
+# Build and run macOS app
+mac: ios-generate
+    xcodebuild -project {{ios_project}} -scheme {{ios_scheme}} \
+        -destination 'platform=macOS' \
+        -derivedDataPath {{ios_build_dir}} build \
+        CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
+        CODE_SIGN_ENTITLEMENTS=""
+    open {{ios_build_dir}}/Build/Products/Debug/Know.app


### PR DESCRIPTION
Adds an Obsidian-style quick picker (Cmd+O) that fuzzy-matches document paths from the local SwiftData cache for instant, offline-capable navigation. Shows recently accessed documents when the query is empty, and supports creating new notes inline.

## New Features
- **Quick Picker** — fuzzy file finder triggered by Cmd+O (macOS) or toolbar button (iOS)
- **Recent Documents** — SwiftData model tracking last 50 accessed documents, shown as default results
- **Fuzzy Matching** — scored character-order matching with bonuses for consecutive, boundary, and camelCase matches
- **Inline Create** — Shift+Enter creates a new document at the typed path when no exact match exists
- **macOS build target** — `just mac` builds and runs the macOS Catalyst app

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)