### PR TITLE
feat: add TUI file browser with fuzzy search

### DIFF
--- a/cmd/know/cmd_browse.go
+++ b/cmd/know/cmd_browse.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
+	"github.com/raphi011/know/internal/models"
+	"github.com/raphi011/know/internal/tui/browse"
+	"github.com/spf13/cobra"
+)
+
+var (
+	browseAPI     *apiFlags
+	browseVaultID *string
+)
+
+var browseCmd = &cobra.Command{
+	Use:   "browse",
+	Short: "Browse vault files with fuzzy search",
+	Long: `Launch a terminal UI for browsing files in a vault.
+
+Fuzzy-find documents by path or title, then view rendered markdown.
+Press Enter to open a file, Esc to return to the finder, q to quit.
+
+  KNOW_SERVER_URL   Server base URL (default: http://localhost:4001)
+  KNOW_TOKEN        API bearer token
+  KNOW_VAULT        Default vault ID
+
+Examples:
+  know browse
+  know browse --vault default`,
+	RunE: runBrowse,
+}
+
+func init() {
+	browseAPI = addAPIFlags(browseCmd)
+	browseVaultID = addVaultFlag(browseCmd, browseAPI)
+}
+
+func runBrowse(_ *cobra.Command, _ []string) error {
+	isDark := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+
+	client := browseAPI.newClient()
+
+	files, err := client.ListFiles(context.Background(), *browseVaultID, "/", true)
+	if err != nil {
+		return fmt.Errorf("browse: %w", err)
+	}
+
+	// Filter out directories — only show documents
+	docs := make([]models.FileEntry, 0, len(files))
+	for _, f := range files {
+		if !f.IsDir {
+			docs = append(docs, f)
+		}
+	}
+
+	model := browse.NewModel(client, *browseVaultID, docs, isDark)
+	p := tea.NewProgram(model)
+	if _, err := p.Run(); err != nil {
+		return fmt.Errorf("browse: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/know/main.go
+++ b/cmd/know/main.go
@@ -84,6 +84,7 @@ func main() {
 	rootCmd.AddCommand(vaultCmd)
 	rootCmd.AddCommand(remoteCmd)
 	rootCmd.AddCommand(taskCmd)
+	rootCmd.AddCommand(browseCmd)
 	rootCmd.AddCommand(completionCmd)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.4.0
 	github.com/pkg/sftp v1.13.10
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
+	github.com/sahilm/fuzzy v0.1.1
 	github.com/samber/slog-multi v1.7.1
 	github.com/spf13/cobra v1.10.2
 	github.com/surrealdb/surrealdb.go v1.4.0
@@ -40,7 +41,6 @@ require (
 require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/rasky/go-xdr v0.0.0-20170124162913-1a41d1a06c93 // indirect
-	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/willscott/go-nfs-client v0.0.0-20240104095149-b44639837b00 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/internal/api/ls.go
+++ b/internal/api/ls.go
@@ -77,9 +77,10 @@ func (s *Server) ls(w http.ResponseWriter, r *http.Request) {
 		}
 		for _, d := range docs {
 			entries = append(entries, models.FileEntry{
-				Name: path.Base(d.Path),
-				Path: d.Path,
-				Size: d.Size,
+				Name:  path.Base(d.Path),
+				Path:  d.Path,
+				Title: d.Title,
+				Size:  d.Size,
 			})
 		}
 	} else {
@@ -103,9 +104,10 @@ func (s *Server) ls(w http.ResponseWriter, r *http.Request) {
 			rel := strings.TrimPrefix(d.Path, prefix)
 			if rel != d.Path && !strings.Contains(rel, "/") {
 				entries = append(entries, models.FileEntry{
-					Name: path.Base(d.Path),
-					Path: d.Path,
-					Size: d.Size,
+					Name:  path.Base(d.Path),
+					Path:  d.Path,
+					Title: d.Title,
+					Size:  d.Size,
 				})
 			}
 		}

--- a/internal/db/queries_file.go
+++ b/internal/db/queries_file.go
@@ -536,7 +536,7 @@ func (c *Client) ListFileMetas(ctx context.Context, filter ListFilesFilter) ([]m
 	if err != nil {
 		return nil, fmt.Errorf("list file metas: %w", err)
 	}
-	sql := fmt.Sprintf("SELECT path, mime_type, size, content_hash ?? null AS content_hash, is_folder, updated_at FROM file WHERE %s %s", where, suffix)
+	sql := fmt.Sprintf("SELECT path, title, mime_type, size, content_hash ?? null AS content_hash, is_folder, updated_at FROM file WHERE %s %s", where, suffix)
 
 	results, err := surrealdb.Query[[]models.FileMeta](ctx, c.DB(), sql, vars)
 	if err != nil {

--- a/internal/models/file.go
+++ b/internal/models/file.go
@@ -63,6 +63,7 @@ func (f FileInput) Validate() error {
 // (e.g. WebDAV Stat, directory listings) that don't need content or data.
 type FileMeta struct {
 	Path        string    `json:"path"`
+	Title       string    `json:"title"`
 	MimeType    string    `json:"mime_type"`
 	Size        int       `json:"size"`
 	ContentHash *string   `json:"content_hash,omitempty"`
@@ -80,6 +81,7 @@ type LabelCount struct {
 type FileEntry struct {
 	Name  string `json:"name"`
 	Path  string `json:"path"`
+	Title string `json:"title,omitempty"`
 	IsDir bool   `json:"isDir"`
 	Size  int    `json:"size,omitempty"`
 }

--- a/internal/tui/browse/browser.go
+++ b/internal/tui/browse/browser.go
@@ -1,0 +1,179 @@
+// Package browse provides a bubbletea v2 TUI for fuzzy-finding and viewing
+// vault documents.
+package browse
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/glamour"
+	"github.com/raphi011/know/internal/apiclient"
+	"github.com/raphi011/know/internal/models"
+)
+
+type viewState int
+
+const (
+	stateFinding viewState = iota
+	stateViewing
+)
+
+// documentFetchedMsg is the result of an async document fetch.
+type documentFetchedMsg struct {
+	doc *apiclient.Document
+	err error
+}
+
+// Model is the root browser model composing a finder and viewer.
+type Model struct {
+	state   viewState
+	finder  finderModel
+	viewer  viewerModel
+	client  *apiclient.Client
+	vaultID string
+	width   int
+	height  int
+
+	glamourStyle string
+	renderer     *glamour.TermRenderer
+}
+
+// NewModel creates a browser with a pre-fetched file list.
+// isDark should be detected before bubbletea starts.
+func NewModel(client *apiclient.Client, vaultID string, files []models.FileEntry, isDark bool) Model {
+	glamourStyle := "light"
+	if isDark {
+		glamourStyle = "dark"
+	}
+
+	r, err := glamour.NewTermRenderer(
+		glamour.WithStandardStyle(glamourStyle),
+		glamour.WithWordWrap(100),
+	)
+	if err != nil {
+		slog.Warn("glamour renderer init failed", "error", err)
+	}
+
+	return Model{
+		state:        stateFinding,
+		finder:       newFinder(files),
+		client:       client,
+		vaultID:      vaultID,
+		glamourStyle: glamourStyle,
+		renderer:     r,
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return m.finder.Init()
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.finder.width = msg.Width
+		m.finder.height = msg.Height
+		m.updateRenderer()
+		if m.state == stateViewing {
+			m.viewer.width = msg.Width
+			m.viewer.viewport.SetWidth(msg.Width)
+			m.viewer.viewport.SetHeight(max(msg.Height-2, 1))
+		}
+		return m, nil
+
+	case tea.KeyPressMsg:
+		// Global quit (ctrl+c works in both states)
+		if msg.String() == "ctrl+c" {
+			return m, tea.Quit
+		}
+
+	case fileSelectedMsg:
+		return m, m.fetchDocument(msg.path)
+
+	case documentFetchedMsg:
+		if msg.err != nil {
+			slog.Warn("document fetch failed", "error", msg.err)
+			m.finder.statusErr = fmt.Sprintf("Failed to open: %v", msg.err)
+			return m, nil
+		}
+		m.finder.statusErr = ""
+		content := msg.doc.Content
+		if m.renderer != nil {
+			rendered, err := m.renderer.Render(content)
+			if err != nil {
+				slog.Warn("glamour render failed, showing raw content", "path", msg.doc.Path, "error", err)
+			} else {
+				content = rendered
+			}
+		}
+		m.viewer = newViewer(msg.doc.Path, content, m.width, m.height)
+		m.state = stateViewing
+		return m, nil
+
+	case backToFinderMsg:
+		m.state = stateFinding
+		return m, m.finder.input.Focus()
+	}
+
+	// Route to active sub-model
+	switch m.state {
+	case stateFinding:
+		var cmd tea.Cmd
+		m.finder, cmd = m.finder.Update(msg)
+		return m, cmd
+	case stateViewing:
+		var cmd tea.Cmd
+		m.viewer, cmd = m.viewer.Update(msg)
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m Model) View() tea.View {
+	var content string
+
+	switch m.state {
+	case stateFinding:
+		content = m.finder.View()
+	case stateViewing:
+		content = m.viewer.View()
+	}
+
+	v := tea.NewView(content)
+	v.AltScreen = true
+	return v
+}
+
+func (m *Model) fetchDocument(path string) tea.Cmd {
+	client := m.client
+	vaultID := m.vaultID
+	return func() tea.Msg {
+		doc, err := client.GetDocument(context.Background(), vaultID, path)
+		if err != nil {
+			return documentFetchedMsg{err: fmt.Errorf("fetch %s: %w", path, err)}
+		}
+		return documentFetchedMsg{doc: doc}
+	}
+}
+
+// updateRenderer recreates the glamour renderer when terminal width changes.
+func (m *Model) updateRenderer() {
+	wrapWidth := max(m.width-4, 20)
+	if wrapWidth > 100 {
+		wrapWidth = 100
+	}
+	r, err := glamour.NewTermRenderer(
+		glamour.WithStandardStyle(m.glamourStyle),
+		glamour.WithWordWrap(wrapWidth),
+	)
+	if err != nil {
+		slog.Warn("glamour renderer re-creation failed on resize", "width", wrapWidth, "error", err)
+	} else {
+		m.renderer = r
+	}
+}

--- a/internal/tui/browse/finder.go
+++ b/internal/tui/browse/finder.go
@@ -1,0 +1,215 @@
+package browse
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
+	"github.com/raphi011/know/internal/models"
+	"github.com/sahilm/fuzzy"
+)
+
+// fileSelectedMsg is sent when the user presses Enter on a file.
+type fileSelectedMsg struct {
+	path string
+}
+
+// fileSource implements fuzzy.Source for matching against file path + title.
+type fileSource []models.FileEntry
+
+func (s fileSource) String(i int) string {
+	e := s[i]
+	if e.Title != "" {
+		return e.Path + " " + e.Title
+	}
+	return e.Path
+}
+
+func (s fileSource) Len() int { return len(s) }
+
+type finderModel struct {
+	input     textinput.Model
+	allFiles  []models.FileEntry
+	matches   []fuzzy.Match
+	cursor    int
+	offset    int // scroll offset for visible window
+	statusErr string
+	width     int
+	height    int
+}
+
+func newFinder(files []models.FileEntry) finderModel {
+	ti := textinput.New()
+	ti.Placeholder = "Search files..."
+	ti.CharLimit = 256
+	ti.Prompt = promptStyle.Render("/ ")
+
+	styles := ti.Styles()
+	styles.Cursor.Blink = false
+	ti.SetStyles(styles)
+
+	f := finderModel{
+		input:    ti,
+		allFiles: files,
+	}
+	f.refilter()
+	return f
+}
+
+func (f finderModel) Init() tea.Cmd {
+	return f.input.Focus()
+}
+
+func (f finderModel) Update(msg tea.Msg) (finderModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "enter":
+			if len(f.matches) > 0 && f.cursor < len(f.matches) {
+				idx := f.matches[f.cursor].Index
+				return f, func() tea.Msg {
+					return fileSelectedMsg{path: f.allFiles[idx].Path}
+				}
+			}
+			return f, nil
+		case "up":
+			if f.cursor > 0 {
+				f.cursor--
+				f.ensureCursorVisible()
+			}
+			return f, nil
+		case "down":
+			if f.cursor < len(f.matches)-1 {
+				f.cursor++
+				f.ensureCursorVisible()
+			}
+			return f, nil
+		}
+	}
+
+	// Delegate to text input
+	var cmd tea.Cmd
+	prev := f.input.Value()
+	f.input, cmd = f.input.Update(msg)
+	if f.input.Value() != prev {
+		f.statusErr = ""
+		f.refilter()
+	}
+	return f, cmd
+}
+
+func (f finderModel) View() string {
+	var b strings.Builder
+
+	// Input line
+	b.WriteString(f.input.View())
+	b.WriteString("\n")
+
+	// Result count
+	b.WriteString(countStyle.Render(fmt.Sprintf("  %d/%d files", len(f.matches), len(f.allFiles))))
+	b.WriteString("\n")
+
+	// File list
+	visible := f.visibleRows()
+	end := min(f.offset+visible, len(f.matches))
+
+	for i := f.offset; i < end; i++ {
+		m := f.matches[i]
+		entry := f.allFiles[m.Index]
+
+		prefix := "  "
+		style := normalStyle
+		if i == f.cursor {
+			prefix = "> "
+			style = selectedStyle
+		}
+
+		// Render path with highlighted match characters
+		line := renderHighlighted(entry.Path, m.MatchedIndexes, style)
+
+		// Append title if present and different from path
+		if entry.Title != "" {
+			line += " " + titleStyle.Render(entry.Title)
+		}
+
+		b.WriteString(prefix + line + "\n")
+	}
+
+	// Pad remaining space
+	rendered := end - f.offset
+	for i := rendered; i < visible; i++ {
+		b.WriteString("\n")
+	}
+
+	// Error line (if any)
+	if f.statusErr != "" {
+		b.WriteString(errStyle.Render("  " + f.statusErr))
+		b.WriteString("\n")
+	}
+
+	// Help line
+	b.WriteString(countStyle.Render("  enter: open  esc: quit"))
+
+	return b.String()
+}
+
+// visibleRows returns how many file rows fit in the current terminal height.
+// Reserves 4 lines: input, count, help, and a blank line.
+func (f finderModel) visibleRows() int {
+	rows := max(f.height-4, 1)
+	return rows
+}
+
+func (f *finderModel) refilter() {
+	query := f.input.Value()
+	if query == "" {
+		// Show all files when query is empty
+		f.matches = make([]fuzzy.Match, len(f.allFiles))
+		for i := range f.allFiles {
+			f.matches[i] = fuzzy.Match{Index: i}
+		}
+	} else {
+		f.matches = fuzzy.FindFrom(query, fileSource(f.allFiles))
+	}
+
+	// Clamp cursor
+	if f.cursor >= len(f.matches) {
+		f.cursor = max(0, len(f.matches)-1)
+	}
+	f.ensureCursorVisible()
+}
+
+func (f *finderModel) ensureCursorVisible() {
+	visible := f.visibleRows()
+	if f.cursor < f.offset {
+		f.offset = f.cursor
+	}
+	if f.cursor >= f.offset+visible {
+		f.offset = f.cursor - visible + 1
+	}
+}
+
+// renderHighlighted renders a string with matched character indices highlighted.
+func renderHighlighted(s string, matchedIndexes []int, baseStyle lipgloss.Style) string {
+	if len(matchedIndexes) == 0 {
+		return baseStyle.Render(s)
+	}
+
+	matchSet := make(map[int]bool, len(matchedIndexes))
+	for _, idx := range matchedIndexes {
+		matchSet[idx] = true
+	}
+
+	var b strings.Builder
+	for i, ch := range s {
+		c := string(ch)
+		if matchSet[i] {
+			b.WriteString(matchStyle.Render(c))
+		} else {
+			b.WriteString(baseStyle.Render(c))
+		}
+	}
+	return b.String()
+}

--- a/internal/tui/browse/styles.go
+++ b/internal/tui/browse/styles.go
@@ -1,0 +1,45 @@
+package browse
+
+import lipgloss "charm.land/lipgloss/v2"
+
+var (
+	// Colors — reuse the violet/gray palette from the agent TUI.
+	primaryColor = lipgloss.Color("#7C3AED")
+	mutedColor   = lipgloss.Color("#9CA3AF")
+	matchColor   = lipgloss.Color("#F59E0B") // amber for fuzzy match highlights
+
+	// Finder styles
+	promptStyle = lipgloss.NewStyle().
+			Foreground(primaryColor).
+			Bold(true)
+
+	countStyle = lipgloss.NewStyle().
+			Foreground(mutedColor)
+
+	selectedStyle = lipgloss.NewStyle().
+			Foreground(primaryColor).
+			Bold(true)
+
+	normalStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#D1D5DB"))
+
+	matchStyle = lipgloss.NewStyle().
+			Foreground(matchColor).
+			Bold(true)
+
+	titleStyle = lipgloss.NewStyle().
+			Foreground(mutedColor)
+
+	errStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#EF4444"))
+
+	// Viewer styles
+	headerBarStyle = lipgloss.NewStyle().
+			Background(primaryColor).
+			Foreground(lipgloss.Color("#FFFFFF")).
+			Bold(true).
+			Padding(0, 1)
+
+	footerBarStyle = lipgloss.NewStyle().
+			Foreground(mutedColor)
+)

--- a/internal/tui/browse/viewer.go
+++ b/internal/tui/browse/viewer.go
@@ -1,0 +1,76 @@
+package browse
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+)
+
+// backToFinderMsg signals the browser to switch back to the finder.
+type backToFinderMsg struct{}
+
+type viewerModel struct {
+	viewport viewport.Model
+	path     string
+	width    int
+}
+
+func newViewer(path, renderedContent string, width, height int) viewerModel {
+	vp := viewport.New(viewport.WithWidth(width), viewport.WithHeight(max(height-2, 1)))
+	vp.SetContent(renderedContent)
+
+	return viewerModel{
+		viewport: vp,
+		path:     path,
+		width:    width,
+	}
+}
+
+func (v viewerModel) Update(msg tea.Msg) (viewerModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "escape":
+			return v, func() tea.Msg { return backToFinderMsg{} }
+		case "q":
+			return v, tea.Quit
+		}
+	}
+
+	var cmd tea.Cmd
+	v.viewport, cmd = v.viewport.Update(msg)
+	return v, cmd
+}
+
+func (v viewerModel) View() string {
+	var b strings.Builder
+
+	// Header bar with file path
+	header := headerBarStyle.Render(truncate(v.path, v.width-2))
+	b.WriteString(header)
+	b.WriteString("\n")
+
+	// Viewport content
+	b.WriteString(v.viewport.View())
+	b.WriteString("\n")
+
+	// Footer with scroll position and keybinds
+	pct := v.viewport.ScrollPercent()
+	footer := footerBarStyle.Render(fmt.Sprintf("  %.0f%%  esc: back  q: quit", pct*100))
+	b.WriteString(footer)
+
+	return b.String()
+}
+
+// truncate shortens a string to maxLen, adding "..." if truncated.
+func truncate(s string, maxLen int) string {
+	if maxLen < 4 {
+		maxLen = 4
+	}
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}


### PR DESCRIPTION
Add `know browse` command — a terminal UI for browsing vault documents with fuzzy search by path/title and rendered markdown viewing. Also exposes document titles through the ls API and FileMeta model.

## New Features
- `know browse` command with bubbletea v2 TUI
- Fuzzy file finder matching on path and title (sahilm/fuzzy)
- Markdown document viewer with glamour rendering
- Title field added to `FileEntry` and `FileMeta` models
- Title included in ls API responses and DB queries

## Breaking Changes
- None