### PR TITLE
feat(helm): add STT and multimodal embedding env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ bedrock-setup.fish
 .DS_Store
 Thumbs.db
 
+# Temporary assets
+tmp-assets/
+
 # Whisper models (downloaded via `just whisper-pull`)
 /models/
 

--- a/helm/know/templates/deployment.yaml
+++ b/helm/know/templates/deployment.yaml
@@ -94,6 +94,32 @@ spec:
             - name: KNOW_EMBED_DIMENSION
               value: {{ .Values.embedding.dimension | quote }}
             {{- end }}
+            # Speech-to-text
+            {{- if .Values.stt.provider }}
+            - name: KNOW_STT_PROVIDER
+              value: {{ .Values.stt.provider | quote }}
+            {{- end }}
+            {{- if .Values.stt.model }}
+            - name: KNOW_STT_MODEL
+              value: {{ .Values.stt.model | quote }}
+            {{- end }}
+            {{- if .Values.stt.baseUrl }}
+            - name: KNOW_STT_BASE_URL
+              value: {{ .Values.stt.baseUrl | quote }}
+            {{- end }}
+            {{- if .Values.stt.audioSegmentSeconds }}
+            - name: KNOW_AUDIO_SEGMENT_SECONDS
+              value: {{ .Values.stt.audioSegmentSeconds | quote }}
+            {{- end }}
+            # Multimodal embedding
+            {{- if .Values.multimodalEmbedding.provider }}
+            - name: KNOW_MULTIMODAL_EMBED_PROVIDER
+              value: {{ .Values.multimodalEmbedding.provider | quote }}
+            {{- end }}
+            {{- if .Values.multimodalEmbedding.model }}
+            - name: KNOW_MULTIMODAL_EMBED_MODEL
+              value: {{ .Values.multimodalEmbedding.model | quote }}
+            {{- end }}
             # Ollama
             {{- if .Values.ollama.host }}
             - name: OLLAMA_HOST

--- a/helm/know/values.yaml
+++ b/helm/know/values.yaml
@@ -37,6 +37,18 @@ embedding:
   model: ""          # e.g. gemini-embedding-001, voyage-3-large, text-embedding-3-small
   dimension: ""      # e.g. 768, 1024
 
+# Speech-to-text (transcription) configuration
+stt:
+  provider: ""       # none | openai
+  model: ""          # e.g. gpt-4o-transcribe (default), whisper-1
+  baseUrl: ""        # custom base URL for STT API (e.g. http://whisper:8080/v1)
+  audioSegmentSeconds: ""  # max audio segment duration (default: 60, max 80 for Gemini)
+
+# Multimodal embedding configuration
+multimodalEmbedding:
+  provider: ""       # none | googleai
+  model: ""          # e.g. multimodalembedding@001
+
 # Ollama settings (when using ollama provider)
 ollama:
   host: ""           # e.g. http://ollama:11434


### PR DESCRIPTION
## Summary
- Add Helm values and deployment template env vars for speech-to-text (`KNOW_STT_PROVIDER`, `KNOW_STT_MODEL`, `KNOW_STT_BASE_URL`, `KNOW_AUDIO_SEGMENT_SECONDS`)
- Add Helm values and deployment template env vars for multimodal embedding (`KNOW_MULTIMODAL_EMBED_PROVIDER`, `KNOW_MULTIMODAL_EMBED_MODEL`)
- Add `tmp-assets/` to `.gitignore`

## Test plan
- [x] `helm template` renders successfully with default (empty) values
- [ ] Deploy with STT values set and verify env vars appear in pod spec
- [ ] Deploy with multimodal embedding values set and verify env vars appear in pod spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)