### PR TITLE
feat: add YouTube transcript fetching via Apify API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,9 @@ KNOW_EMBED_DIMENSION=768
 # Tavily (web search for agent)
 # TAVILY_API_KEY=tvly-...
 
+# Apify (YouTube transcript fetching and other scraping)
+# KNOW_APIFY_TOKEN=apify_api_...
+
 # AWS Bedrock (Claude models only for LLM, see bedrock-setup.sh for Teleport setup)
 # KNOW_BEDROCK_EMBED_MODEL_PROVIDER=amazon     # For embedding inference profiles
 # KNOW_TLS_SKIP_VERIFY=false                   # Skip TLS verification for local Teleport proxy

--- a/cmd/know/cmd_serve.go
+++ b/cmd/know/cmd_serve.go
@@ -188,6 +188,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 			app.VaultService(),
 			app.RemoteService(),
 			app.MemoryService(),
+			app.ApifyClient(),
 		)
 		mux.Handle("/mcp", authMw(mcpHandler))
 		slog.Info("MCP endpoint enabled", "path", "/mcp")

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/schema"
+	"github.com/raphi011/know/internal/apify"
 	"github.com/raphi011/know/internal/db"
 	"github.com/raphi011/know/internal/diff"
 	"github.com/raphi011/know/internal/llm"
@@ -49,6 +50,7 @@ type Service struct {
 	model           atomic.Pointer[llm.Model]
 	tools           []tool.BaseTool
 	tavily          *tavilyClient
+	apifyClient     *apify.Client
 	checkpointStore *SurrealCheckPointStore
 }
 
@@ -64,10 +66,11 @@ func (s *Service) getModel() *llm.Model {
 
 // NewService creates a new agent service. The tools slice should contain
 // multi-vault tool wrappers built by the bootstrap layer.
-func NewService(db *db.Client, model *llm.Model, agentTools []tool.BaseTool, tavilyAPIKey string) *Service {
+func NewService(db *db.Client, model *llm.Model, agentTools []tool.BaseTool, tavilyAPIKey string, apifyClient *apify.Client) *Service {
 	s := &Service{
 		db:              db,
 		tools:           agentTools,
+		apifyClient:     apifyClient,
 		checkpointStore: NewCheckPointStore(db),
 	}
 	s.model.Store(model)
@@ -265,6 +268,9 @@ func (s *Service) buildAgent(ctx context.Context, model *llm.Model, req *ChatReq
 	copy(agentTools, s.tools)
 	if s.tavily != nil {
 		agentTools = append(agentTools, &WebSearchTool{tavily: s.tavily})
+	}
+	if s.apifyClient != nil {
+		agentTools = append(agentTools, &YouTubeTranscriptTool{client: s.apifyClient})
 	}
 	if !req.AutoApprove {
 		agentTools = wrapWriteToolsForApproval(ctx, agentTools, s, req.VaultID)

--- a/internal/agent/youtube_transcript_tool.go
+++ b/internal/agent/youtube_transcript_tool.go
@@ -1,0 +1,58 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/schema"
+	"github.com/raphi011/know/internal/apify"
+	"github.com/raphi011/know/internal/logutil"
+	"github.com/raphi011/know/internal/tools"
+)
+
+// YouTubeTranscriptTool is an agent-only InvokableTool that fetches YouTube
+// video transcripts via the Apify API.
+type YouTubeTranscriptTool struct {
+	client *apify.Client
+}
+
+func (t *YouTubeTranscriptTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{
+		Name: "fetch_youtube_transcript",
+		Desc: "Fetch the transcript of a YouTube video. Accepts a YouTube URL or video ID. Returns the transcript text with video metadata.",
+		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+			"url": {
+				Type:     schema.String,
+				Desc:     "YouTube video URL (e.g. https://www.youtube.com/watch?v=...) or video ID",
+				Required: true,
+			},
+		}),
+	}, nil
+}
+
+func (t *YouTubeTranscriptTool) InvokableRun(ctx context.Context, argumentsInJSON string, _ ...tool.Option) (string, error) {
+	var input struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal([]byte(argumentsInJSON), &input); err != nil {
+		return "", fmt.Errorf("parse fetch_youtube_transcript input: %w", err)
+	}
+
+	start := time.Now()
+	result, err := apify.FetchTranscript(ctx, t.client, input.URL)
+	durationMs := time.Since(start).Milliseconds()
+	if err != nil {
+		logutil.FromCtx(ctx).Warn("fetch youtube transcript failed",
+			"url", input.URL, "duration_ms", durationMs, "error", err)
+		return "", fmt.Errorf("fetch youtube transcript: %w", err)
+	}
+
+	tools.SetResultMeta(ctx, &tools.ToolResultMeta{
+		DurationMs: durationMs,
+	})
+
+	return apify.FormatTranscript(result), nil
+}

--- a/internal/apify/client.go
+++ b/internal/apify/client.go
@@ -1,0 +1,90 @@
+// Package apify provides a client for the Apify REST API.
+package apify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	baseURL = "https://api.apify.com/v2"
+
+	// defaultTimeout is the maximum time to wait for a synchronous actor run.
+	defaultTimeout = 120
+)
+
+// Client is a thin wrapper around the Apify REST API.
+type Client struct {
+	token      string
+	httpClient *http.Client
+}
+
+// New creates an Apify client with the given API token.
+func New(token string) *Client {
+	return &Client{
+		token: token,
+		httpClient: &http.Client{
+			Timeout: time.Duration(defaultTimeout+30) * time.Second,
+		},
+	}
+}
+
+// RunActorSync starts an actor run synchronously and returns the dataset items.
+// It uses the Apify "run-sync-get-dataset-items" endpoint which blocks until the
+// actor finishes (up to defaultTimeout seconds) and returns the dataset directly.
+func (c *Client) RunActorSync(ctx context.Context, actorID string, input any) ([]json.RawMessage, error) {
+	body, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("marshal input: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/acts/%s/run-sync-get-dataset-items?timeout=%d&format=json",
+		baseURL, actorID, defaultTimeout)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("run actor: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusRequestTimeout {
+		return nil, fmt.Errorf("actor run timed out after %ds", defaultTimeout)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("actor not found: %s", actorID)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("apify API error (HTTP %d): %s", resp.StatusCode, truncate(string(respBody), 200))
+	}
+
+	var items []json.RawMessage
+	if err := json.Unmarshal(respBody, &items); err != nil {
+		return nil, fmt.Errorf("unmarshal dataset items: %w", err)
+	}
+
+	return items, nil
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/internal/apify/client_test.go
+++ b/internal/apify/client_test.go
@@ -1,0 +1,107 @@
+package apify
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRunActorSync_Success(t *testing.T) {
+	items := []map[string]string{
+		{"title": "Test Video", "transcript": "Hello world"},
+	}
+	itemsJSON, _ := json.Marshal(items)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("unexpected auth header: %s", r.Header.Get("Authorization"))
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		w.WriteHeader(http.StatusCreated)
+		if _, err := w.Write(itemsJSON); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := New("test-token")
+	// Use a custom RoundTripper to redirect requests to the test server.
+	client.httpClient.Transport = rewriteTransport{target: srv.URL}
+
+	result, err := client.RunActorSync(context.Background(), "test/actor", map[string]string{"url": "https://youtube.com/watch?v=abc"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(result))
+	}
+}
+
+func TestRunActorSync_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		if _, err := w.Write([]byte(`{"error":"Actor not found"}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := New("test-token")
+	client.httpClient.Transport = rewriteTransport{target: srv.URL}
+
+	_, err := client.RunActorSync(context.Background(), "nonexistent/actor", nil)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestRunActorSync_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusRequestTimeout)
+	}))
+	defer srv.Close()
+
+	client := New("test-token")
+	client.httpClient.Transport = rewriteTransport{target: srv.URL}
+
+	_, err := client.RunActorSync(context.Background(), "test/actor", nil)
+	if err == nil {
+		t.Fatal("expected error for timeout")
+	}
+}
+
+func TestRunActorSync_ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Simulate slow response — context should cancel first.
+		select {}
+	}))
+	defer srv.Close()
+
+	client := New("test-token")
+	client.httpClient.Transport = rewriteTransport{target: srv.URL}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := client.RunActorSync(ctx, "test/actor", nil)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+// rewriteTransport redirects all requests to a test server URL while
+// preserving the original path and query parameters.
+type rewriteTransport struct {
+	target string
+}
+
+func (t rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	// Parse target to get host.
+	req.URL.Host = t.target[len("http://"):]
+	return http.DefaultTransport.RoundTrip(req)
+}

--- a/internal/apify/youtube.go
+++ b/internal/apify/youtube.go
@@ -1,0 +1,174 @@
+package apify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// defaultActorID is the Apify actor used for YouTube transcript extraction.
+// This can be changed if a better actor becomes available.
+const defaultActorID = "topaz_sharingan/youtube-transcript-scraper"
+
+// TranscriptResult holds a fetched YouTube transcript.
+type TranscriptResult struct {
+	Title       string
+	Channel     string
+	URL         string
+	Content     string // full transcript text
+	LanguageTag string // e.g. "en"
+}
+
+// actorInput is the input schema for the YouTube transcript actor.
+type actorInput struct {
+	StartURLs         []actorURL `json:"startUrls"`
+	IncludeTimestamps string     `json:"includeTimestamps"`
+}
+
+type actorURL struct {
+	URL string `json:"url"`
+}
+
+// actorOutput is the output schema from the YouTube transcript actor.
+type actorOutput struct {
+	Title         string `json:"title"`
+	URL           string `json:"url"`
+	ChannelName   string `json:"channelName"`
+	TranscriptRaw string `json:"transcript"`
+	Language      string `json:"language"`
+	// Some actors return structured segments instead of flat text.
+	Segments []struct {
+		Text string `json:"text"`
+	} `json:"segments"`
+}
+
+// FetchTranscript fetches the transcript for a YouTube video.
+func FetchTranscript(ctx context.Context, client *Client, videoURL string) (*TranscriptResult, error) {
+	if client == nil {
+		return nil, fmt.Errorf("apify client is nil")
+	}
+
+	normalized, err := normalizeYouTubeURL(videoURL)
+	if err != nil {
+		return nil, err
+	}
+
+	input := actorInput{
+		StartURLs:         []actorURL{{URL: normalized}},
+		IncludeTimestamps: "No",
+	}
+
+	items, err := client.RunActorSync(ctx, defaultActorID, input)
+	if err != nil {
+		return nil, fmt.Errorf("fetch transcript: %w", err)
+	}
+	if len(items) == 0 {
+		return nil, fmt.Errorf("no transcript available for %s (the video may not have captions)", normalized)
+	}
+
+	var out actorOutput
+	if err := json.Unmarshal(items[0], &out); err != nil {
+		return nil, fmt.Errorf("unmarshal transcript: %w", err)
+	}
+
+	content := out.TranscriptRaw
+	if content == "" && len(out.Segments) > 0 {
+		var sb strings.Builder
+		for _, seg := range out.Segments {
+			sb.WriteString(seg.Text)
+			sb.WriteString(" ")
+		}
+		content = strings.TrimSpace(sb.String())
+	}
+	if content == "" {
+		return nil, fmt.Errorf("transcript is empty for %s", normalized)
+	}
+
+	return &TranscriptResult{
+		Title:       out.Title,
+		Channel:     out.ChannelName,
+		URL:         out.URL,
+		Content:     content,
+		LanguageTag: out.Language,
+	}, nil
+}
+
+// FormatTranscript formats a TranscriptResult as a human-readable markdown string.
+func FormatTranscript(r *TranscriptResult) string {
+	var sb strings.Builder
+	if r.Title != "" {
+		fmt.Fprintf(&sb, "# %s\n", r.Title)
+	}
+	var meta []string
+	if r.Channel != "" {
+		meta = append(meta, "Channel: "+r.Channel)
+	}
+	if r.URL != "" {
+		meta = append(meta, "URL: "+r.URL)
+	}
+	if len(meta) > 0 {
+		sb.WriteString(strings.Join(meta, " | "))
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+	sb.WriteString(r.Content)
+	return sb.String()
+}
+
+// normalizeYouTubeURL parses a YouTube URL or video ID and returns a
+// canonical youtube.com/watch?v= URL.
+func normalizeYouTubeURL(input string) (string, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", fmt.Errorf("empty YouTube URL")
+	}
+
+	// Bare video ID (11 characters, alphanumeric + _ + -)
+	if !strings.Contains(input, "/") && !strings.Contains(input, ".") {
+		if len(input) >= 10 && len(input) <= 12 {
+			return "https://www.youtube.com/watch?v=" + input, nil
+		}
+		return "", fmt.Errorf("invalid YouTube video ID: %s", input)
+	}
+
+	// Add scheme if missing.
+	if !strings.HasPrefix(input, "http://") && !strings.HasPrefix(input, "https://") {
+		input = "https://" + input
+	}
+
+	u, err := url.Parse(input)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL: %w", err)
+	}
+
+	host := strings.ToLower(u.Hostname())
+
+	switch {
+	case host == "youtu.be":
+		videoID := strings.TrimPrefix(u.Path, "/")
+		if videoID == "" {
+			return "", fmt.Errorf("missing video ID in youtu.be URL")
+		}
+		return "https://www.youtube.com/watch?v=" + videoID, nil
+
+	case host == "youtube.com" || host == "www.youtube.com" || host == "m.youtube.com":
+		// /watch?v=ID
+		if v := u.Query().Get("v"); v != "" {
+			return "https://www.youtube.com/watch?v=" + v, nil
+		}
+		// /shorts/ID or /embed/ID or /v/ID
+		parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
+		if len(parts) >= 2 {
+			switch parts[0] {
+			case "shorts", "embed", "v", "live":
+				return "https://www.youtube.com/watch?v=" + parts[1], nil
+			}
+		}
+		return "", fmt.Errorf("could not extract video ID from YouTube URL: %s", input)
+
+	default:
+		return "", fmt.Errorf("not a YouTube URL: %s", input)
+	}
+}

--- a/internal/apify/youtube_test.go
+++ b/internal/apify/youtube_test.go
@@ -1,0 +1,273 @@
+package apify
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeYouTubeURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "standard watch URL",
+			input: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+			want:  "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		},
+		{
+			name:  "watch URL with extra params",
+			input: "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=30s",
+			want:  "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		},
+		{
+			name:  "short URL",
+			input: "https://youtu.be/dQw4w9WgXcQ",
+			want:  "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		},
+		{
+			name:  "shorts URL",
+			input: "https://youtube.com/shorts/dQw4w9WgXcQ",
+			want:  "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		},
+		{
+			name:  "embed URL",
+			input: "https://youtube.com/embed/dQw4w9WgXcQ",
+			want:  "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		},
+		{
+			name:  "live URL",
+			input: "https://www.youtube.com/live/dQw4w9WgXcQ",
+			want:  "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		},
+		{
+			name:  "mobile URL",
+			input: "https://m.youtube.com/watch?v=dQw4w9WgXcQ",
+			want:  "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		},
+		{
+			name:  "bare video ID",
+			input: "dQw4w9WgXcQ",
+			want:  "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		},
+		{
+			name:  "no scheme",
+			input: "youtube.com/watch?v=dQw4w9WgXcQ",
+			want:  "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		},
+		{
+			name:    "empty input",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "not a YouTube URL",
+			input:   "https://vimeo.com/12345",
+			wantErr: true,
+		},
+		{
+			name:    "YouTube URL without video ID",
+			input:   "https://www.youtube.com/",
+			wantErr: true,
+		},
+		{
+			name:    "youtu.be without path",
+			input:   "https://youtu.be/",
+			wantErr: true,
+		},
+		{
+			name:    "too short to be video ID",
+			input:   "abc",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeYouTubeURL(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchTranscript_Success(t *testing.T) {
+	items := []actorOutput{
+		{Title: "Test Video", ChannelName: "Test Channel", URL: "https://youtube.com/watch?v=abc", TranscriptRaw: "Hello world transcript text"},
+	}
+	itemsJSON, _ := json.Marshal(items)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write(itemsJSON); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := New("test-token")
+	client.httpClient.Transport = rewriteTransport{target: srv.URL}
+
+	result, err := FetchTranscript(context.Background(), client, "https://youtube.com/watch?v=abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Title != "Test Video" {
+		t.Errorf("title = %q, want %q", result.Title, "Test Video")
+	}
+	if result.Channel != "Test Channel" {
+		t.Errorf("channel = %q, want %q", result.Channel, "Test Channel")
+	}
+	if result.Content != "Hello world transcript text" {
+		t.Errorf("content = %q, want %q", result.Content, "Hello world transcript text")
+	}
+}
+
+func TestFetchTranscript_SegmentsFallback(t *testing.T) {
+	type segmentOutput struct {
+		Title    string `json:"title"`
+		Segments []struct {
+			Text string `json:"text"`
+		} `json:"segments"`
+	}
+	items := []segmentOutput{
+		{
+			Title: "Segments Video",
+			Segments: []struct {
+				Text string `json:"text"`
+			}{
+				{Text: "Hello"},
+				{Text: "world"},
+			},
+		},
+	}
+	itemsJSON, _ := json.Marshal(items)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write(itemsJSON); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := New("test-token")
+	client.httpClient.Transport = rewriteTransport{target: srv.URL}
+
+	result, err := FetchTranscript(context.Background(), client, "https://youtube.com/watch?v=abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Content != "Hello world" {
+		t.Errorf("content = %q, want %q", result.Content, "Hello world")
+	}
+}
+
+func TestFetchTranscript_EmptyDataset(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write([]byte(`[]`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := New("test-token")
+	client.httpClient.Transport = rewriteTransport{target: srv.URL}
+
+	_, err := FetchTranscript(context.Background(), client, "https://youtube.com/watch?v=abc")
+	if err == nil {
+		t.Fatal("expected error for empty dataset")
+	}
+	if !strings.Contains(err.Error(), "no transcript available") {
+		t.Errorf("error = %q, want it to contain 'no transcript available'", err)
+	}
+}
+
+func TestFetchTranscript_EmptyTranscript(t *testing.T) {
+	items := []actorOutput{
+		{Title: "No Captions", TranscriptRaw: ""},
+	}
+	itemsJSON, _ := json.Marshal(items)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write(itemsJSON); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := New("test-token")
+	client.httpClient.Transport = rewriteTransport{target: srv.URL}
+
+	_, err := FetchTranscript(context.Background(), client, "https://youtube.com/watch?v=abc")
+	if err == nil {
+		t.Fatal("expected error for empty transcript")
+	}
+	if !strings.Contains(err.Error(), "transcript is empty") {
+		t.Errorf("error = %q, want it to contain 'transcript is empty'", err)
+	}
+}
+
+func TestFetchTranscript_NilClient(t *testing.T) {
+	_, err := FetchTranscript(context.Background(), nil, "https://youtube.com/watch?v=abc")
+	if err == nil {
+		t.Fatal("expected error for nil client")
+	}
+}
+
+func TestFormatTranscript(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *TranscriptResult
+		want   string
+	}{
+		{
+			name: "full metadata",
+			result: &TranscriptResult{
+				Title:   "My Video",
+				Channel: "My Channel",
+				URL:     "https://youtube.com/watch?v=abc",
+				Content: "transcript text",
+			},
+			want: "# My Video\nChannel: My Channel | URL: https://youtube.com/watch?v=abc\n\ntranscript text",
+		},
+		{
+			name: "content only",
+			result: &TranscriptResult{
+				Content: "just the text",
+			},
+			want: "\njust the text",
+		},
+		{
+			name: "title and content",
+			result: &TranscriptResult{
+				Title:   "Title Only",
+				Content: "some text",
+			},
+			want: "# Title Only\n\nsome text",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatTranscript(tt.result)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,6 +100,9 @@ type Config struct {
 	VersionCoalesceMinutes int // minutes between version snapshots (default: 10)
 	VersionRetentionCount  int // max versions per document (default: 50)
 
+	// Apify
+	ApifyToken string // KNOW_APIFY_TOKEN — enables YouTube transcript tool
+
 	// TLS settings
 	TLSSkipVerify bool // skip TLS verification for Bedrock proxy (KNOW_TLS_SKIP_VERIFY)
 
@@ -233,6 +236,9 @@ func Load() Config {
 		// Versioning
 		VersionCoalesceMinutes: getEnvInt("KNOW_VERSION_COALESCE_MINUTES", 10),
 		VersionRetentionCount:  getEnvInt("KNOW_VERSION_RETENTION", 50),
+
+		// Apify
+		ApifyToken: getEnv("KNOW_APIFY_TOKEN", ""),
 
 		// TLS
 		TLSSkipVerify: getEnvBool("KNOW_TLS_SKIP_VERIFY", false),

--- a/internal/integration/mcp_http_test.go
+++ b/internal/integration/mcp_http_test.go
@@ -34,7 +34,7 @@ func setupMCPServer(t *testing.T, suffix string) (*httptest.Server, string, *fil
 		FileSvc: docSvc,
 	}
 
-	handler := mcptools.NewHandler(executor, testDB, vaultSvc, nil, nil)
+	handler := mcptools.NewHandler(executor, testDB, vaultSvc, nil, nil, nil)
 	wrappedHandler := auth.NoAuthMiddleware(handler)
 
 	srv := httptest.NewServer(wrappedHandler)

--- a/internal/mcptools/server.go
+++ b/internal/mcptools/server.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/raphi011/know/internal/apify"
 	"github.com/raphi011/know/internal/db"
 	"github.com/raphi011/know/internal/memory"
 	"github.com/raphi011/know/internal/remote"
@@ -17,13 +18,14 @@ import (
 // NewHandler creates the MCP HTTP handler that serves know tools at the
 // given path. Auth is handled externally via auth.Middleware wrapping this handler.
 // remoteService and memoryService may be nil if not configured.
-func NewHandler(executor tools.ToolExecutor, dbClient *db.Client, vaultService *vault.Service, remoteService *remote.Service, memoryService *memory.Service) http.Handler {
+func NewHandler(executor tools.ToolExecutor, dbClient *db.Client, vaultService *vault.Service, remoteService *remote.Service, memoryService *memory.Service, apifyClient *apify.Client) http.Handler {
 	t := &mcpTools{
 		executor:      executor,
 		db:            dbClient,
 		vaultService:  vaultService,
 		remoteService: remoteService,
 		memoryService: memoryService,
+		apifyClient:   apifyClient,
 		cache:         newCache(60 * time.Second),
 	}
 

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/raphi011/know/internal/apify"
 	"github.com/raphi011/know/internal/db"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/memory"
@@ -24,6 +25,7 @@ type mcpTools struct {
 	vaultService  *vault.Service
 	remoteService *remote.Service
 	memoryService *memory.Service
+	apifyClient   *apify.Client
 	cache         *cache
 }
 
@@ -131,6 +133,19 @@ func (t *mcpTools) register(server *mcp.Server) {
 		Description: "Toggle a task's status between open and done. Modifies the source markdown document (changes `- [ ]` to `- [x]` or vice versa). Use list_tasks to find task IDs.",
 		Annotations: writeNonDestructive,
 	}, t.toggleTask)
+
+	if t.apifyClient != nil {
+		openWorld := &mcp.ToolAnnotations{
+			ReadOnlyHint:    true,
+			DestructiveHint: new(false),
+			OpenWorldHint:   new(true),
+		}
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "fetch_youtube_transcript",
+			Description: "Fetch the transcript of a YouTube video. Accepts a YouTube URL or video ID. Returns the transcript text with video metadata.",
+			Annotations: openWorld,
+		}, t.fetchYouTubeTranscript)
+	}
 }
 
 // ---------- Read tool handlers (iterate all vaults) ----------
@@ -633,6 +648,26 @@ func (t *mcpTools) toggleTask(ctx context.Context, req *mcp.CallToolRequest, inp
 		return errorResult("task_id is required"), nil, nil
 	}
 	return t.executeWriteTool(ctx, "toggle_task", input.Vault, input)
+}
+
+// ---------- YouTube transcript handler ----------
+
+type fetchYouTubeTranscriptInput struct {
+	URL string `json:"url" jsonschema:"YouTube video URL (e.g. https://www.youtube.com/watch?v=...) or video ID"`
+}
+
+func (t *mcpTools) fetchYouTubeTranscript(ctx context.Context, req *mcp.CallToolRequest, input fetchYouTubeTranscriptInput) (*mcp.CallToolResult, any, error) {
+	if strings.TrimSpace(input.URL) == "" {
+		return errorResult("url is required"), nil, nil
+	}
+
+	result, err := apify.FetchTranscript(ctx, t.apifyClient, input.URL)
+	if err != nil {
+		logutil.FromCtx(ctx).Warn("fetch youtube transcript failed", "url", input.URL, "error", err)
+		return errorResult(fmt.Sprintf("failed to fetch transcript: %v", err)), nil, nil
+	}
+
+	return textResult(apify.FormatTranscript(result)), nil, nil
 }
 
 // ---------- helpers ----------

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/joho/godotenv"
 	"github.com/raphi011/know/internal/agent"
+	"github.com/raphi011/know/internal/apify"
 	"github.com/raphi011/know/internal/auth"
 	"github.com/raphi011/know/internal/config"
 	"github.com/raphi011/know/internal/db"
@@ -64,6 +65,7 @@ type App struct {
 	agentRunner              *agent.Runner
 	remoteService            *remote.Service
 	memoryService            *memory.Service
+	apifyClient              *apify.Client
 	bus                      *event.Bus
 	workerCancel             context.CancelFunc // guarded by mu
 	workerDone               chan struct{}      // guarded by mu
@@ -182,7 +184,11 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	}
 	vaultSvc := vault.NewService(dbClient)
 	agentTools := buildAgentTools(localExecutor, vaultSvc, remoteSvc)
-	agentSvc := agent.NewService(dbClient, model, agentTools, cfg.TavilyAPIKey)
+	var apifyClient *apify.Client
+	if cfg.ApifyToken != "" {
+		apifyClient = apify.New(cfg.ApifyToken)
+	}
+	agentSvc := agent.NewService(dbClient, model, agentTools, cfg.TavilyAPIKey, apifyClient)
 	agentRunner := agent.NewRunner(agentSvc, dbClient)
 	memorySvc := memory.NewService(dbClient, fileSvc, model)
 
@@ -197,6 +203,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		searchService:            searchSvc,
 		agentService:             agentSvc,
 		agentRunner:              agentRunner,
+		apifyClient:              apifyClient,
 		bus:                      bus,
 		workerDone:               embeddingWorkerDone,
 		processingWorkerDone:     processingWorkerDone,
@@ -280,6 +287,11 @@ func (a *App) RemoteService() *remote.Service {
 // MemoryService returns the memory service.
 func (a *App) MemoryService() *memory.Service {
 	return a.memoryService
+}
+
+// ApifyClient returns the Apify client, or nil if not configured.
+func (a *App) ApifyClient() *apify.Client {
+	return a.apifyClient
 }
 
 // NewForTest creates a minimal App for integration tests — no background workers,


### PR DESCRIPTION
Add a new `fetch_youtube_transcript` tool (both MCP and agent) that fetches YouTube video transcripts via the Apify API. Accepts any YouTube URL format or bare video ID and returns transcript text with metadata.

## New Features
- `fetch_youtube_transcript` MCP tool and agent tool for fetching YouTube video transcripts
- New `internal/apify` package with generic Apify API client and YouTube-specific transcript logic
- URL normalization supporting all YouTube URL formats (watch, shorts, embed, live, youtu.be, mobile, bare ID)
- Configurable via `KNOW_APIFY_TOKEN` env var — tool only registered when token is set

## Breaking Changes
- None