### PR TITLE
feat: per-vault configurable search and versioning settings

### DIFF
--- a/cmd/know/cmd_vault_settings.go
+++ b/cmd/know/cmd_vault_settings.go
@@ -35,6 +35,12 @@ Valid keys:
   memory_decay_half_life   days until memory score halves (default: 30)
   template_path            folder for templates (default: /templates)
   daily_note_path          folder for daily notes (default: /daily)
+  rrf_k                    RRF K parameter for hybrid search (default: 60)
+  hnsw_ef                  HNSW EF parameter for vector search (default: 40)
+  default_search_limit     default number of search results (default: 20)
+  max_search_limit         maximum search result limit (default: 100)
+  version_coalesce_minutes minutes between version snapshots (default: 10)
+  version_retention_count  max versions per file (default: 50)
 
 Environment variables:
   KNOW_VAULT    vault name (alternative to --vault flag)`,
@@ -112,6 +118,42 @@ func parseSettingsPatch(pairs []string) (models.VaultSettings, error) {
 				return s, fmt.Errorf("invalid value for %s: %w", key, err)
 			}
 			s.MemoryDecayHalfLife = v
+		case "rrf_k":
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return s, fmt.Errorf("invalid value for %s: %w", key, err)
+			}
+			s.RRFK = v
+		case "hnsw_ef":
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return s, fmt.Errorf("invalid value for %s: %w", key, err)
+			}
+			s.HNSWEF = v
+		case "default_search_limit":
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return s, fmt.Errorf("invalid value for %s: %w", key, err)
+			}
+			s.DefaultSearchLimit = v
+		case "max_search_limit":
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return s, fmt.Errorf("invalid value for %s: %w", key, err)
+			}
+			s.MaxSearchLimit = v
+		case "version_coalesce_minutes":
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return s, fmt.Errorf("invalid value for %s: %w", key, err)
+			}
+			s.VersionCoalesceMinutes = v
+		case "version_retention_count":
+			v, err := strconv.Atoi(value)
+			if err != nil {
+				return s, fmt.Errorf("invalid value for %s: %w", key, err)
+			}
+			s.VersionRetentionCount = v
 		default:
 			return s, fmt.Errorf("unknown setting %q", key)
 		}
@@ -129,11 +171,17 @@ func printSettings(s *models.VaultSettings) error {
 		return nil
 	}
 
-	fmt.Printf("%-25s %s\n", "memory_path:", s.MemoryPath)
-	fmt.Printf("%-25s %.2f\n", "memory_merge_threshold:", s.MemoryMergeThreshold)
-	fmt.Printf("%-25s %.2f\n", "memory_archive_threshold:", s.MemoryArchiveThreshold)
-	fmt.Printf("%-25s %d\n", "memory_decay_half_life:", s.MemoryDecayHalfLife)
-	fmt.Printf("%-25s %s\n", "template_path:", s.TemplatePath)
-	fmt.Printf("%-25s %s\n", "daily_note_path:", s.DailyNotePath)
+	fmt.Printf("%-30s %s\n", "memory_path:", s.MemoryPath)
+	fmt.Printf("%-30s %.2f\n", "memory_merge_threshold:", s.MemoryMergeThreshold)
+	fmt.Printf("%-30s %.2f\n", "memory_archive_threshold:", s.MemoryArchiveThreshold)
+	fmt.Printf("%-30s %d\n", "memory_decay_half_life:", s.MemoryDecayHalfLife)
+	fmt.Printf("%-30s %s\n", "template_path:", s.TemplatePath)
+	fmt.Printf("%-30s %s\n", "daily_note_path:", s.DailyNotePath)
+	fmt.Printf("%-30s %d\n", "rrf_k:", s.RRFK)
+	fmt.Printf("%-30s %d\n", "hnsw_ef:", s.HNSWEF)
+	fmt.Printf("%-30s %d\n", "default_search_limit:", s.DefaultSearchLimit)
+	fmt.Printf("%-30s %d\n", "max_search_limit:", s.MaxSearchLimit)
+	fmt.Printf("%-30s %d\n", "version_coalesce_minutes:", s.VersionCoalesceMinutes)
+	fmt.Printf("%-30s %d\n", "version_retention_count:", s.VersionRetentionCount)
 	return nil
 }

--- a/internal/db/queries_search.go
+++ b/internal/db/queries_search.go
@@ -17,6 +17,8 @@ type SearchFilter struct {
 	DocType *string
 	Folder  *string
 	Limit   int
+	RRFK    int // RRF K parameter (0 = use models.DefaultRRFK)
+	HNSWEF  int // HNSW EF parameter (0 = use models.DefaultHNSWEF)
 }
 
 type ChunkWithScore struct {
@@ -60,7 +62,7 @@ func (c *Client) BM25ChunkSearch(ctx context.Context, query string, filter Searc
 	defer c.logOp(ctx, "search.bm25", time.Now())
 	limit := filter.Limit
 	if limit <= 0 {
-		limit = 20
+		limit = models.DefaultSearchLimit
 	}
 
 	conditions, vars := buildChunkFilterConditions(filter)
@@ -94,7 +96,7 @@ func (c *Client) HybridSearch(ctx context.Context, query string, embedding []flo
 	defer c.logOp(ctx, "search.hybrid", time.Now())
 	limit := filter.Limit
 	if limit <= 0 {
-		limit = 20
+		limit = models.DefaultSearchLimit
 	}
 
 	conditions, vars := buildChunkFilterConditions(filter)
@@ -102,6 +104,15 @@ func (c *Client) HybridSearch(ctx context.Context, query string, embedding []flo
 	vars["embedding"] = embedding
 
 	whereClause := strings.Join(conditions, " AND ")
+
+	hnswEF := filter.HNSWEF
+	if hnswEF <= 0 {
+		hnswEF = models.DefaultHNSWEF
+	}
+	rrfK := filter.RRFK
+	if rrfK <= 0 {
+		rrfK = models.DefaultRRFK
+	}
 
 	// LET variables don't work with search::rrf() (return None) — subqueries must be inlined.
 	// ORDER BY is omitted: BM25 @1@ returns results in relevance order, and <|K,EF|> returns
@@ -119,10 +130,10 @@ func (c *Client) HybridSearch(ctx context.Context, query string, embedding []flo
 			 LIMIT %d),
 			(SELECT * FROM chunk
 			 WHERE %s
-			   AND embedding <|%d,40|> $embedding
+			   AND embedding <|%d,%d|> $embedding
 			 LIMIT %d)
-		], %d, 60)
-	`, whereClause, limit, whereClause, limit, limit, limit)
+		], %d, %d)
+	`, whereClause, limit, whereClause, limit, hnswEF, limit, limit, rrfK)
 
 	results, err := surrealdb.Query[[]ChunkWithScore](ctx, c.DB(), sql, vars)
 	if err != nil {

--- a/internal/file/version.go
+++ b/internal/file/version.go
@@ -9,6 +9,29 @@ import (
 	"github.com/raphi011/know/internal/models"
 )
 
+// resolveVersionConfig returns a VersionConfig that uses vault-specific overrides
+// when explicitly set, falling back to the service-wide defaults.
+// Checks raw vault.Settings (not Defaults()) so that hardcoded model defaults
+// don't override the service-level config from env vars.
+func (s *Service) resolveVersionConfig(ctx context.Context, vaultID string) VersionConfig {
+	vc := s.versionConfig
+	vault, err := s.db.GetVault(ctx, vaultID)
+	if err != nil {
+		logutil.FromCtx(ctx).Warn("failed to load vault for version config, using defaults", "vault_id", vaultID, "error", err)
+		return vc
+	}
+	if vault.Settings == nil {
+		return vc
+	}
+	if vault.Settings.VersionCoalesceMinutes > 0 {
+		vc.CoalesceMinutes = vault.Settings.VersionCoalesceMinutes
+	}
+	if vault.Settings.VersionRetentionCount > 0 {
+		vc.RetentionCount = vault.Settings.VersionRetentionCount
+	}
+	return vc
+}
+
 // maybeCreateVersion snapshots the old file content as a version if the
 // coalescing window has elapsed and the content actually changed.
 func (s *Service) maybeCreateVersion(ctx context.Context, fileID, vaultID string, oldFile *models.File, newContentHash string) {
@@ -19,15 +42,17 @@ func (s *Service) maybeCreateVersion(ctx context.Context, fileID, vaultID string
 		return
 	}
 
+	vc := s.resolveVersionConfig(ctx, vaultID)
+
 	// Coalescing: skip version if last one is too recent (0 = disabled)
-	if s.versionConfig.CoalesceMinutes > 0 {
+	if vc.CoalesceMinutes > 0 {
 		latest, err := s.db.GetLatestVersion(ctx, fileID)
 		if err != nil {
 			logger.Warn("failed to check latest version for coalescing", "file_id", fileID, "error", err)
 			return
 		}
 		if latest != nil {
-			threshold := time.Now().Add(-time.Duration(s.versionConfig.CoalesceMinutes) * time.Minute)
+			threshold := time.Now().Add(-time.Duration(vc.CoalesceMinutes) * time.Minute)
 			if latest.CreatedAt.After(threshold) {
 				return
 			}
@@ -57,13 +82,13 @@ func (s *Service) maybeCreateVersion(ctx context.Context, fileID, vaultID string
 	logger.Info("created version snapshot", "file_id", fileID, "version", nextVersion)
 
 	// Enforce retention cap
-	s.enforceRetention(ctx, fileID)
+	s.enforceRetention(ctx, fileID, vc)
 }
 
 // enforceRetention deletes versions beyond the retention cap.
-func (s *Service) enforceRetention(ctx context.Context, fileID string) {
+func (s *Service) enforceRetention(ctx context.Context, fileID string, vc VersionConfig) {
 	logger := logutil.FromCtx(ctx)
-	deleted, err := s.db.DeleteOldestVersions(ctx, fileID, s.versionConfig.RetentionCount)
+	deleted, err := s.db.DeleteOldestVersions(ctx, fileID, vc.RetentionCount)
 	if err != nil {
 		logger.Warn("failed to enforce version retention", "file_id", fileID, "error", err)
 		return

--- a/internal/models/vault.go
+++ b/internal/models/vault.go
@@ -25,6 +25,16 @@ type VaultSettings struct {
 	MemoryDecayHalfLife    int     `json:"memory_decay_half_life,omitempty"`
 	TemplatePath           string  `json:"template_path,omitempty"`
 	DailyNotePath          string  `json:"daily_note_path,omitempty"`
+
+	// Search tuning
+	RRFK               int `json:"rrf_k,omitempty"`
+	HNSWEF             int `json:"hnsw_ef,omitempty"`
+	DefaultSearchLimit int `json:"default_search_limit,omitempty"`
+	MaxSearchLimit     int `json:"max_search_limit,omitempty"`
+
+	// Versioning
+	VersionCoalesceMinutes int `json:"version_coalesce_minutes,omitempty"`
+	VersionRetentionCount  int `json:"version_retention_count,omitempty"`
 }
 
 const (
@@ -40,6 +50,18 @@ const (
 	DefaultMemoryArchiveThreshold = 0.2
 	// DefaultMemoryDecayHalfLife is the half-life in days for memory recency decay.
 	DefaultMemoryDecayHalfLife = 30
+	// DefaultRRFK is the default RRF K parameter for hybrid search fusion.
+	DefaultRRFK = 60
+	// DefaultHNSWEF is the default HNSW EF parameter for vector search.
+	DefaultHNSWEF = 40
+	// DefaultSearchLimit is the default number of search results.
+	DefaultSearchLimit = 20
+	// DefaultMaxSearchLimit is the maximum allowed search result limit.
+	DefaultMaxSearchLimit = 100
+	// DefaultVersionCoalesceMinutes is the default coalescing window for version snapshots.
+	DefaultVersionCoalesceMinutes = 10
+	// DefaultVersionRetentionCount is the default max versions per file.
+	DefaultVersionRetentionCount = 50
 )
 
 // Validate checks that all non-zero fields in VaultSettings are within valid ranges.
@@ -52,6 +74,27 @@ func (s VaultSettings) Validate() error {
 	}
 	if s.MemoryDecayHalfLife < 0 {
 		return fmt.Errorf("memory_decay_half_life must be non-negative, got %d", s.MemoryDecayHalfLife)
+	}
+	if s.RRFK < 0 {
+		return fmt.Errorf("rrf_k must be non-negative, got %d", s.RRFK)
+	}
+	if s.HNSWEF < 0 {
+		return fmt.Errorf("hnsw_ef must be non-negative, got %d", s.HNSWEF)
+	}
+	if s.DefaultSearchLimit < 0 {
+		return fmt.Errorf("default_search_limit must be non-negative, got %d", s.DefaultSearchLimit)
+	}
+	if s.MaxSearchLimit < 0 {
+		return fmt.Errorf("max_search_limit must be non-negative, got %d", s.MaxSearchLimit)
+	}
+	if s.DefaultSearchLimit > 0 && s.MaxSearchLimit > 0 && s.DefaultSearchLimit > s.MaxSearchLimit {
+		return fmt.Errorf("default_search_limit (%d) must not exceed max_search_limit (%d)", s.DefaultSearchLimit, s.MaxSearchLimit)
+	}
+	if s.VersionCoalesceMinutes < 0 {
+		return fmt.Errorf("version_coalesce_minutes must be non-negative, got %d", s.VersionCoalesceMinutes)
+	}
+	if s.VersionRetentionCount < 0 {
+		return fmt.Errorf("version_retention_count must be non-negative, got %d", s.VersionRetentionCount)
 	}
 	return nil
 }
@@ -76,6 +119,24 @@ func (s VaultSettings) Merge(patch VaultSettings) VaultSettings {
 	if patch.DailyNotePath != "" {
 		s.DailyNotePath = patch.DailyNotePath
 	}
+	if patch.RRFK > 0 {
+		s.RRFK = patch.RRFK
+	}
+	if patch.HNSWEF > 0 {
+		s.HNSWEF = patch.HNSWEF
+	}
+	if patch.DefaultSearchLimit > 0 {
+		s.DefaultSearchLimit = patch.DefaultSearchLimit
+	}
+	if patch.MaxSearchLimit > 0 {
+		s.MaxSearchLimit = patch.MaxSearchLimit
+	}
+	if patch.VersionCoalesceMinutes > 0 {
+		s.VersionCoalesceMinutes = patch.VersionCoalesceMinutes
+	}
+	if patch.VersionRetentionCount > 0 {
+		s.VersionRetentionCount = patch.VersionRetentionCount
+	}
 	return s
 }
 
@@ -88,6 +149,12 @@ func (v *Vault) Defaults() VaultSettings {
 		MemoryDecayHalfLife:    DefaultMemoryDecayHalfLife,
 		TemplatePath:           DefaultTemplatePath,
 		DailyNotePath:          DefaultDailyNotePath,
+		RRFK:                   DefaultRRFK,
+		HNSWEF:                 DefaultHNSWEF,
+		DefaultSearchLimit:     DefaultSearchLimit,
+		MaxSearchLimit:         DefaultMaxSearchLimit,
+		VersionCoalesceMinutes: DefaultVersionCoalesceMinutes,
+		VersionRetentionCount:  DefaultVersionRetentionCount,
 	}
 	if v.Settings == nil {
 		return s

--- a/internal/models/vault_test.go
+++ b/internal/models/vault_test.go
@@ -45,6 +45,24 @@ func TestVaultDefaults(t *testing.T) {
 		if d.MemoryArchiveThreshold != 0.2 {
 			t.Errorf("MemoryArchiveThreshold = %f, want 0.2", d.MemoryArchiveThreshold)
 		}
+		if d.RRFK != DefaultRRFK {
+			t.Errorf("RRFK = %d, want %d", d.RRFK, DefaultRRFK)
+		}
+		if d.HNSWEF != DefaultHNSWEF {
+			t.Errorf("HNSWEF = %d, want %d", d.HNSWEF, DefaultHNSWEF)
+		}
+		if d.DefaultSearchLimit != DefaultSearchLimit {
+			t.Errorf("DefaultSearchLimit = %d, want %d", d.DefaultSearchLimit, DefaultSearchLimit)
+		}
+		if d.MaxSearchLimit != DefaultMaxSearchLimit {
+			t.Errorf("MaxSearchLimit = %d, want %d", d.MaxSearchLimit, DefaultMaxSearchLimit)
+		}
+		if d.VersionCoalesceMinutes != DefaultVersionCoalesceMinutes {
+			t.Errorf("VersionCoalesceMinutes = %d, want %d", d.VersionCoalesceMinutes, DefaultVersionCoalesceMinutes)
+		}
+		if d.VersionRetentionCount != DefaultVersionRetentionCount {
+			t.Errorf("VersionRetentionCount = %d, want %d", d.VersionRetentionCount, DefaultVersionRetentionCount)
+		}
 	})
 
 	t.Run("custom settings override defaults", func(t *testing.T) {
@@ -55,6 +73,12 @@ func TestVaultDefaults(t *testing.T) {
 			MemoryDecayHalfLife:    60,
 			MemoryMergeThreshold:   0.8,
 			MemoryArchiveThreshold: 0.1,
+			RRFK:                   80,
+			HNSWEF:                 60,
+			DefaultSearchLimit:     10,
+			MaxSearchLimit:         50,
+			VersionCoalesceMinutes: 5,
+			VersionRetentionCount:  25,
 		}}
 		d := v.Defaults()
 		if d.MemoryPath != "/custom-mem" {
@@ -74,6 +98,24 @@ func TestVaultDefaults(t *testing.T) {
 		}
 		if d.MemoryArchiveThreshold != 0.1 {
 			t.Errorf("MemoryArchiveThreshold = %f, want 0.1", d.MemoryArchiveThreshold)
+		}
+		if d.RRFK != 80 {
+			t.Errorf("RRFK = %d, want 80", d.RRFK)
+		}
+		if d.HNSWEF != 60 {
+			t.Errorf("HNSWEF = %d, want 60", d.HNSWEF)
+		}
+		if d.DefaultSearchLimit != 10 {
+			t.Errorf("DefaultSearchLimit = %d, want 10", d.DefaultSearchLimit)
+		}
+		if d.MaxSearchLimit != 50 {
+			t.Errorf("MaxSearchLimit = %d, want 50", d.MaxSearchLimit)
+		}
+		if d.VersionCoalesceMinutes != 5 {
+			t.Errorf("VersionCoalesceMinutes = %d, want 5", d.VersionCoalesceMinutes)
+		}
+		if d.VersionRetentionCount != 25 {
+			t.Errorf("VersionRetentionCount = %d, want 25", d.VersionRetentionCount)
 		}
 	})
 
@@ -124,6 +166,19 @@ func TestVaultSettingsValidate(t *testing.T) {
 		{"zero decay half life", VaultSettings{MemoryDecayHalfLife: 0}, false},
 		{"boundary merge threshold 0", VaultSettings{MemoryMergeThreshold: 0}, false},
 		{"boundary merge threshold 1", VaultSettings{MemoryMergeThreshold: 1}, false},
+		{"valid search settings", VaultSettings{RRFK: 80, HNSWEF: 60, DefaultSearchLimit: 10, MaxSearchLimit: 50}, false},
+		{"negative rrf_k", VaultSettings{RRFK: -1}, true},
+		{"negative hnsw_ef", VaultSettings{HNSWEF: -1}, true},
+		{"negative default_search_limit", VaultSettings{DefaultSearchLimit: -1}, true},
+		{"negative max_search_limit", VaultSettings{MaxSearchLimit: -1}, true},
+		{"default exceeds max search limit", VaultSettings{DefaultSearchLimit: 200, MaxSearchLimit: 100}, true},
+		{"default equals max search limit", VaultSettings{DefaultSearchLimit: 100, MaxSearchLimit: 100}, false},
+		{"only default set", VaultSettings{DefaultSearchLimit: 50}, false},
+		{"only max set", VaultSettings{MaxSearchLimit: 50}, false},
+		{"negative coalesce minutes", VaultSettings{VersionCoalesceMinutes: -1}, true},
+		{"zero coalesce minutes", VaultSettings{VersionCoalesceMinutes: 0}, false},
+		{"negative retention count", VaultSettings{VersionRetentionCount: -1}, true},
+		{"valid version settings", VaultSettings{VersionCoalesceMinutes: 5, VersionRetentionCount: 25}, false},
 	}
 
 	for _, tt := range tests {
@@ -144,6 +199,12 @@ func TestVaultSettingsMerge(t *testing.T) {
 		MemoryDecayHalfLife:    30,
 		TemplatePath:           "/templates",
 		DailyNotePath:          "/daily",
+		RRFK:                   60,
+		HNSWEF:                 40,
+		DefaultSearchLimit:     20,
+		MaxSearchLimit:         100,
+		VersionCoalesceMinutes: 10,
+		VersionRetentionCount:  50,
 	}
 
 	t.Run("empty patch changes nothing", func(t *testing.T) {
@@ -167,6 +228,34 @@ func TestVaultSettingsMerge(t *testing.T) {
 		// Unchanged fields preserved
 		if got.TemplatePath != "/templates" {
 			t.Errorf("TemplatePath = %q, want /templates", got.TemplatePath)
+		}
+	})
+
+	t.Run("patch overrides search and version fields", func(t *testing.T) {
+		got := base.Merge(VaultSettings{
+			RRFK:                   80,
+			HNSWEF:                 60,
+			DefaultSearchLimit:     10,
+			VersionCoalesceMinutes: 5,
+		})
+		if got.RRFK != 80 {
+			t.Errorf("RRFK = %d, want 80", got.RRFK)
+		}
+		if got.HNSWEF != 60 {
+			t.Errorf("HNSWEF = %d, want 60", got.HNSWEF)
+		}
+		if got.DefaultSearchLimit != 10 {
+			t.Errorf("DefaultSearchLimit = %d, want 10", got.DefaultSearchLimit)
+		}
+		if got.VersionCoalesceMinutes != 5 {
+			t.Errorf("VersionCoalesceMinutes = %d, want 5", got.VersionCoalesceMinutes)
+		}
+		// Unchanged fields preserved
+		if got.MaxSearchLimit != 100 {
+			t.Errorf("MaxSearchLimit = %d, want 100", got.MaxSearchLimit)
+		}
+		if got.VersionRetentionCount != 50 {
+			t.Errorf("VersionRetentionCount = %d, want 50", got.VersionRetentionCount)
 		}
 	})
 }

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -85,18 +85,31 @@ func truncateSnippet(s string, maxLen int) string {
 	return string(runes[:cut]) + "…"
 }
 
-const maxLimit = 100
-
 // Search performs search with graceful degradation.
 // With embedder: hybrid search via SurrealDB's search::rrf() (BM25 + vector, fused in DB).
 // Without embedder: BM25-only chunk search.
 func (s *Service) Search(ctx context.Context, input SearchInput) ([]SearchResult, error) {
+	// Load vault settings for per-vault search tuning. If the vault lookup fails,
+	// fall back to model defaults — the subsequent search query may still succeed,
+	// and using default tuning params is better than blocking search entirely.
+	vault, err := s.db.GetVault(ctx, input.VaultID)
+	if err != nil {
+		logutil.FromCtx(ctx).Warn("failed to load vault settings for search, using defaults",
+			"vault_id", input.VaultID, "error", err)
+	}
+	var settings models.VaultSettings
+	if vault != nil {
+		settings = vault.Defaults()
+	} else {
+		settings = (&models.Vault{}).Defaults()
+	}
+
 	limit := input.Limit
 	if limit <= 0 {
-		limit = 20
+		limit = settings.DefaultSearchLimit
 	}
-	if limit > maxLimit {
-		limit = maxLimit
+	if limit > settings.MaxSearchLimit {
+		limit = settings.MaxSearchLimit
 	}
 
 	filter := db.SearchFilter{
@@ -105,6 +118,8 @@ func (s *Service) Search(ctx context.Context, input SearchInput) ([]SearchResult
 		DocType: input.DocType,
 		Folder:  input.Folder,
 		Limit:   limit,
+		RRFK:    settings.RRFK,
+		HNSWEF:  settings.HNSWEF,
 	}
 
 	// BM25-only path: no embedder or explicitly requested


### PR DESCRIPTION
Add 6 new vault settings so each vault can independently tune hybrid search parameters and version retention, instead of relying on hardcoded defaults or server-wide env vars.

## New Features
- `rrf_k` — RRF K parameter for hybrid search fusion (default: 60)
- `hnsw_ef` — HNSW EF parameter for vector search (default: 40)
- `default_search_limit` / `max_search_limit` — per-vault search result limits (defaults: 20 / 100)
- `version_coalesce_minutes` — minutes between version snapshots (default: 10)
- `version_retention_count` — max versions per file (default: 50)

## Breaking Changes
- None


🤖 Generated with [Claude Code](https://claude.com/claude-code)