### PR TITLE
feat: extract and store external URLs from markdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,8 @@ The server exposes a REST API at `/api/` for CLI and TUI communication:
 - `GET /api/config` — server configuration
 - `GET /api/tasks?vault={id}&status=open&labels=work&due_before=2026-03-20&folder=/daily/` — list tasks
 - `POST /api/tasks/{id}/toggle` — toggle task status (modifies source document)
+- `GET /api/external-links/stats?vault={id}` — aggregated external link counts by hostname
+- `GET /api/external-links?vault={id}&hostname=...&limit=...&offset=...` — list external links
 
 Agent endpoints (background execution):
 - `POST /agent/chat` — start agent, returns 202 `{conversationId, status}`

--- a/docs/feature-ingestion.md
+++ b/docs/feature-ingestion.md
@@ -10,9 +10,9 @@ When a document is ingested via `know cp` or the WebDAV interface, it passes thr
 
 ### Pipeline Stages
 
-1. **Parse** -- Extract frontmatter metadata (title, labels, summary, relations) and markdown content. Wiki-links in the body are also detected during this phase.
+1. **Parse** -- Extract frontmatter metadata (title, labels, summary, relations) and markdown content. Wiki-links and external URLs in the body are also detected during this phase.
 2. **Embed** -- Generate vector embeddings for the document content using the configured embedding model.
-3. **Link** -- Resolve `relates_to` entries from frontmatter and wiki-links in the body. Relations are stored as SurrealDB graph edges with a unique constraint on `(from, to, rel_type)`. Frontmatter relations are created automatically; wiki-link resolution uses exact path match first, then title match (shortest path wins).
+3. **Link** -- Resolve `relates_to` entries from frontmatter and wiki-links in the body. Relations are stored as SurrealDB graph edges with a unique constraint on `(from, to, rel_type)`. Frontmatter relations are created automatically; wiki-link resolution uses exact path match first, then title match (shortest path wins). External URLs (both `[text](url)` markdown links and bare autolinked URLs) are stored in the `external_link` table with hostname, URL path, and source file reference.
 4. **Chunk** -- Split the document into heading-based chunks for retrieval. Each heading section becomes its own chunk. Large sections exceeding the max size are split at paragraph boundaries. Empty sections are skipped.
 
 ### Chunking Strategy

--- a/helm/know/Chart.yaml
+++ b/helm/know/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: know
 description: Know - Personal Knowledge RAG Database with REST API and WebDAV
 type: application
-version: 0.7.0
-appVersion: "0.7.0"
+version: 0.8.0
+appVersion: "0.8.0"
 keywords:
   - know
   - knowledge-graph

--- a/internal/api/external_links.go
+++ b/internal/api/external_links.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/db"
+	"github.com/raphi011/know/internal/logutil"
+	"github.com/raphi011/know/internal/models"
+)
+
+func (s *Server) externalLinkStats(w http.ResponseWriter, r *http.Request) {
+	vaultID := r.URL.Query().Get("vault")
+	if vaultID == "" {
+		writeError(w, http.StatusBadRequest, "vault query parameter required")
+		return
+	}
+
+	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	stats, err := s.app.DBClient().GetExternalLinkStats(r.Context(), vaultID)
+	if err != nil {
+		logutil.FromCtx(r.Context()).Error("get external link stats", "vault_id", vaultID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get external link stats")
+		return
+	}
+
+	if stats == nil {
+		stats = []db.ExternalLinkHostStats{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"stats": stats})
+}
+
+func (s *Server) listExternalLinks(w http.ResponseWriter, r *http.Request) {
+	vaultID := r.URL.Query().Get("vault")
+	if vaultID == "" {
+		writeError(w, http.StatusBadRequest, "vault query parameter required")
+		return
+	}
+
+	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	filter := db.ExternalLinkFilter{
+		VaultID: vaultID,
+	}
+
+	if h := r.URL.Query().Get("hostname"); h != "" {
+		filter.Hostname = &h
+	}
+	if f := r.URL.Query().Get("file"); f != "" {
+		filter.FileID = &f
+	}
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if v, err := strconv.Atoi(l); err == nil && v > 0 {
+			filter.Limit = v
+		}
+	}
+	if o := r.URL.Query().Get("offset"); o != "" {
+		if v, err := strconv.Atoi(o); err == nil && v >= 0 {
+			filter.Offset = v
+		}
+	}
+
+	logger := logutil.FromCtx(r.Context())
+
+	links, err := s.app.DBClient().ListExternalLinks(r.Context(), filter)
+	if err != nil {
+		logger.Error("list external links", "vault_id", vaultID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list external links")
+		return
+	}
+
+	total, err := s.app.DBClient().CountExternalLinks(r.Context(), filter)
+	if err != nil {
+		logger.Error("count external links", "vault_id", vaultID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to count external links")
+		return
+	}
+
+	if links == nil {
+		links = []models.ExternalLink{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"links": links,
+		"total": total,
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -74,6 +74,10 @@ func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Han
 	mux.Handle("POST /api/remotes", authMw(http.HandlerFunc(s.addRemote)))
 	mux.Handle("DELETE /api/remotes/{name}", authMw(http.HandlerFunc(s.removeRemote)))
 
+	// External links
+	mux.Handle("GET /api/external-links/stats", authMw(http.HandlerFunc(s.externalLinkStats)))
+	mux.Handle("GET /api/external-links", authMw(http.HandlerFunc(s.listExternalLinks)))
+
 	// Export
 	mux.Handle("GET /api/export", authMw(http.HandlerFunc(s.export)))
 

--- a/internal/db/queries_external_link.go
+++ b/internal/db/queries_external_link.go
@@ -1,0 +1,161 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/raphi011/know/internal/models"
+	"github.com/surrealdb/surrealdb.go"
+)
+
+// ExternalLinkInput represents input for creating an external link.
+type ExternalLinkInput struct {
+	Hostname string
+	URLPath  string
+	FullURL  string
+	LinkText *string
+}
+
+// ExternalLinkHostStats holds aggregated link counts by hostname.
+type ExternalLinkHostStats struct {
+	Hostname string `json:"hostname"`
+	Count    int    `json:"count"`
+}
+
+// ExternalLinkFilter controls the external link list query.
+type ExternalLinkFilter struct {
+	VaultID  string
+	Hostname *string
+	FileID   *string
+	Limit    int
+	Offset   int
+}
+
+// CreateExternalLinks batch-inserts external links for a file.
+func (c *Client) CreateExternalLinks(ctx context.Context, fromFileID, vaultID string, links []ExternalLinkInput) error {
+	defer c.logOp(ctx, "external_link.create", time.Now())
+	if len(links) == 0 {
+		return nil
+	}
+
+	fromFile := newRecordID("file", bareID("file", fromFileID))
+	vault := newRecordID("vault", bareID("vault", vaultID))
+
+	rows := make([]map[string]any, len(links))
+	for i, link := range links {
+		rows[i] = map[string]any{
+			"from_file": fromFile,
+			"vault":     vault,
+			"hostname":  link.Hostname,
+			"url_path":  link.URLPath,
+			"full_url":  link.FullURL,
+			"link_text": optionalString(link.LinkText),
+		}
+	}
+
+	sql := `INSERT INTO external_link $links RETURN NONE`
+	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
+		"links": rows,
+	}); err != nil {
+		return fmt.Errorf("create external links: %w", err)
+	}
+	return nil
+}
+
+// DeleteExternalLinksByFile removes all external links originating from a file.
+func (c *Client) DeleteExternalLinksByFile(ctx context.Context, fromFileID string) error {
+	defer c.logOp(ctx, "external_link.delete", time.Now())
+	sql := `DELETE FROM external_link WHERE from_file = type::record("file", $file_id)`
+	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
+		"file_id": bareID("file", fromFileID),
+	}); err != nil {
+		return fmt.Errorf("delete external links: %w", err)
+	}
+	return nil
+}
+
+// GetExternalLinkStats returns link counts grouped by hostname for a vault.
+func (c *Client) GetExternalLinkStats(ctx context.Context, vaultID string) ([]ExternalLinkHostStats, error) {
+	defer c.logOp(ctx, "external_link.stats", time.Now())
+	sql := `SELECT hostname, count() AS count
+		FROM external_link
+		WHERE vault = type::record("vault", $vault_id)
+		GROUP BY hostname
+		ORDER BY count DESC`
+	results, err := surrealdb.Query[[]ExternalLinkHostStats](ctx, c.DB(), sql, map[string]any{
+		"vault_id": bareID("vault", vaultID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get external link stats: %w", err)
+	}
+	return allResults(results), nil
+}
+
+// externalLinkWhere builds a shared WHERE clause and params for external link queries.
+func externalLinkWhere(filter ExternalLinkFilter) (string, map[string]any) {
+	var conditions []string
+	params := map[string]any{
+		"vault_id": bareID("vault", filter.VaultID),
+	}
+
+	conditions = append(conditions, `vault = type::record("vault", $vault_id)`)
+
+	if filter.Hostname != nil {
+		conditions = append(conditions, `hostname = $hostname`)
+		params["hostname"] = *filter.Hostname
+	}
+	if filter.FileID != nil {
+		conditions = append(conditions, `from_file = type::record("file", $file_id)`)
+		params["file_id"] = bareID("file", *filter.FileID)
+	}
+
+	return strings.Join(conditions, " AND "), params
+}
+
+// ListExternalLinks returns external links for a vault, optionally filtered.
+func (c *Client) ListExternalLinks(ctx context.Context, filter ExternalLinkFilter) ([]models.ExternalLink, error) {
+	defer c.logOp(ctx, "external_link.list", time.Now())
+
+	where, params := externalLinkWhere(filter)
+
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	params["limit"] = limit
+	params["start"] = filter.Offset
+
+	sql := fmt.Sprintf(`SELECT * FROM external_link WHERE %s ORDER BY hostname, full_url LIMIT $limit START $start`, where)
+
+	results, err := surrealdb.Query[[]models.ExternalLink](ctx, c.DB(), sql, params)
+	if err != nil {
+		return nil, fmt.Errorf("list external links: %w", err)
+	}
+	return allResults(results), nil
+}
+
+// CountExternalLinks returns the total count of external links matching the filter.
+func (c *Client) CountExternalLinks(ctx context.Context, filter ExternalLinkFilter) (int, error) {
+	defer c.logOp(ctx, "external_link.count", time.Now())
+
+	where, params := externalLinkWhere(filter)
+
+	sql := fmt.Sprintf(`SELECT count() AS total FROM external_link WHERE %s GROUP ALL`, where)
+
+	type countResult struct {
+		Total int `json:"total"`
+	}
+
+	results, err := surrealdb.Query[[]countResult](ctx, c.DB(), sql, params)
+	if err != nil {
+		return 0, fmt.Errorf("count external links: %w", err)
+	}
+
+	r := firstResultOpt(results)
+	if r == nil {
+		return 0, nil
+	}
+	return r.Total, nil
+}

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -103,6 +103,11 @@ func SchemaSQL(dimension int) string {
         DELETE FROM has_label WHERE in = $before.id
     };
 
+    DEFINE EVENT IF NOT EXISTS cascade_delete_file_external_links ON file
+    WHEN $event = "DELETE" AND $before.is_folder = false ASYNC RETRY 3 THEN {
+        DELETE FROM external_link WHERE from_file = $before.id
+    };
+
     -- Auto-create tombstone when a non-folder file is deleted
     DEFINE EVENT IF NOT EXISTS create_tombstone_on_delete ON file
     WHEN $event = "DELETE" AND $before.is_folder = false ASYNC RETRY 3 THEN {
@@ -165,6 +170,21 @@ func SchemaSQL(dimension int) string {
     DEFINE INDEX IF NOT EXISTS idx_wiki_link_to_file          ON wiki_link FIELDS to_file;
     DEFINE INDEX IF NOT EXISTS idx_wiki_link_vault             ON wiki_link FIELDS vault;
     DEFINE INDEX IF NOT EXISTS idx_wiki_link_vault_raw_target  ON wiki_link FIELDS vault, raw_target;
+
+    -- ==========================================================================
+    -- EXTERNAL_LINK TABLE
+    -- ==========================================================================
+    DEFINE TABLE IF NOT EXISTS external_link SCHEMAFULL;
+
+    DEFINE FIELD IF NOT EXISTS from_file  ON external_link TYPE record<file>;
+    DEFINE FIELD IF NOT EXISTS vault      ON external_link TYPE record<vault>;
+    DEFINE FIELD IF NOT EXISTS hostname   ON external_link TYPE string;
+    DEFINE FIELD IF NOT EXISTS url_path   ON external_link TYPE string;
+    DEFINE FIELD IF NOT EXISTS full_url   ON external_link TYPE string;
+    DEFINE FIELD IF NOT EXISTS link_text  ON external_link TYPE option<string>;
+
+    DEFINE INDEX IF NOT EXISTS idx_external_link_from_file  ON external_link FIELDS from_file;
+    DEFINE INDEX IF NOT EXISTS idx_external_link_vault_host ON external_link FIELDS vault, hostname;
 
     -- ==========================================================================
     -- FILE_RELATION TABLE (RELATION: file -> file)

--- a/internal/file/external_links.go
+++ b/internal/file/external_links.go
@@ -1,0 +1,54 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/raphi011/know/internal/db"
+	"github.com/raphi011/know/internal/logutil"
+	"github.com/raphi011/know/internal/parser"
+)
+
+// processExternalLinks extracts external URLs from parsed markdown and stores
+// them in the external_link table. Follows the same delete-then-insert pattern
+// as processWikiLinks.
+func (s *Service) processExternalLinks(ctx context.Context, fileID, vaultID string, links []parser.ExtractedLink) error {
+	if err := s.db.DeleteExternalLinksByFile(ctx, fileID); err != nil {
+		return fmt.Errorf("delete old: %w", err)
+	}
+
+	if len(links) == 0 {
+		return nil
+	}
+
+	logger := logutil.FromCtx(ctx)
+
+	inputs := make([]db.ExternalLinkInput, 0, len(links))
+	for _, l := range links {
+		u, err := url.Parse(l.URL)
+		if err != nil {
+			logger.Warn("skipping unparseable URL", "url", l.URL, "error", err)
+			continue
+		}
+		if u.Hostname() == "" {
+			logger.Debug("skipping URL with empty hostname", "url", l.URL)
+			continue
+		}
+
+		input := db.ExternalLinkInput{
+			Hostname: u.Hostname(),
+			URLPath:  u.Path,
+			FullURL:  l.URL,
+		}
+		if l.LinkText != "" {
+			input.LinkText = &l.LinkText
+		}
+		inputs = append(inputs, input)
+	}
+
+	if err := s.db.CreateExternalLinks(ctx, fileID, vaultID, inputs); err != nil {
+		return fmt.Errorf("create: %w", err)
+	}
+	return nil
+}

--- a/internal/file/service.go
+++ b/internal/file/service.go
@@ -307,6 +307,11 @@ func (s *Service) ProcessFile(ctx context.Context, doc *models.File) error {
 		if err := s.syncTasks(ctx, fileID, vaultID, parsed.Tasks); err != nil {
 			return fmt.Errorf("sync tasks for %s: %w", doc.Path, err)
 		}
+
+		// 5.6. Extract and store external links
+		if err := s.processExternalLinks(ctx, fileID, vaultID, parsed.ExternalLinks); err != nil {
+			return fmt.Errorf("process external links for %s: %w", doc.Path, err)
+		}
 	}
 
 	// 5. Sync label graph (has_label edges) — applies to all file types
@@ -968,8 +973,8 @@ func (s *Service) processRelatesTo(ctx context.Context, fileID, vaultID string, 
 		if _, err := s.db.CreateRelation(ctx, models.FileRelationInput{
 			FromFileID: fileID,
 			ToFileID:   toFileID,
-			RelType:   string(models.RelRelatesTo),
-			Source:    string(models.RelSourceFrontmatter),
+			RelType:    string(models.RelRelatesTo),
+			Source:     string(models.RelSourceFrontmatter),
 		}); err != nil {
 			return fmt.Errorf("create relates_to relation for %q: %w", target, err)
 		}

--- a/internal/models/external_link.go
+++ b/internal/models/external_link.go
@@ -1,0 +1,13 @@
+package models
+
+import surrealmodels "github.com/surrealdb/surrealdb.go/pkg/models"
+
+type ExternalLink struct {
+	ID       surrealmodels.RecordID `json:"id"`
+	FromFile surrealmodels.RecordID `json:"from_file"`
+	Vault    surrealmodels.RecordID `json:"vault"`
+	Hostname string                 `json:"hostname"`
+	URLPath  string                 `json:"url_path"`
+	FullURL  string                 `json:"full_url"`
+	LinkText *string                `json:"link_text,omitempty"`
+}

--- a/internal/parser/goldmark.go
+++ b/internal/parser/goldmark.go
@@ -20,6 +20,7 @@ func init() {
 	mdParser = goldmark.New(
 		goldmark.WithExtensions(
 			extension.TaskList,
+			extension.Linkify,
 			&wikilink.Extender{},
 			meta.Meta,
 		),

--- a/internal/parser/markdown.go
+++ b/internal/parser/markdown.go
@@ -14,6 +14,12 @@ import (
 	wlast "go.abhg.dev/goldmark/wikilink"
 )
 
+// ExtractedLink represents an external URL found in markdown content.
+type ExtractedLink struct {
+	URL      string // full URL (scheme + host + path + query + fragment)
+	LinkText string // anchor text (empty for bare/autolinked URLs)
+}
+
 // mentionRegex matches @mentions. Applied only to text nodes (not code blocks).
 var mentionRegex = regexp.MustCompile(`@([a-zA-Z0-9_-]+)`)
 
@@ -45,6 +51,9 @@ type MarkdownDoc struct {
 
 	// Inline #labels found outside code blocks
 	InlineLabels []string
+
+	// External URLs extracted from [text](url) and bare/autolinked URLs
+	ExternalLinks []ExtractedLink
 }
 
 // Section represents a heading and its content.
@@ -106,6 +115,9 @@ func ParseMarkdown(content string) *MarkdownDoc {
 	// Deduplicate wiki-links
 	doc.WikiLinks = dedup(w.wikiLinks)
 
+	// Deduplicate external links
+	doc.ExternalLinks = dedupExternalLinks(w.externalLinks)
+
 	// Extract mentions and labels from collected text (excludes code blocks)
 	doc.Mentions = extractMentions(w.textContent.String())
 	doc.InlineLabels = extractInlineLabels(w.textContent.String())
@@ -163,6 +175,9 @@ type astWalker struct {
 
 	// Wiki-links
 	wikiLinks []string
+
+	// External links
+	externalLinks []ExtractedLink
 
 	// Query blocks
 	queryBlocks []QueryBlock
@@ -419,6 +434,23 @@ func (w *astWalker) collectText(node ast.Node) {
 		case *ast.Text:
 			w.textContent.Write(t.Value(w.source))
 			w.textContent.WriteByte(' ')
+		case *ast.Link:
+			dest := string(t.Destination)
+			if isExternalURL(dest) {
+				w.externalLinks = append(w.externalLinks, ExtractedLink{
+					URL:      dest,
+					LinkText: inlineText(w.source, t),
+				})
+			}
+		case *ast.AutoLink:
+			if t.AutoLinkType == ast.AutoLinkURL {
+				url := string(t.URL(w.source))
+				if isExternalURL(url) {
+					w.externalLinks = append(w.externalLinks, ExtractedLink{
+						URL: url,
+					})
+				}
+			}
 		case *wlast.Node:
 			target := strings.TrimSpace(string(t.Target))
 			if target != "" {
@@ -685,6 +717,32 @@ func (d *MarkdownDoc) GetFrontmatterStringSlice(key string) []string {
 		return v
 	}
 	return nil
+}
+
+// isExternalURL returns true for http:// and https:// URLs.
+func isExternalURL(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}
+
+// dedupExternalLinks deduplicates links by URL, keeping the first occurrence's link text.
+func dedupExternalLinks(links []ExtractedLink) []ExtractedLink {
+	if len(links) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool)
+	result := make([]ExtractedLink, 0, len(links))
+	for _, l := range links {
+		if !seen[l.URL] {
+			seen[l.URL] = true
+			result = append(result, l)
+		}
+	}
+	return result
+}
+
+// ExtractExternalLinks finds external URLs in content using AST parsing.
+func ExtractExternalLinks(content string) []ExtractedLink {
+	return ParseMarkdown(content).ExternalLinks
 }
 
 // ExtractWikiLinks finds [[wiki-style]] links in content using AST parsing.

--- a/internal/parser/markdown_test.go
+++ b/internal/parser/markdown_test.go
@@ -575,3 +575,129 @@ func TestParseMarkdown_OnlyFrontmatter(t *testing.T) {
 		t.Errorf("expected 0 tasks, got %d", len(doc.Tasks))
 	}
 }
+
+func TestParseMarkdown_ExternalLinks_MarkdownLink(t *testing.T) {
+	content := "Check [GitHub](https://github.com/repo) and [Docs](https://docs.example.com/guide)."
+
+	doc := ParseMarkdown(content)
+
+	if len(doc.ExternalLinks) != 2 {
+		t.Fatalf("expected 2 external links, got %d: %v", len(doc.ExternalLinks), doc.ExternalLinks)
+	}
+	if doc.ExternalLinks[0].URL != "https://github.com/repo" {
+		t.Errorf("first link URL = %q, want https://github.com/repo", doc.ExternalLinks[0].URL)
+	}
+	if doc.ExternalLinks[0].LinkText != "GitHub" {
+		t.Errorf("first link text = %q, want GitHub", doc.ExternalLinks[0].LinkText)
+	}
+	if doc.ExternalLinks[1].URL != "https://docs.example.com/guide" {
+		t.Errorf("second link URL = %q, want https://docs.example.com/guide", doc.ExternalLinks[1].URL)
+	}
+}
+
+func TestParseMarkdown_ExternalLinks_BareURL(t *testing.T) {
+	content := "Visit https://example.com/page for more info."
+
+	doc := ParseMarkdown(content)
+
+	if len(doc.ExternalLinks) != 1 {
+		t.Fatalf("expected 1 external link, got %d: %v", len(doc.ExternalLinks), doc.ExternalLinks)
+	}
+	if doc.ExternalLinks[0].URL != "https://example.com/page" {
+		t.Errorf("link URL = %q, want https://example.com/page", doc.ExternalLinks[0].URL)
+	}
+	if doc.ExternalLinks[0].LinkText != "" {
+		t.Errorf("bare URL should have empty link text, got %q", doc.ExternalLinks[0].LinkText)
+	}
+}
+
+func TestParseMarkdown_ExternalLinks_InsideCodeBlock(t *testing.T) {
+	content := "See [real](https://real.com) here.\n\n```\n[fake](https://fake.com)\nhttps://also-fake.com\n```\n\nEnd."
+
+	doc := ParseMarkdown(content)
+
+	if len(doc.ExternalLinks) != 1 {
+		t.Fatalf("expected 1 external link (code block excluded), got %d: %v", len(doc.ExternalLinks), doc.ExternalLinks)
+	}
+	if doc.ExternalLinks[0].URL != "https://real.com" {
+		t.Errorf("link URL = %q, want https://real.com", doc.ExternalLinks[0].URL)
+	}
+}
+
+func TestParseMarkdown_ExternalLinks_RelativeIgnored(t *testing.T) {
+	content := "See [local](/docs/foo) and [external](https://example.com)."
+
+	doc := ParseMarkdown(content)
+
+	if len(doc.ExternalLinks) != 1 {
+		t.Fatalf("expected 1 external link (relative excluded), got %d: %v", len(doc.ExternalLinks), doc.ExternalLinks)
+	}
+	if doc.ExternalLinks[0].URL != "https://example.com" {
+		t.Errorf("link URL = %q, want https://example.com", doc.ExternalLinks[0].URL)
+	}
+}
+
+func TestParseMarkdown_ExternalLinks_Dedup(t *testing.T) {
+	content := "Link [first](https://example.com) and [second](https://example.com) again."
+
+	doc := ParseMarkdown(content)
+
+	if len(doc.ExternalLinks) != 1 {
+		t.Fatalf("expected 1 external link after dedup, got %d: %v", len(doc.ExternalLinks), doc.ExternalLinks)
+	}
+	if doc.ExternalLinks[0].LinkText != "first" {
+		t.Errorf("dedup should keep first occurrence text, got %q", doc.ExternalLinks[0].LinkText)
+	}
+}
+
+func TestParseMarkdown_ExternalLinks_HttpAndHttps(t *testing.T) {
+	content := "Both [http](http://example.com) and [https](https://example.com/secure)."
+
+	doc := ParseMarkdown(content)
+
+	if len(doc.ExternalLinks) != 2 {
+		t.Fatalf("expected 2 external links, got %d: %v", len(doc.ExternalLinks), doc.ExternalLinks)
+	}
+}
+
+func TestParseMarkdown_ExternalLinks_MailtoIgnored(t *testing.T) {
+	content := "Email <user@example.com> and visit [site](https://example.com)."
+
+	doc := ParseMarkdown(content)
+
+	for _, l := range doc.ExternalLinks {
+		if strings.Contains(l.URL, "mailto") || strings.Contains(l.URL, "@") {
+			t.Errorf("mailto should not be extracted, got %q", l.URL)
+		}
+	}
+	// Should have at least the https link
+	found := false
+	for _, l := range doc.ExternalLinks {
+		if l.URL == "https://example.com" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected https://example.com in external links")
+	}
+}
+
+func TestParseMarkdown_ExternalLinks_InListItems(t *testing.T) {
+	content := "# Resources\n\n- [Go docs](https://go.dev)\n- [Rust docs](https://doc.rust-lang.org)\n"
+
+	doc := ParseMarkdown(content)
+
+	if len(doc.ExternalLinks) != 2 {
+		t.Fatalf("expected 2 external links from list items, got %d: %v", len(doc.ExternalLinks), doc.ExternalLinks)
+	}
+}
+
+func TestParseMarkdown_ExternalLinks_Empty(t *testing.T) {
+	content := "No links here, just text."
+
+	doc := ParseMarkdown(content)
+
+	if doc.ExternalLinks != nil {
+		t.Errorf("expected nil external links, got %v", doc.ExternalLinks)
+	}
+}


### PR DESCRIPTION
Extract external links (`[text](url)` and bare autolinked URLs) during document ingestion and store them in a new `external_link` table. Adds two REST API endpoints for querying link data.

## New Features
- Parse external URLs from markdown AST (`ast.Link` + `ast.AutoLink` nodes) via goldmark Linkify extension
- Store links in `external_link` table with hostname, URL path, full URL, link text, and source file reference
- `GET /api/external-links/stats?vault={id}` — aggregated link counts by hostname
- `GET /api/external-links?vault={id}&hostname=...&limit=...&offset=...` — filtered link listing with pagination
- Cascade delete event removes external links when source file is deleted
- Helm chart bumped to 0.8.0

## Breaking Changes
- None