### PR TITLE
feat: respect .gitignore and skip dotfiles during import

### DIFF
--- a/cmd/know/cmd_import.go
+++ b/cmd/know/cmd_import.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -24,6 +25,7 @@ var (
 	importForce     bool
 	importRecursive bool
 	importYes       bool
+	importNoIgnore  bool
 )
 
 var importCmd = &cobra.Command{
@@ -41,13 +43,19 @@ Image files (PNG, JPEG, GIF, SVG, WebP) are uploaded as binary assets.
 By default only top-level files are imported from directories. Use -r to recurse
 into subdirectories. Archives are always imported recursively.
 
+When importing from a git repository, .gitignore rules are respected automatically.
+Files and directories ignored by git are skipped. When importing from a non-git
+directory, dotfiles (e.g. .DS_Store) and dot-directories (e.g. .obsidian/) are skipped.
+Use --no-ignore to disable all filtering and import everything.
+
 Examples:
   know import ./docs --vault default -r
   know import ./docs /imported --vault default -r
   know import ./notes /notes --vault default --labels personal,notes
   know import ./export.tar.gz --vault default
   know import ./export.tar.gz /restored --vault default --dry-run
-  know import ./docs /docs --vault default --force --yes`,
+  know import ./docs /docs --vault default --force --yes
+  know import ./vault /vault --vault default -r --no-ignore`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: runImport,
 }
@@ -61,6 +69,7 @@ func init() {
 	importCmd.Flags().BoolVar(&importForce, "force", false, "overwrite existing files if content hash differs")
 	importCmd.Flags().BoolVarP(&importRecursive, "recursive", "r", false, "recurse into subdirectories")
 	importCmd.Flags().BoolVarP(&importYes, "yes", "y", false, "skip confirmation prompt")
+	importCmd.Flags().BoolVar(&importNoIgnore, "no-ignore", false, "import all files, ignoring .gitignore rules and dotfile filtering")
 	if err := importCmd.MarkFlagRequired("vault"); err != nil {
 		panic(fmt.Sprintf("mark vault flag required: %v", err))
 	}
@@ -371,16 +380,123 @@ func collectArchiveEntries(archivePath string) ([]archiveEntry, int, error) {
 	return entries, skipped, nil
 }
 
-// collectImportFiles collects files from a directory. When recursive is false,
-// only top-level files are returned and the number of skipped subdirectories is reported.
-// Also counts skipped archive files (.tar.gz, .tgz).
+// collectImportFiles collects files from a directory, respecting ignore rules.
+//
+// When importNoIgnore is false (default), it tries git-based discovery first:
+// if the directory is inside a git repo, it uses `git ls-files` to list only
+// tracked and untracked-but-not-ignored files, respecting .gitignore rules.
+// If git is unavailable or the directory is not a git repo, it falls back to
+// filesystem walking with dot-prefix filtering (skipping .dotfiles and .dotdirs).
+//
+// When importNoIgnore is true, all files are included (only extension and archive filtering apply).
 func collectImportFiles(dirPath string, recursive bool) (files []string, skippedDirs, skippedArchives int, err error) {
+	if !importNoIgnore {
+		gitFiles, gitErr := collectGitFiles(dirPath, recursive)
+		if gitErr == nil {
+			fmt.Fprintf(os.Stderr, "Using .gitignore rules (use --no-ignore to include all files)\n")
+			// git ls-files doesn't distinguish dirs/archives — filter out archives from results.
+			var filtered []string
+			for _, f := range gitFiles {
+				if isArchiveFile(f) {
+					skippedArchives++
+					continue
+				}
+				filtered = append(filtered, f)
+			}
+			return filtered, 0, skippedArchives, nil
+		}
+		// Not a git repo or git unavailable — fall back to dotfile filtering.
+		fmt.Fprintf(os.Stderr, "Skipping dotfiles and dot-directories (use --no-ignore to include all files)\n")
+	}
+
+	return collectWalkFiles(dirPath, recursive, !importNoIgnore)
+}
+
+// collectGitFiles uses `git ls-files` to collect files from a git repository,
+// respecting .gitignore rules. Returns an error if the directory is not in a git
+// repo or git is not available.
+func collectGitFiles(dirPath string, recursive bool) ([]string, error) {
+	absDir, err := filepath.Abs(dirPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve path: %w", err)
+	}
+
+	// Resolve symlinks so absDir matches the repo root from git (which resolves
+	// symlinks). On macOS, /tmp → /private/tmp causes mismatches otherwise.
+	absDir, err = filepath.EvalSymlinks(absDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve symlinks: %w", err)
+	}
+
+	// Verify this is inside a git repo.
+	check := exec.Command("git", "-C", absDir, "rev-parse", "--show-toplevel")
+	if err := check.Run(); err != nil {
+		return nil, fmt.Errorf("not a git repo: %w", err)
+	}
+
+	// List tracked + untracked-but-not-ignored files.
+	// With -C absDir and absDir as pathspec, output is relative to absDir.
+	cmd := exec.Command("git", "-C", absDir, "ls-files", "--cached", "--others", "--exclude-standard", absDir)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git ls-files: %w", err)
+	}
+
+	var files []string
+	for line := range strings.SplitSeq(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// git ls-files with -C absDir returns paths relative to absDir.
+		absPath := line
+		if !filepath.IsAbs(line) {
+			absPath = filepath.Join(absDir, line)
+		}
+
+		// Skip files that no longer exist on disk (e.g. tracked but deleted).
+		if _, err := os.Stat(absPath); err != nil {
+			continue
+		}
+
+		if !isSupportedFile(absPath) {
+			continue
+		}
+
+		if !recursive {
+			// Only include direct children of dirPath.
+			rel, err := filepath.Rel(absDir, absPath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: skipping %s: %v\n", absPath, err)
+				continue
+			}
+			if strings.Contains(rel, string(filepath.Separator)) {
+				continue
+			}
+		}
+
+		files = append(files, absPath)
+	}
+
+	return files, nil
+}
+
+// collectWalkFiles collects files by walking the filesystem. When skipDot is true,
+// directories and files starting with "." are skipped.
+func collectWalkFiles(dirPath string, recursive, skipDot bool) (files []string, skippedDirs, skippedArchives int, err error) {
 	if !recursive {
 		entries, err := os.ReadDir(dirPath)
 		if err != nil {
 			return nil, 0, 0, fmt.Errorf("read directory: %w", err)
 		}
 		for _, e := range entries {
+			if skipDot && strings.HasPrefix(e.Name(), ".") {
+				if e.IsDir() {
+					skippedDirs++
+				}
+				continue
+			}
 			if e.IsDir() {
 				skippedDirs++
 				continue
@@ -401,6 +517,13 @@ func collectImportFiles(dirPath string, recursive bool) (files []string, skipped
 			return err
 		}
 		if d.IsDir() {
+			if skipDot && d.Name() != "." && strings.HasPrefix(d.Name(), ".") {
+				skippedDirs++
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if skipDot && strings.HasPrefix(d.Name(), ".") {
 			return nil
 		}
 		if isArchiveFile(path) {
@@ -415,7 +538,7 @@ func collectImportFiles(dirPath string, recursive bool) (files []string, skipped
 	if err != nil {
 		return nil, 0, 0, fmt.Errorf("scan directory: %w", err)
 	}
-	return files, 0, skippedArchives, nil
+	return files, skippedDirs, skippedArchives, nil
 }
 
 func isSupportedFile(path string) bool {

--- a/cmd/know/cmd_import_test.go
+++ b/cmd/know/cmd_import_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -232,6 +233,355 @@ func TestCollectArchiveEntries_CorruptFile(t *testing.T) {
 	_, _, err := collectArchiveEntries(path)
 	if err == nil {
 		t.Fatal("expected error for corrupt file, got nil")
+	}
+}
+
+// initGitRepo creates a git repo in dir with the given files committed,
+// plus an optional .gitignore.
+func initGitRepo(t *testing.T, dir string, files map[string]string, gitignore string) {
+	t.Helper()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+
+	if gitignore != "" {
+		writeFile(t, filepath.Join(dir, ".gitignore"), gitignore)
+	}
+
+	for path, content := range files {
+		abs := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, abs, content)
+	}
+
+	run("git", "add", "-A")
+	run("git", "commit", "-m", "init", "--no-gpg-sign")
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCollectImportFiles_GitIgnore(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir, map[string]string{
+		"notes/hello.md":  "# Hello",
+		"notes/world.md":  "# World",
+		"images/logo.png": "png-data",
+	}, "ignored/\n")
+
+	// Add an ignored directory with a markdown file after commit.
+	ignoredDir := filepath.Join(dir, "ignored")
+	if err := os.MkdirAll(ignoredDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(ignoredDir, "skip.md"), "# Skipped")
+
+	oldNoIgnore := importNoIgnore
+	importNoIgnore = false
+	defer func() { importNoIgnore = oldNoIgnore }()
+
+	files, _, _, err := collectImportFiles(dir, true)
+	if err != nil {
+		t.Fatalf("collectImportFiles: %v", err)
+	}
+
+	// Should include hello.md, world.md, logo.png — NOT skip.md
+	if got := len(files); got != 3 {
+		names := make([]string, len(files))
+		for i, f := range files {
+			names[i] = filepath.Base(f)
+		}
+		t.Fatalf("expected 3 files, got %d: %v", got, names)
+	}
+
+	for _, f := range files {
+		if filepath.Base(f) == "skip.md" {
+			t.Error("gitignored file skip.md should not be included")
+		}
+	}
+}
+
+func TestCollectImportFiles_GitTrackedDotfile(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir, map[string]string{
+		"notes/hello.md":          "# Hello",
+		".special/tracked-dot.md": "# Tracked dotfile",
+	}, "")
+
+	oldNoIgnore := importNoIgnore
+	importNoIgnore = false
+	defer func() { importNoIgnore = oldNoIgnore }()
+
+	files, _, _, err := collectImportFiles(dir, true)
+	if err != nil {
+		t.Fatalf("collectImportFiles: %v", err)
+	}
+
+	// Git tracks .special/tracked-dot.md, so it should be included.
+	var found bool
+	for _, f := range files {
+		if filepath.Base(f) == "tracked-dot.md" {
+			found = true
+		}
+	}
+	if !found {
+		names := make([]string, len(files))
+		for i, f := range files {
+			names[i] = f
+		}
+		t.Fatalf("tracked dotfile should be included, got: %v", names)
+	}
+}
+
+func TestCollectImportFiles_NonGitSkipsDotfiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create files without git init.
+	for path, content := range map[string]string{
+		"notes/hello.md":           "# Hello",
+		".obsidian/templates/d.md": "# Template",
+		".hidden.md":               "# Hidden",
+	} {
+		abs := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, abs, content)
+	}
+
+	oldNoIgnore := importNoIgnore
+	importNoIgnore = false
+	defer func() { importNoIgnore = oldNoIgnore }()
+
+	files, _, _, err := collectImportFiles(dir, true)
+	if err != nil {
+		t.Fatalf("collectImportFiles: %v", err)
+	}
+
+	if got := len(files); got != 1 {
+		names := make([]string, len(files))
+		for i, f := range files {
+			names[i] = f
+		}
+		t.Fatalf("expected 1 file (hello.md), got %d: %v", got, names)
+	}
+	if filepath.Base(files[0]) != "hello.md" {
+		t.Errorf("expected hello.md, got %s", filepath.Base(files[0]))
+	}
+}
+
+func TestCollectImportFiles_NoIgnoreIncludesAll(t *testing.T) {
+	dir := t.TempDir()
+
+	for path, content := range map[string]string{
+		"notes/hello.md":           "# Hello",
+		".obsidian/templates/d.md": "# Template",
+		".hidden.md":               "# Hidden",
+	} {
+		abs := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, abs, content)
+	}
+
+	importNoIgnore = true
+	defer func() { importNoIgnore = false }()
+
+	files, _, _, err := collectImportFiles(dir, true)
+	if err != nil {
+		t.Fatalf("collectImportFiles: %v", err)
+	}
+
+	// Should include all 3 markdown files.
+	if got := len(files); got != 3 {
+		names := make([]string, len(files))
+		for i, f := range files {
+			names[i] = f
+		}
+		t.Fatalf("expected 3 files, got %d: %v", got, names)
+	}
+}
+
+func TestCollectImportFiles_GitNonRecursive(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir, map[string]string{
+		"top.md":           "# Top",
+		"sub/nested.md":    "# Nested",
+		"sub/deep/deep.md": "# Deep",
+	}, "")
+
+	oldNoIgnore := importNoIgnore
+	importNoIgnore = false
+	defer func() { importNoIgnore = oldNoIgnore }()
+
+	files, _, _, err := collectImportFiles(dir, false)
+	if err != nil {
+		t.Fatalf("collectImportFiles: %v", err)
+	}
+
+	// Non-recursive: only top.md.
+	if got := len(files); got != 1 {
+		names := make([]string, len(files))
+		for i, f := range files {
+			names[i] = f
+		}
+		t.Fatalf("expected 1 file (top.md), got %d: %v", got, names)
+	}
+	if filepath.Base(files[0]) != "top.md" {
+		t.Errorf("expected top.md, got %s", filepath.Base(files[0]))
+	}
+}
+
+func TestCollectImportFiles_NoIgnoreInGitRepo(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir, map[string]string{
+		"hello.md": "# Hello",
+	}, "ignored/\n")
+
+	// Add an ignored directory with a markdown file.
+	ignoredDir := filepath.Join(dir, "ignored")
+	if err := os.MkdirAll(ignoredDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(ignoredDir, "secret.md"), "# Secret")
+
+	oldNoIgnore := importNoIgnore
+	importNoIgnore = true
+	defer func() { importNoIgnore = oldNoIgnore }()
+
+	files, _, _, err := collectImportFiles(dir, true)
+	if err != nil {
+		t.Fatalf("collectImportFiles: %v", err)
+	}
+
+	// --no-ignore should include the gitignored file.
+	if got := len(files); got != 2 {
+		names := make([]string, len(files))
+		for i, f := range files {
+			names[i] = filepath.Base(f)
+		}
+		t.Fatalf("expected 2 files (hello.md, secret.md), got %d: %v", got, names)
+	}
+}
+
+func TestCollectImportFiles_GitUntrackedFile(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir, map[string]string{
+		"committed.md": "# Committed",
+	}, "")
+
+	// Add an untracked file after commit — should be included.
+	writeFile(t, filepath.Join(dir, "untracked.md"), "# Untracked")
+
+	oldNoIgnore := importNoIgnore
+	importNoIgnore = false
+	defer func() { importNoIgnore = oldNoIgnore }()
+
+	files, _, _, err := collectImportFiles(dir, true)
+	if err != nil {
+		t.Fatalf("collectImportFiles: %v", err)
+	}
+
+	if got := len(files); got != 2 {
+		names := make([]string, len(files))
+		for i, f := range files {
+			names[i] = filepath.Base(f)
+		}
+		t.Fatalf("expected 2 files (committed.md, untracked.md), got %d: %v", got, names)
+	}
+}
+
+func TestCollectImportFiles_GitSubdirectory(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir, map[string]string{
+		"top.md":           "# Top",
+		"sub/nested.md":    "# Nested",
+		"sub/deep/deep.md": "# Deep",
+		"other/other.md":   "# Other",
+	}, "")
+
+	// Import only the sub/ directory.
+	subDir := filepath.Join(dir, "sub")
+
+	oldNoIgnore := importNoIgnore
+	importNoIgnore = false
+	defer func() { importNoIgnore = oldNoIgnore }()
+
+	files, _, _, err := collectImportFiles(subDir, true)
+	if err != nil {
+		t.Fatalf("collectImportFiles: %v", err)
+	}
+
+	// Should include nested.md and deep.md — NOT top.md or other.md.
+	if got := len(files); got != 2 {
+		names := make([]string, len(files))
+		for i, f := range files {
+			names[i] = filepath.Base(f)
+		}
+		t.Fatalf("expected 2 files (nested.md, deep.md), got %d: %v", got, names)
+	}
+
+	for _, f := range files {
+		base := filepath.Base(f)
+		if base != "nested.md" && base != "deep.md" {
+			t.Errorf("unexpected file: %s", f)
+		}
+	}
+}
+
+func TestCollectImportFiles_NonGitNonRecursiveSkipsDotfiles(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, filepath.Join(dir, "visible.md"), "# Visible")
+	writeFile(t, filepath.Join(dir, ".hidden.md"), "# Hidden")
+	if err := os.MkdirAll(filepath.Join(dir, ".dotdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "subdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldNoIgnore := importNoIgnore
+	importNoIgnore = false
+	defer func() { importNoIgnore = oldNoIgnore }()
+
+	files, skippedDirs, _, err := collectImportFiles(dir, false)
+	if err != nil {
+		t.Fatalf("collectImportFiles: %v", err)
+	}
+
+	// Should include only visible.md.
+	if got := len(files); got != 1 {
+		names := make([]string, len(files))
+		for i, f := range files {
+			names[i] = filepath.Base(f)
+		}
+		t.Fatalf("expected 1 file (visible.md), got %d: %v", got, names)
+	}
+	if filepath.Base(files[0]) != "visible.md" {
+		t.Errorf("expected visible.md, got %s", filepath.Base(files[0]))
+	}
+	// .dotdir and subdir should both be counted as skipped.
+	if skippedDirs != 2 {
+		t.Errorf("expected 2 skipped dirs (.dotdir + subdir), got %d", skippedDirs)
 	}
 }
 


### PR DESCRIPTION
When importing from a git repository, use `git ls-files` to respect .gitignore rules automatically. For non-git directories, skip dotfiles and dot-directories (e.g. `.obsidian/`, `.DS_Store`). Add `--no-ignore` flag to bypass all filtering and import everything.

## New Features
- Git-aware import: respects `.gitignore` rules when importing from a git repo
- Dotfile filtering: skips `.dotfiles` and `.dotdirs` in non-git directories
- `--no-ignore` flag: disables all filtering for full import
- Stderr feedback: always shows which filtering mode is active

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)