### PR TITLE
test: comprehensive integration tests for all DB query methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,10 @@ just test            # Run Go tests
 For SurrealDB-specific syntax, v3.0 breaking changes, and query patterns:
 - **Subagent**: Use the `surrealdb` subagent for complex query work (has built-in reference guide)
 
+**IMPORTANT**: Every public `internal/db/` query method must have an integration test in the corresponding `queries_*_test.go` file. Tests run against a real SurrealDB instance via testcontainers — no mocking. When adding a new query method, add its test in the same PR.
+
+**IMPORTANT**: Avoid N+1 queries, especially on hot paths (search, list endpoints, document processing). Prefer batch operations (`INSERT INTO table $rows`, `WHERE id IN $ids`) over looping single-record queries.
+
 ## Error Handling
 
 **CRITICAL**: Never ignore errors with `_ =` assignments. All errors must be either:

--- a/internal/db/queries_chunk_test.go
+++ b/internal/db/queries_chunk_test.go
@@ -280,3 +280,136 @@ func TestBatchUpdateChunkPositions(t *testing.T) {
 		t.Errorf("Expected position 10 for second chunk, got %d", updated[1].Position)
 	}
 }
+
+func TestGetFirstChunksByFileIDs(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	doc1, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/first-chunk-1.md", Title: "First Chunk 1",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile 1 failed: %v", err)
+	}
+	doc2, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/first-chunk-2.md", Title: "First Chunk 2",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile 2 failed: %v", err)
+	}
+	doc1ID := models.MustRecordIDString(doc1.ID)
+	doc2ID := models.MustRecordIDString(doc2.ID)
+
+	if err := testDB.CreateChunks(ctx, []models.ChunkInput{
+		{FileID: doc1ID, Text: "Doc1 Chunk0", Position: 0, Embedding: dummyEmbedding()},
+		{FileID: doc1ID, Text: "Doc1 Chunk1", Position: 1, Embedding: dummyEmbedding()},
+		{FileID: doc2ID, Text: "Doc2 Chunk0", Position: 0, Embedding: dummyEmbedding()},
+		{FileID: doc2ID, Text: "Doc2 Chunk1", Position: 1, Embedding: dummyEmbedding()},
+	}); err != nil {
+		t.Fatalf("CreateChunks failed: %v", err)
+	}
+
+	result, err := testDB.GetFirstChunksByFileIDs(ctx, []string{doc1ID, doc2ID})
+	if err != nil {
+		t.Fatalf("GetFirstChunksByFileIDs failed: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("Expected 2 entries in map, got %d", len(result))
+	}
+	if ch, ok := result[doc1ID]; !ok || ch.Position != 0 {
+		t.Errorf("Expected first chunk of doc1 with position 0, got %+v (ok=%v)", result[doc1ID], ok)
+	}
+	if ch, ok := result[doc2ID]; !ok || ch.Position != 0 {
+		t.Errorf("Expected first chunk of doc2 with position 0, got %+v (ok=%v)", result[doc2ID], ok)
+	}
+}
+
+func TestGetUnembeddedChunks(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	doc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/unembedded-chunks.md", Title: "Unembedded Chunks",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	if err := testDB.CreateChunks(ctx, []models.ChunkInput{
+		{FileID: docID, Text: "Has embedding", Position: 0, Embedding: dummyEmbedding()},
+		{FileID: docID, Text: "No embedding", Position: 1, Embedding: nil},
+	}); err != nil {
+		t.Fatalf("CreateChunks failed: %v", err)
+	}
+
+	unembedded, err := testDB.GetUnembeddedChunks(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetUnembeddedChunks failed: %v", err)
+	}
+	if len(unembedded) != 1 {
+		t.Fatalf("Expected 1 unembedded chunk, got %d", len(unembedded))
+	}
+	if unembedded[0].Text != "No embedding" {
+		t.Errorf("Expected unembedded chunk text 'No embedding', got %q", unembedded[0].Text)
+	}
+}
+
+func TestBatchUpdateChunkEmbeddings(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	doc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/batch-embed-test.md", Title: "Batch Embed",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	if err := testDB.CreateChunks(ctx, []models.ChunkInput{
+		{FileID: docID, Text: "Chunk A", Position: 0, Embedding: nil},
+		{FileID: docID, Text: "Chunk B", Position: 1, Embedding: nil},
+	}); err != nil {
+		t.Fatalf("CreateChunks failed: %v", err)
+	}
+
+	chunks, err := testDB.GetChunks(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetChunks failed: %v", err)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("Expected 2 chunks, got %d", len(chunks))
+	}
+
+	updates := []ChunkEmbeddingUpdate{
+		{ID: models.MustRecordIDString(chunks[0].ID), Embedding: dummyEmbedding()},
+		{ID: models.MustRecordIDString(chunks[1].ID), Embedding: dummyEmbedding()},
+	}
+	if err := testDB.BatchUpdateChunkEmbeddings(ctx, updates); err != nil {
+		t.Fatalf("BatchUpdateChunkEmbeddings failed: %v", err)
+	}
+
+	updated, err := testDB.GetChunks(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetChunks after batch update failed: %v", err)
+	}
+	for _, ch := range updated {
+		if len(ch.Embedding) != 384 {
+			t.Errorf("Expected embedding length 384, got %d for chunk %v", len(ch.Embedding), ch.Text)
+		}
+	}
+}

--- a/internal/db/queries_conversation_test.go
+++ b/internal/db/queries_conversation_test.go
@@ -195,3 +195,178 @@ func TestListMessages(t *testing.T) {
 		t.Errorf("Expected 2 messages, got %d", len(msgs))
 	}
 }
+
+func TestUpdateConversationTokens(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	conv, err := testDB.CreateConversation(ctx, vaultID, userID)
+	if err != nil {
+		t.Fatalf("CreateConversation failed: %v", err)
+	}
+	convID := models.MustRecordIDString(conv.ID)
+
+	err = testDB.UpdateConversationTokens(ctx, convID, 100, 50)
+	if err != nil {
+		t.Fatalf("UpdateConversationTokens failed: %v", err)
+	}
+
+	got, err := testDB.GetConversation(ctx, convID)
+	if err != nil {
+		t.Fatalf("GetConversation failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetConversation returned nil")
+	}
+	if got.TokenInput != 100 {
+		t.Errorf("Expected token_input 100, got %d", got.TokenInput)
+	}
+	if got.TokenOutput != 50 {
+		t.Errorf("Expected token_output 50, got %d", got.TokenOutput)
+	}
+}
+
+func TestSetConversationBgRunning(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	conv, err := testDB.CreateConversation(ctx, vaultID, userID)
+	if err != nil {
+		t.Fatalf("CreateConversation failed: %v", err)
+	}
+	convID := models.MustRecordIDString(conv.ID)
+
+	err = testDB.SetConversationBgRunning(ctx, convID)
+	if err != nil {
+		t.Fatalf("SetConversationBgRunning failed: %v", err)
+	}
+
+	got, err := testDB.GetConversation(ctx, convID)
+	if err != nil {
+		t.Fatalf("GetConversation failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetConversation returned nil")
+	}
+	if got.BgStatus == nil || *got.BgStatus != "running" {
+		t.Errorf("Expected bg_status 'running', got %v", got.BgStatus)
+	}
+	if got.BgStartedAt == nil {
+		t.Error("Expected bg_started_at to be set")
+	}
+}
+
+func TestSetConversationBgCompleted(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	conv, err := testDB.CreateConversation(ctx, vaultID, userID)
+	if err != nil {
+		t.Fatalf("CreateConversation failed: %v", err)
+	}
+	convID := models.MustRecordIDString(conv.ID)
+
+	if err = testDB.SetConversationBgRunning(ctx, convID); err != nil {
+		t.Fatalf("SetConversationBgRunning failed: %v", err)
+	}
+
+	err = testDB.SetConversationBgCompleted(ctx, convID)
+	if err != nil {
+		t.Fatalf("SetConversationBgCompleted failed: %v", err)
+	}
+
+	got, err := testDB.GetConversation(ctx, convID)
+	if err != nil {
+		t.Fatalf("GetConversation failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetConversation returned nil")
+	}
+	if got.BgStatus == nil || *got.BgStatus != "completed" {
+		t.Errorf("Expected bg_status 'completed', got %v", got.BgStatus)
+	}
+}
+
+func TestSetConversationBgFailed(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	conv, err := testDB.CreateConversation(ctx, vaultID, userID)
+	if err != nil {
+		t.Fatalf("CreateConversation failed: %v", err)
+	}
+	convID := models.MustRecordIDString(conv.ID)
+
+	if err = testDB.SetConversationBgRunning(ctx, convID); err != nil {
+		t.Fatalf("SetConversationBgRunning failed: %v", err)
+	}
+
+	errMsg := "something went wrong"
+	err = testDB.SetConversationBgFailed(ctx, convID, errMsg)
+	if err != nil {
+		t.Fatalf("SetConversationBgFailed failed: %v", err)
+	}
+
+	got, err := testDB.GetConversation(ctx, convID)
+	if err != nil {
+		t.Fatalf("GetConversation failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetConversation returned nil")
+	}
+	if got.BgStatus == nil || *got.BgStatus != "failed" {
+		t.Errorf("Expected bg_status 'failed', got %v", got.BgStatus)
+	}
+	if got.BgError == nil || *got.BgError != errMsg {
+		t.Errorf("Expected bg_error %q, got %v", errMsg, got.BgError)
+	}
+}
+
+func TestReconcileStaleRunningConversations(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	conv, err := testDB.CreateConversation(ctx, vaultID, userID)
+	if err != nil {
+		t.Fatalf("CreateConversation failed: %v", err)
+	}
+	convID := models.MustRecordIDString(conv.ID)
+
+	if err = testDB.SetConversationBgRunning(ctx, convID); err != nil {
+		t.Fatalf("SetConversationBgRunning failed: %v", err)
+	}
+
+	count, err := testDB.ReconcileStaleRunningConversations(ctx)
+	if err != nil {
+		t.Fatalf("ReconcileStaleRunningConversations failed: %v", err)
+	}
+	if count < 1 {
+		t.Errorf("Expected at least 1 reconciled conversation, got %d", count)
+	}
+
+	got, err := testDB.GetConversation(ctx, convID)
+	if err != nil {
+		t.Fatalf("GetConversation failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetConversation returned nil")
+	}
+	if got.BgStatus == nil || *got.BgStatus != "failed" {
+		t.Errorf("Expected bg_status 'failed' after reconcile, got %v", got.BgStatus)
+	}
+}

--- a/internal/db/queries_external_link_test.go
+++ b/internal/db/queries_external_link_test.go
@@ -1,0 +1,300 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/raphi011/know/internal/models"
+)
+
+func TestCreateExternalLinks(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/ext-create-" + suffix + ".md", Title: "Ext Create",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	linkText := "Go Blog"
+	links := []ExternalLinkInput{
+		{Hostname: "go.dev", URLPath: "/blog", FullURL: "https://go.dev/blog", LinkText: &linkText},
+		{Hostname: "go.dev", URLPath: "/doc", FullURL: "https://go.dev/doc"},
+		{Hostname: "github.com", URLPath: "/golang/go", FullURL: "https://github.com/golang/go"},
+	}
+
+	if err := testDB.CreateExternalLinks(ctx, fileID, vaultID, links); err != nil {
+		t.Fatalf("CreateExternalLinks failed: %v", err)
+	}
+
+	listed, err := testDB.ListExternalLinks(ctx, ExternalLinkFilter{VaultID: vaultID, Limit: 50})
+	if err != nil {
+		t.Fatalf("ListExternalLinks failed: %v", err)
+	}
+	if len(listed) != 3 {
+		t.Errorf("expected 3 external links, got %d", len(listed))
+	}
+}
+
+func TestCreateExternalLinks_Empty(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/ext-empty-" + suffix + ".md", Title: "Ext Empty",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	if err := testDB.CreateExternalLinks(ctx, fileID, vaultID, []ExternalLinkInput{}); err != nil {
+		t.Errorf("CreateExternalLinks with empty slice should not error, got: %v", err)
+	}
+}
+
+func TestDeleteExternalLinksByFile(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	fileA, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/ext-del-a-" + suffix + ".md", Title: "Ext Del A",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile A failed: %v", err)
+	}
+	fileB, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/ext-del-b-" + suffix + ".md", Title: "Ext Del B",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile B failed: %v", err)
+	}
+	fileAID := models.MustRecordIDString(fileA.ID)
+	fileBID := models.MustRecordIDString(fileB.ID)
+
+	if err := testDB.CreateExternalLinks(ctx, fileAID, vaultID, []ExternalLinkInput{
+		{Hostname: "example.com", URLPath: "/a", FullURL: "https://example.com/a"},
+	}); err != nil {
+		t.Fatalf("CreateExternalLinks A failed: %v", err)
+	}
+	if err := testDB.CreateExternalLinks(ctx, fileBID, vaultID, []ExternalLinkInput{
+		{Hostname: "example.com", URLPath: "/b", FullURL: "https://example.com/b"},
+		{Hostname: "example.com", URLPath: "/b2", FullURL: "https://example.com/b2"},
+	}); err != nil {
+		t.Fatalf("CreateExternalLinks B failed: %v", err)
+	}
+
+	if err := testDB.DeleteExternalLinksByFile(ctx, fileAID); err != nil {
+		t.Fatalf("DeleteExternalLinksByFile failed: %v", err)
+	}
+
+	// File A's links should be gone
+	linksA, err := testDB.ListExternalLinks(ctx, ExternalLinkFilter{VaultID: vaultID, FileID: &fileAID, Limit: 50})
+	if err != nil {
+		t.Fatalf("ListExternalLinks for file A after delete failed: %v", err)
+	}
+	if len(linksA) != 0 {
+		t.Errorf("expected 0 links for file A after delete, got %d", len(linksA))
+	}
+
+	// File B's links should remain
+	linksB, err := testDB.ListExternalLinks(ctx, ExternalLinkFilter{VaultID: vaultID, FileID: &fileBID, Limit: 50})
+	if err != nil {
+		t.Fatalf("ListExternalLinks for file B failed: %v", err)
+	}
+	if len(linksB) != 2 {
+		t.Errorf("expected 2 links for file B, got %d", len(linksB))
+	}
+}
+
+func TestGetExternalLinkStats(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/ext-stats-" + suffix + ".md", Title: "Ext Stats",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	if err := testDB.CreateExternalLinks(ctx, fileID, vaultID, []ExternalLinkInput{
+		{Hostname: "go.dev", URLPath: "/blog", FullURL: "https://go.dev/blog"},
+		{Hostname: "go.dev", URLPath: "/doc", FullURL: "https://go.dev/doc"},
+		{Hostname: "go.dev", URLPath: "/ref", FullURL: "https://go.dev/ref"},
+		{Hostname: "github.com", URLPath: "/a", FullURL: "https://github.com/a"},
+	}); err != nil {
+		t.Fatalf("CreateExternalLinks failed: %v", err)
+	}
+
+	stats, err := testDB.GetExternalLinkStats(ctx, vaultID)
+	if err != nil {
+		t.Fatalf("GetExternalLinkStats failed: %v", err)
+	}
+
+	statsMap := make(map[string]int, len(stats))
+	for _, s := range stats {
+		statsMap[s.Hostname] = s.Count
+	}
+
+	if statsMap["go.dev"] != 3 {
+		t.Errorf("expected go.dev count=3, got %d", statsMap["go.dev"])
+	}
+	if statsMap["github.com"] != 1 {
+		t.Errorf("expected github.com count=1, got %d", statsMap["github.com"])
+	}
+
+	// Stats should be ordered by count DESC
+	if len(stats) >= 2 && stats[0].Count < stats[1].Count {
+		t.Errorf("expected stats ordered by count DESC, got %v then %v", stats[0].Count, stats[1].Count)
+	}
+}
+
+func TestListExternalLinks_HostnameFilter(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/ext-hostname-" + suffix + ".md", Title: "Ext Hostname",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	if err := testDB.CreateExternalLinks(ctx, fileID, vaultID, []ExternalLinkInput{
+		{Hostname: "golang.org", URLPath: "/pkg", FullURL: "https://golang.org/pkg"},
+		{Hostname: "golang.org", URLPath: "/ref", FullURL: "https://golang.org/ref"},
+		{Hostname: "rust-lang.org", URLPath: "/doc", FullURL: "https://rust-lang.org/doc"},
+	}); err != nil {
+		t.Fatalf("CreateExternalLinks failed: %v", err)
+	}
+
+	hostname := "golang.org"
+	links, err := testDB.ListExternalLinks(ctx, ExternalLinkFilter{VaultID: vaultID, Hostname: &hostname, Limit: 50})
+	if err != nil {
+		t.Fatalf("ListExternalLinks with hostname filter failed: %v", err)
+	}
+	if len(links) != 2 {
+		t.Errorf("expected 2 links for golang.org, got %d", len(links))
+	}
+	for _, l := range links {
+		if l.Hostname != "golang.org" {
+			t.Errorf("expected hostname 'golang.org', got %q", l.Hostname)
+		}
+	}
+}
+
+func TestListExternalLinks_Pagination(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/ext-page-" + suffix + ".md", Title: "Ext Page",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	batch := make([]ExternalLinkInput, 5)
+	for i := range 5 {
+		batch[i] = ExternalLinkInput{
+			Hostname: "paginate.example",
+			URLPath:  fmt.Sprintf("/page/%d", i),
+			FullURL:  fmt.Sprintf("https://paginate.example/page/%d", i),
+		}
+	}
+	if err := testDB.CreateExternalLinks(ctx, fileID, vaultID, batch); err != nil {
+		t.Fatalf("CreateExternalLinks failed: %v", err)
+	}
+
+	links, err := testDB.ListExternalLinks(ctx, ExternalLinkFilter{VaultID: vaultID, Limit: 2, Offset: 0})
+	if err != nil {
+		t.Fatalf("ListExternalLinks with limit=2 failed: %v", err)
+	}
+	if len(links) != 2 {
+		t.Errorf("expected 2 links with limit=2, got %d", len(links))
+	}
+}
+
+func TestCountExternalLinks(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/ext-count-" + suffix + ".md", Title: "Ext Count",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	batch := []ExternalLinkInput{
+		{Hostname: "count.example", URLPath: "/1", FullURL: "https://count.example/1"},
+		{Hostname: "count.example", URLPath: "/2", FullURL: "https://count.example/2"},
+		{Hostname: "count.example", URLPath: "/3", FullURL: "https://count.example/3"},
+	}
+	if err := testDB.CreateExternalLinks(ctx, fileID, vaultID, batch); err != nil {
+		t.Fatalf("CreateExternalLinks failed: %v", err)
+	}
+
+	count, err := testDB.CountExternalLinks(ctx, ExternalLinkFilter{VaultID: vaultID})
+	if err != nil {
+		t.Fatalf("CountExternalLinks failed: %v", err)
+	}
+
+	listed, err := testDB.ListExternalLinks(ctx, ExternalLinkFilter{VaultID: vaultID, Limit: 999})
+	if err != nil {
+		t.Fatalf("ListExternalLinks failed: %v", err)
+	}
+
+	if count != len(listed) {
+		t.Errorf("CountExternalLinks=%d does not match ListExternalLinks count=%d", count, len(listed))
+	}
+	if count < 3 {
+		t.Errorf("expected at least 3 links, got %d", count)
+	}
+}

--- a/internal/db/queries_file.go
+++ b/internal/db/queries_file.go
@@ -112,25 +112,6 @@ func buildFileFilter(filter ListFilesFilter) (whereClause string, vars map[strin
 }
 
 // ---------------------------------------------------------------------------
-// Sync types
-// ---------------------------------------------------------------------------
-
-// SyncMeta is lightweight file metadata used for sync.
-type SyncMeta struct {
-	ID          surrealmodels.RecordID `json:"id"`
-	Path        string                 `json:"path"`
-	ContentHash *string                `json:"content_hash"`
-	UpdatedAt   time.Time              `json:"updated_at"`
-}
-
-// SyncTombstone represents a deleted file for sync.
-type SyncTombstone struct {
-	FileID    string    `json:"file_id"`
-	Path      string    `json:"path"`
-	DeletedAt time.Time `json:"deleted_at"`
-}
-
-// ---------------------------------------------------------------------------
 // File CRUD
 // ---------------------------------------------------------------------------
 
@@ -546,16 +527,6 @@ func (c *Client) UpsertFile(ctx context.Context, input models.FileInput) (file *
 // Access tracking
 // ---------------------------------------------------------------------------
 
-// UpdateFileAccess increments access_count and sets last_accessed_at to now.
-func (c *Client) UpdateFileAccess(ctx context.Context, fileID string) error {
-	defer c.logOp(ctx, "file.update_access", time.Now())
-	sql := `UPDATE type::record("file", $id) SET last_accessed_at = time::now(), access_count += 1`
-	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"id": fileID}); err != nil {
-		return fmt.Errorf("update file access: %w", err)
-	}
-	return nil
-}
-
 // BatchUpdateFileAccess increments access_count and sets last_accessed_at for multiple files.
 func (c *Client) BatchUpdateFileAccess(ctx context.Context, fileIDs []string) error {
 	if len(fileIDs) == 0 {
@@ -712,65 +683,6 @@ func (c *Client) ListFileMetas(ctx context.Context, filter ListFilesFilter) ([]m
 	results, err := surrealdb.Query[[]models.FileMeta](ctx, c.DB(), sql, vars)
 	if err != nil {
 		return nil, fmt.Errorf("list file metas: %w", err)
-	}
-	return allResults(results), nil
-}
-
-// ---------------------------------------------------------------------------
-// Sync
-// ---------------------------------------------------------------------------
-
-// ListSyncMetadata returns lightweight metadata for files in a vault,
-// optionally filtered by updated_at > since. Used for incremental sync.
-func (c *Client) ListSyncMetadata(ctx context.Context, vaultID string, since *string, limit, offset int) ([]SyncMeta, error) {
-	defer c.logOp(ctx, "file.list_sync_metadata", time.Now())
-	if limit <= 0 {
-		limit = 500
-	}
-	if offset < 0 {
-		offset = 0
-	}
-
-	vars := map[string]any{
-		"vault_id": bareID("vault", vaultID),
-		"limit":    limit,
-		"offset":   offset,
-	}
-
-	var sql string
-	if since != nil {
-		sql = `SELECT id, path, content_hash ?? null AS content_hash, updated_at FROM file WHERE vault = type::record("vault", $vault_id) AND updated_at > type::datetime($since) ORDER BY path ASC LIMIT $limit START $offset`
-		vars["since"] = *since
-	} else {
-		sql = `SELECT id, path, content_hash ?? null AS content_hash, updated_at FROM file WHERE vault = type::record("vault", $vault_id) ORDER BY path ASC LIMIT $limit START $offset`
-	}
-
-	results, err := surrealdb.Query[[]SyncMeta](ctx, c.DB(), sql, vars)
-	if err != nil {
-		return nil, fmt.Errorf("list sync metadata: %w", err)
-	}
-	return allResults(results), nil
-}
-
-// ListTombstones returns tombstones for deleted files in a vault since the given time.
-func (c *Client) ListTombstones(ctx context.Context, vaultID string, since string, limit, offset int) ([]SyncTombstone, error) {
-	defer c.logOp(ctx, "file.list_tombstones", time.Now())
-	if limit <= 0 {
-		limit = 500
-	}
-	if offset < 0 {
-		offset = 0
-	}
-
-	sql := `SELECT file_id, path, deleted_at FROM file_tombstone WHERE vault = type::record("vault", $vault_id) AND deleted_at > type::datetime($since) ORDER BY deleted_at ASC LIMIT $limit START $offset`
-	results, err := surrealdb.Query[[]SyncTombstone](ctx, c.DB(), sql, map[string]any{
-		"vault_id": bareID("vault", vaultID),
-		"since":    since,
-		"limit":    limit,
-		"offset":   offset,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("list tombstones: %w", err)
 	}
 	return allResults(results), nil
 }

--- a/internal/db/queries_file_folder_test.go
+++ b/internal/db/queries_file_folder_test.go
@@ -64,6 +64,42 @@ func TestEnsureFolders(t *testing.T) {
 	}
 }
 
+func TestEnsureFolderPath(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	prefix := fmt.Sprintf("/efp-%d", time.Now().UnixNano())
+	deepPath := prefix + "/a/b/c"
+
+	if err := testDB.EnsureFolderPath(ctx, vaultID, deepPath); err != nil {
+		t.Fatalf("EnsureFolderPath failed: %v", err)
+	}
+
+	// All ancestor folders should exist
+	for _, fp := range []string{prefix, prefix + "/a", prefix + "/a/b", deepPath} {
+		got, err := testDB.GetFolderByPath(ctx, vaultID, fp)
+		if err != nil {
+			t.Fatalf("GetFolderByPath %s failed: %v", fp, err)
+		}
+		if got == nil {
+			t.Errorf("expected folder %s to exist after EnsureFolderPath", fp)
+		}
+	}
+
+	// Idempotent — calling again must not error
+	if err := testDB.EnsureFolderPath(ctx, vaultID, deepPath); err != nil {
+		t.Fatalf("EnsureFolderPath (idempotent) failed: %v", err)
+	}
+
+	// Root path should be a no-op
+	if err := testDB.EnsureFolderPath(ctx, vaultID, "/"); err != nil {
+		t.Fatalf("EnsureFolderPath root failed: %v", err)
+	}
+}
+
 func TestListFolders(t *testing.T) {
 	ctx := context.Background()
 	user := createTestUser(t, ctx)
@@ -129,23 +165,45 @@ func TestDeleteFolder(t *testing.T) {
 	vault := createTestVault(t, ctx, userID)
 	vaultID := models.MustRecordIDString(vault.ID)
 
-	folderPath := fmt.Sprintf("/df-%d", time.Now().UnixNano())
-	_, err := testDB.CreateFolder(ctx, vaultID, folderPath)
-	if err != nil {
-		t.Fatalf("CreateFolder failed: %v", err)
+	prefix := fmt.Sprintf("/df-%d", time.Now().UnixNano())
+	parent := prefix + "/parent"
+	child := parent + "/sub"
+	sibling := prefix + "/sibling"
+
+	for _, fp := range []string{parent, child, sibling} {
+		if _, err := testDB.CreateFolder(ctx, vaultID, fp); err != nil {
+			t.Fatalf("CreateFolder %s failed: %v", fp, err)
+		}
 	}
 
-	err = testDB.DeleteFolder(ctx, vaultID, folderPath)
-	if err != nil {
+	// Delete parent — should cascade to child
+	if err := testDB.DeleteFolder(ctx, vaultID, parent); err != nil {
 		t.Fatalf("DeleteFolder failed: %v", err)
 	}
 
-	got, err := testDB.GetFolderByPath(ctx, vaultID, folderPath)
+	got, err := testDB.GetFolderByPath(ctx, vaultID, parent)
 	if err != nil {
-		t.Fatalf("GetFolderByPath after delete failed: %v", err)
+		t.Fatalf("GetFolderByPath parent failed: %v", err)
 	}
 	if got != nil {
-		t.Error("Folder should be nil after delete")
+		t.Error("parent folder should be deleted")
+	}
+
+	gotChild, err := testDB.GetFolderByPath(ctx, vaultID, child)
+	if err != nil {
+		t.Fatalf("GetFolderByPath child failed: %v", err)
+	}
+	if gotChild != nil {
+		t.Error("child folder should be deleted with parent")
+	}
+
+	// Sibling should survive
+	gotSibling, err := testDB.GetFolderByPath(ctx, vaultID, sibling)
+	if err != nil {
+		t.Fatalf("GetFolderByPath sibling failed: %v", err)
+	}
+	if gotSibling == nil {
+		t.Error("sibling folder should survive parent deletion")
 	}
 }
 
@@ -157,19 +215,32 @@ func TestDeleteFoldersByPrefix(t *testing.T) {
 	vaultID := models.MustRecordIDString(vault.ID)
 
 	prefix := fmt.Sprintf("/dfp-%d", time.Now().UnixNano())
-	for _, p := range []string{prefix + "/docs/a", prefix + "/docs/b", prefix + "/other"} {
+	base := prefix + "/docs"
+	for _, p := range []string{base, base + "/a", base + "/a/nested", prefix + "/other"} {
 		_, err := testDB.CreateFolder(ctx, vaultID, p)
 		if err != nil {
 			t.Fatalf("CreateFolder %s failed: %v", p, err)
 		}
 	}
 
-	count, err := testDB.DeleteFoldersByPrefix(ctx, vaultID, prefix+"/docs/")
+	// Delete base and all children
+	count, err := testDB.DeleteFoldersByPrefix(ctx, vaultID, base)
 	if err != nil {
 		t.Fatalf("DeleteFoldersByPrefix failed: %v", err)
 	}
-	if count != 2 {
-		t.Errorf("Expected 2 deleted, got %d", count)
+	if count != 3 {
+		t.Errorf("Expected 3 deleted (base + 2 children), got %d", count)
+	}
+
+	// All deleted folders should be gone
+	for _, fp := range []string{base, base + "/a", base + "/a/nested"} {
+		got, err := testDB.GetFolderByPath(ctx, vaultID, fp)
+		if err != nil {
+			t.Fatalf("GetFolderByPath %s failed: %v", fp, err)
+		}
+		if got != nil {
+			t.Errorf("expected folder %s to be deleted", fp)
+		}
 	}
 
 	// Verify /other survives
@@ -224,18 +295,42 @@ func TestMoveFoldersByPrefix(t *testing.T) {
 	vaultID := models.MustRecordIDString(vault.ID)
 
 	prefix := fmt.Sprintf("/mfp-%d", time.Now().UnixNano())
-	for _, p := range []string{prefix + "/old/a", prefix + "/old/b"} {
+	oldBase := prefix + "/old"
+	newBase := prefix + "/new"
+	for _, p := range []string{oldBase, oldBase + "/child"} {
 		_, err := testDB.CreateFolder(ctx, vaultID, p)
 		if err != nil {
 			t.Fatalf("CreateFolder %s failed: %v", p, err)
 		}
 	}
 
-	count, err := testDB.MoveFoldersByPrefix(ctx, vaultID, prefix+"/old/", prefix+"/new/")
+	count, err := testDB.MoveFoldersByPrefix(ctx, vaultID, oldBase, newBase)
 	if err != nil {
 		t.Fatalf("MoveFoldersByPrefix failed: %v", err)
 	}
 	if count != 2 {
 		t.Errorf("Expected 2 moved, got %d", count)
+	}
+
+	// Old paths should be gone
+	for _, fp := range []string{oldBase, oldBase + "/child"} {
+		got, err := testDB.GetFolderByPath(ctx, vaultID, fp)
+		if err != nil {
+			t.Fatalf("GetFolderByPath old %s failed: %v", fp, err)
+		}
+		if got != nil {
+			t.Errorf("expected old folder %s to be gone after move", fp)
+		}
+	}
+
+	// New paths should exist
+	for _, fp := range []string{newBase, newBase + "/child"} {
+		got, err := testDB.GetFolderByPath(ctx, vaultID, fp)
+		if err != nil {
+			t.Fatalf("GetFolderByPath new %s failed: %v", fp, err)
+		}
+		if got == nil {
+			t.Errorf("expected new folder %s to exist after move", fp)
+		}
 	}
 }

--- a/internal/db/queries_file_test.go
+++ b/internal/db/queries_file_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,7 +22,7 @@ func TestCreateFile(t *testing.T) {
 		VaultID:     vaultID,
 		Path:        "/docs/hello.md",
 		Title:       "Hello World",
-		Content:  "---\ntitle: Hello\n---\nHello world content",
+		Content:     "---\ntitle: Hello\n---\nHello world content",
 		Labels:      []string{"test", "greeting"},
 		ContentHash: &hash,
 	})
@@ -555,5 +556,686 @@ func TestUpsertFile(t *testing.T) {
 	}
 	if doc2.Title != "Upsert Updated" {
 		t.Errorf("Expected title 'Upsert Updated', got %q", doc2.Title)
+	}
+}
+
+func TestGetFilesByStem(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	// Two files that share stem "my-note" (different folders)
+	for _, p := range []string{
+		"/folder-a-" + suffix + "/my-note.md",
+		"/folder-b-" + suffix + "/my-note.md",
+	} {
+		_, err := testDB.CreateFile(ctx, models.FileInput{
+			VaultID: vaultID, Path: p, Title: "My Note", Content: "content", Labels: []string{},
+		})
+		if err != nil {
+			t.Fatalf("CreateFile %s failed: %v", p, err)
+		}
+	}
+
+	files, err := testDB.GetFilesByStem(ctx, vaultID, "my-note")
+	if err != nil {
+		t.Fatalf("GetFilesByStem failed: %v", err)
+	}
+	if len(files) < 2 {
+		t.Errorf("Expected at least 2 files with stem 'my-note', got %d", len(files))
+	}
+}
+
+func TestCountFilesByStem(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	stem := "count-stem-" + suffix
+	for _, p := range []string{
+		"/count-stem-dir-a/" + stem + ".md",
+		"/count-stem-dir-b/" + stem + ".md",
+	} {
+		_, err := testDB.CreateFile(ctx, models.FileInput{
+			VaultID: vaultID, Path: p, Title: "Count Stem", Content: "content", Labels: []string{},
+		})
+		if err != nil {
+			t.Fatalf("CreateFile %s failed: %v", p, err)
+		}
+	}
+
+	count, err := testDB.CountFilesByStem(ctx, vaultID, stem)
+	if err != nil {
+		t.Fatalf("CountFilesByStem failed: %v", err)
+	}
+
+	files, err := testDB.GetFilesByStem(ctx, vaultID, stem)
+	if err != nil {
+		t.Fatalf("GetFilesByStem failed: %v", err)
+	}
+	if count != len(files) {
+		t.Errorf("CountFilesByStem=%d does not match GetFilesByStem len=%d", count, len(files))
+	}
+	if count != 2 {
+		t.Errorf("Expected count 2, got %d", count)
+	}
+}
+
+func TestListFilesByPrefix(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	docsPrefix := "/pfx-docs-" + suffix + "/"
+	otherPrefix := "/pfx-other-" + suffix + "/"
+	for _, p := range []string{docsPrefix + "a.md", docsPrefix + "b.md", otherPrefix + "c.md"} {
+		_, err := testDB.CreateFile(ctx, models.FileInput{
+			VaultID: vaultID, Path: p, Title: "Prefix Test", Content: "content", Labels: []string{},
+		})
+		if err != nil {
+			t.Fatalf("CreateFile %s failed: %v", p, err)
+		}
+	}
+
+	files, err := testDB.ListFilesByPrefix(ctx, vaultID, docsPrefix)
+	if err != nil {
+		t.Fatalf("ListFilesByPrefix failed: %v", err)
+	}
+	if len(files) != 2 {
+		t.Errorf("Expected 2 files under docs prefix, got %d", len(files))
+	}
+	for _, f := range files {
+		if !strings.HasPrefix(f.Path, docsPrefix) {
+			t.Errorf("Unexpected path %q returned for prefix %q", f.Path, docsPrefix)
+		}
+	}
+}
+
+func TestUpdateFileTranscript(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	doc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/transcript-" + suffix + ".md", Title: "Transcript Test",
+		Content: "original", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	newContent := "transcribed content"
+	if err := testDB.UpdateFileTranscript(ctx, docID, newContent); err != nil {
+		t.Fatalf("UpdateFileTranscript failed: %v", err)
+	}
+
+	fetched, err := testDB.GetFileByID(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetFileByID failed: %v", err)
+	}
+	if fetched == nil {
+		t.Fatal("GetFileByID returned nil")
+	}
+	if fetched.Content != newContent {
+		t.Errorf("Expected content %q, got %q", newContent, fetched.Content)
+	}
+}
+
+func TestBatchUpdateFileAccess(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	var fileIDs []string
+	for _, p := range []string{
+		"/access-a-" + suffix + ".md",
+		"/access-b-" + suffix + ".md",
+	} {
+		doc, err := testDB.CreateFile(ctx, models.FileInput{
+			VaultID: vaultID, Path: p, Title: "Access Test", Content: "content", Labels: []string{},
+		})
+		if err != nil {
+			t.Fatalf("CreateFile %s failed: %v", p, err)
+		}
+		fileIDs = append(fileIDs, models.MustRecordIDString(doc.ID))
+	}
+
+	if err := testDB.BatchUpdateFileAccess(ctx, fileIDs); err != nil {
+		t.Fatalf("BatchUpdateFileAccess failed: %v", err)
+	}
+
+	for _, id := range fileIDs {
+		f, err := testDB.GetFileByID(ctx, id)
+		if err != nil {
+			t.Fatalf("GetFileByID failed: %v", err)
+		}
+		if f == nil {
+			t.Fatal("GetFileByID returned nil")
+		}
+		if f.AccessCount != 1 {
+			t.Errorf("Expected access_count 1, got %d for file %s", f.AccessCount, id)
+		}
+	}
+}
+
+func TestSetFileAccessCount(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	doc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/setaccess-" + suffix + ".md", Title: "Set Access",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	if err := testDB.SetFileAccessCount(ctx, docID, 42); err != nil {
+		t.Fatalf("SetFileAccessCount failed: %v", err)
+	}
+
+	fetched, err := testDB.GetFileByID(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetFileByID failed: %v", err)
+	}
+	if fetched == nil {
+		t.Fatal("GetFileByID returned nil")
+	}
+	if fetched.AccessCount != 42 {
+		t.Errorf("Expected access_count 42, got %d", fetched.AccessCount)
+	}
+}
+
+func TestGetFilesByAllLabels(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	for _, d := range []struct {
+		path   string
+		labels []string
+	}{
+		{"/allabels-ab-" + suffix + ".md", []string{"lbl-a", "lbl-b"}},
+		{"/allabels-ac-" + suffix + ".md", []string{"lbl-a", "lbl-c"}},
+		{"/allabels-abc-" + suffix + ".md", []string{"lbl-a", "lbl-b", "lbl-c"}},
+	} {
+		doc, err := testDB.CreateFile(ctx, models.FileInput{
+			VaultID: vaultID, Path: d.path, Title: "AllLabels", Content: "content", Labels: d.labels,
+		})
+		if err != nil {
+			t.Fatalf("CreateFile %s failed: %v", d.path, err)
+		}
+		docID := models.MustRecordIDString(doc.ID)
+		if err := testDB.SyncFileLabels(ctx, docID, vaultID, d.labels); err != nil {
+			t.Fatalf("SyncFileLabels %s failed: %v", d.path, err)
+		}
+	}
+
+	// Files with both lbl-a and lbl-b: ab and abc (2 files)
+	files, err := testDB.GetFilesByAllLabels(ctx, vaultID, []string{"lbl-a", "lbl-b"})
+	if err != nil {
+		t.Fatalf("GetFilesByAllLabels failed: %v", err)
+	}
+	if len(files) != 2 {
+		t.Errorf("Expected 2 files with labels [lbl-a, lbl-b], got %d", len(files))
+	}
+}
+
+func TestGetFileMetaByPath(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	p := "/filemeta-" + suffix + ".md"
+	_, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: p, Title: "File Meta Test", Content: "meta content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+
+	meta, err := testDB.GetFileMetaByPath(ctx, vaultID, p)
+	if err != nil {
+		t.Fatalf("GetFileMetaByPath failed: %v", err)
+	}
+	if meta == nil {
+		t.Fatal("GetFileMetaByPath returned nil for existing file")
+	}
+	if meta.Path != p {
+		t.Errorf("Expected path %q, got %q", p, meta.Path)
+	}
+	// FileMeta is a lightweight projection — no content, title not projected by GetFileMetaByPath
+	if meta.IsFolder {
+		t.Error("Expected is_folder=false for a regular file")
+	}
+
+	notFound, err := testDB.GetFileMetaByPath(ctx, vaultID, "/nonexistent-"+suffix+".md")
+	if err != nil {
+		t.Fatalf("GetFileMetaByPath nonexistent error: %v", err)
+	}
+	if notFound != nil {
+		t.Error("Expected nil for nonexistent path")
+	}
+}
+
+func TestGetFileMetaByPaths(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	p1 := "/meta-batch-a-" + suffix + ".md"
+	p2 := "/meta-batch-b-" + suffix + ".md"
+	pMissing := "/meta-batch-missing-" + suffix + ".md"
+
+	for _, p := range []string{p1, p2} {
+		_, err := testDB.CreateFile(ctx, models.FileInput{
+			VaultID: vaultID, Path: p, Title: "Batch Meta", Content: "content", Labels: []string{},
+		})
+		if err != nil {
+			t.Fatalf("CreateFile %s failed: %v", p, err)
+		}
+	}
+
+	// Query with 2 existing + 1 missing path
+	m, err := testDB.GetFileMetaByPaths(ctx, vaultID, []string{p1, p2, pMissing})
+	if err != nil {
+		t.Fatalf("GetFileMetaByPaths failed: %v", err)
+	}
+	if len(m) != 2 {
+		t.Errorf("Expected 2 entries, got %d", len(m))
+	}
+	if m[p1] == nil {
+		t.Error("Expected entry for p1")
+	}
+	if m[p2] == nil {
+		t.Error("Expected entry for p2")
+	}
+	if m[pMissing] != nil {
+		t.Error("Expected nil for missing path")
+	}
+
+	// Empty input returns empty map
+	empty, err := testDB.GetFileMetaByPaths(ctx, vaultID, []string{})
+	if err != nil {
+		t.Fatalf("GetFileMetaByPaths empty failed: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("Expected empty map, got %d entries", len(empty))
+	}
+}
+
+func TestListFileMetas(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	for _, p := range []string{
+		"/listmeta-" + suffix + "/a.md",
+		"/listmeta-" + suffix + "/b.md",
+	} {
+		_, err := testDB.CreateFile(ctx, models.FileInput{
+			VaultID: vaultID, Path: p, Title: "ListMeta", Content: "content", Labels: []string{},
+		})
+		if err != nil {
+			t.Fatalf("CreateFile %s failed: %v", p, err)
+		}
+	}
+
+	folder := "/listmeta-" + suffix + "/"
+	metas, err := testDB.ListFileMetas(ctx, ListFilesFilter{VaultID: vaultID, Folder: &folder})
+	if err != nil {
+		t.Fatalf("ListFileMetas failed: %v", err)
+	}
+	if len(metas) != 2 {
+		t.Errorf("Expected 2 file metas, got %d", len(metas))
+	}
+}
+
+func TestListChildFolders(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	// Create folder structure: /a/, /a/b/, /a/c/, /a/b/d/
+	for _, fp := range []string{
+		"/cf-" + suffix,
+		"/cf-" + suffix + "/b",
+		"/cf-" + suffix + "/c",
+		"/cf-" + suffix + "/b/d",
+	} {
+		_, err := testDB.CreateFolder(ctx, vaultID, fp)
+		if err != nil {
+			t.Fatalf("CreateFolder %s failed: %v", fp, err)
+		}
+	}
+
+	children, err := testDB.ListChildFolders(ctx, vaultID, "/cf-"+suffix)
+	if err != nil {
+		t.Fatalf("ListChildFolders failed: %v", err)
+	}
+	if len(children) != 2 {
+		t.Errorf("Expected 2 immediate child folders, got %d", len(children))
+	}
+	paths := map[string]bool{}
+	for _, ch := range children {
+		paths[ch.Path] = true
+	}
+	if !paths["/cf-"+suffix+"/b"] {
+		t.Errorf("Expected child /cf-%s/b, not found in %v", suffix, paths)
+	}
+	if !paths["/cf-"+suffix+"/c"] {
+		t.Errorf("Expected child /cf-%s/c, not found in %v", suffix, paths)
+	}
+}
+
+func TestRecomputeStems(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	doc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/old-stem-" + suffix + ".md", Title: "Old Stem",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	// Move the file to a new path
+	newPath := "/new-stem-" + suffix + ".md"
+	if _, err := testDB.MoveFile(ctx, docID, newPath); err != nil {
+		t.Fatalf("MoveFile failed: %v", err)
+	}
+
+	// RecomputeStems for the new path prefix
+	if err := testDB.RecomputeStems(ctx, vaultID, "/new-stem-"+suffix); err != nil {
+		t.Fatalf("RecomputeStems failed: %v", err)
+	}
+
+	fetched, err := testDB.GetFileByID(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetFileByID failed: %v", err)
+	}
+	if fetched == nil {
+		t.Fatal("GetFileByID returned nil")
+	}
+	expectedStem := models.FilenameStem(newPath)
+	if fetched.Stem != expectedStem {
+		t.Errorf("Expected stem %q, got %q", expectedStem, fetched.Stem)
+	}
+}
+
+func TestListUnprocessedFiles(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	doc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/unprocessed-" + suffix + ".md", Title: "Unprocessed",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	// Create a parse pipeline job for this file
+	if err := testDB.CreateJob(ctx, docID, "parse", 0); err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	files, err := testDB.ListUnprocessedFiles(ctx, 100)
+	if err != nil {
+		t.Fatalf("ListUnprocessedFiles failed: %v", err)
+	}
+
+	found := false
+	for _, f := range files {
+		if models.MustRecordIDString(f.ID) == docID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected file %s in unprocessed list, got %d files", docID, len(files))
+	}
+}
+
+func TestListFiles_OrderBy(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	for _, p := range []string{
+		"/order-" + suffix + "/b.md",
+		"/order-" + suffix + "/a.md",
+	} {
+		_, err := testDB.CreateFile(ctx, models.FileInput{
+			VaultID: vaultID, Path: p, Title: "Order " + p, Content: "content", Labels: []string{},
+		})
+		if err != nil {
+			t.Fatalf("CreateFile %s failed: %v", p, err)
+		}
+	}
+
+	folder := "/order-" + suffix + "/"
+
+	// Default order (path ASC)
+	docs, err := testDB.ListFiles(ctx, ListFilesFilter{VaultID: vaultID, Folder: &folder})
+	if err != nil {
+		t.Fatalf("ListFiles path ASC failed: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 docs, got %d", len(docs))
+	}
+	if !strings.HasSuffix(docs[0].Path, "/a.md") {
+		t.Errorf("expected first doc to be a.md (path ASC), got %q", docs[0].Path)
+	}
+
+	// Explicit order: created_at DESC → last created first
+	docs, err = testDB.ListFiles(ctx, ListFilesFilter{VaultID: vaultID, Folder: &folder, OrderBy: OrderByCreatedAtDesc})
+	if err != nil {
+		t.Fatalf("ListFiles created_at DESC failed: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 docs, got %d", len(docs))
+	}
+	// a.md was created second, so it should be first with DESC
+	if !strings.HasSuffix(docs[0].Path, "/a.md") {
+		t.Errorf("expected first doc to be a.md (created_at DESC), got %q", docs[0].Path)
+	}
+
+	// Invalid order must return error
+	_, err = testDB.ListFiles(ctx, ListFilesFilter{VaultID: vaultID, OrderBy: FileOrderBy("DROP TABLE; --")})
+	if err == nil {
+		t.Error("expected error for invalid OrderBy, got nil")
+	}
+}
+
+func TestListFiles_DocTypeFilter(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	mdType := "markdown"
+	audioType := "audio"
+	_, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/dtype-" + suffix + "/note.md", Title: "Note",
+		Content: "content", Labels: []string{}, DocType: &mdType,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile note failed: %v", err)
+	}
+	_, err = testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/dtype-" + suffix + "/recording.mp3", Title: "Recording",
+		Content: "", Labels: []string{}, DocType: &audioType, MimeType: "audio/mpeg",
+	})
+	if err != nil {
+		t.Fatalf("CreateFile recording failed: %v", err)
+	}
+
+	// Filter by doc_type
+	docs, err := testDB.ListFiles(ctx, ListFilesFilter{VaultID: vaultID, DocType: &mdType})
+	if err != nil {
+		t.Fatalf("ListFiles by doc_type failed: %v", err)
+	}
+	for _, d := range docs {
+		if d.DocType != nil && *d.DocType != mdType {
+			t.Errorf("expected doc_type %q, got %q", mdType, *d.DocType)
+		}
+	}
+	var found bool
+	for _, d := range docs {
+		if strings.HasSuffix(d.Path, "/note.md") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("note.md not found with doc_type filter")
+	}
+}
+
+func TestListFiles_MimeTypeFilter(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	_, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/mime-" + suffix + "/doc.md", Title: "Markdown",
+		Content: "content", Labels: []string{}, MimeType: "text/markdown",
+	})
+	if err != nil {
+		t.Fatalf("CreateFile markdown failed: %v", err)
+	}
+	_, err = testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/mime-" + suffix + "/image.png", Title: "Image",
+		Content: "", Labels: []string{}, MimeType: "image/png",
+	})
+	if err != nil {
+		t.Fatalf("CreateFile image failed: %v", err)
+	}
+
+	mime := "image/png"
+	docs, err := testDB.ListFiles(ctx, ListFilesFilter{VaultID: vaultID, MimeType: &mime})
+	if err != nil {
+		t.Fatalf("ListFiles by mime_type failed: %v", err)
+	}
+	for _, d := range docs {
+		if d.MimeType != mime {
+			t.Errorf("expected mime_type %q, got %q", mime, d.MimeType)
+		}
+	}
+	var found bool
+	for _, d := range docs {
+		if strings.HasSuffix(d.Path, "/image.png") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("image.png not found with mime_type filter")
+	}
+}
+
+func TestListFiles_IsFolderFilter(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	// Create a regular file
+	_, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/isfolder-" + suffix + "/note.md", Title: "Note",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	// Create a folder
+	_, err = testDB.CreateFolder(ctx, vaultID, "/isfolder-"+suffix+"/sub")
+	if err != nil {
+		t.Fatalf("CreateFolder failed: %v", err)
+	}
+
+	// Default ListFiles excludes folders
+	docs, err := testDB.ListFiles(ctx, ListFilesFilter{VaultID: vaultID})
+	if err != nil {
+		t.Fatalf("ListFiles default failed: %v", err)
+	}
+	for _, d := range docs {
+		if d.IsFolder {
+			t.Errorf("default ListFiles should not return folders, got %q", d.Path)
+		}
+	}
+
+	// Explicitly request folders only
+	isFolder := true
+	folder := "/isfolder-" + suffix + "/"
+	folders, err := testDB.ListFiles(ctx, ListFilesFilter{VaultID: vaultID, IsFolder: &isFolder, Folder: &folder})
+	if err != nil {
+		t.Fatalf("ListFiles is_folder=true failed: %v", err)
+	}
+	if len(folders) != 1 {
+		t.Errorf("expected 1 folder, got %d", len(folders))
+	}
+	for _, d := range folders {
+		if !d.IsFolder {
+			t.Errorf("expected is_folder=true, got false for %q", d.Path)
+		}
 	}
 }

--- a/internal/db/queries_job.go
+++ b/internal/db/queries_job.go
@@ -115,16 +115,3 @@ func (c *Client) ReconcileStaleRunningJobs(ctx context.Context) (int, error) {
 	}
 	return countResults(results), nil
 }
-
-// ListFailedJobs returns the most recently failed jobs up to limit.
-func (c *Client) ListFailedJobs(ctx context.Context, limit int) ([]models.PipelineJob, error) {
-	defer c.logOp(ctx, "pipeline_job.list_failed", time.Now())
-	sql := `SELECT * FROM pipeline_job WHERE status = 'failed' ORDER BY updated_at DESC LIMIT $limit`
-	results, err := surrealdb.Query[[]models.PipelineJob](ctx, c.DB(), sql, map[string]any{
-		"limit": limit,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("list failed jobs: %w", err)
-	}
-	return allResults(results), nil
-}

--- a/internal/db/queries_job_test.go
+++ b/internal/db/queries_job_test.go
@@ -1,0 +1,441 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/raphi011/know/internal/models"
+)
+
+func TestCreateJob(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/job-create-" + suffix + ".md", Title: "Job Create",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	if err := testDB.CreateJob(ctx, fileID, "embed", 10); err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	jobs, err := testDB.ClaimJobs(ctx, 1)
+	if err != nil {
+		t.Fatalf("ClaimJobs failed: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	if jobs[0].Type != "embed" {
+		t.Errorf("expected type 'embed', got %q", jobs[0].Type)
+	}
+	if jobs[0].Priority != 10 {
+		t.Errorf("expected priority 10, got %d", jobs[0].Priority)
+	}
+	// RETURN BEFORE: status in the returned record is the pre-update value
+	if jobs[0].Status != "pending" {
+		t.Errorf("expected status 'pending' (BEFORE), got %q", jobs[0].Status)
+	}
+}
+
+func TestClaimJobs_PriorityOrder(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	fileA, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/job-prio-a-" + suffix + ".md", Title: "Job Prio A",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile A failed: %v", err)
+	}
+	fileB, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/job-prio-b-" + suffix + ".md", Title: "Job Prio B",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile B failed: %v", err)
+	}
+	fileAID := models.MustRecordIDString(fileA.ID)
+	fileBID := models.MustRecordIDString(fileB.ID)
+
+	// Low priority first, then high — claim should return high priority first
+	if err := testDB.CreateJob(ctx, fileAID, "embed", 1); err != nil {
+		t.Fatalf("CreateJob low priority failed: %v", err)
+	}
+	if err := testDB.CreateJob(ctx, fileBID, "embed", 100); err != nil {
+		t.Fatalf("CreateJob high priority failed: %v", err)
+	}
+
+	// Claim only 1 job — should be the high-priority one
+	jobs, err := testDB.ClaimJobs(ctx, 1)
+	if err != nil {
+		t.Fatalf("ClaimJobs failed: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 claimed job, got %d", len(jobs))
+	}
+	if jobs[0].Priority != 100 {
+		t.Errorf("expected high-priority job (100) to be claimed first, got priority %d", jobs[0].Priority)
+	}
+}
+
+func TestClaimJobs_RespectsRunAfter(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/job-runafter-" + suffix + ".md", Title: "Job RunAfter",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	// Create job, then retry it with a far-future run_after
+	if err := testDB.CreateJob(ctx, fileID, "embed", 5); err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	// Claim once to move it to running
+	claimed, err := testDB.ClaimJobs(ctx, 1)
+	if err != nil {
+		t.Fatalf("ClaimJobs (first) failed: %v", err)
+	}
+	if len(claimed) != 1 {
+		t.Fatalf("expected 1 job to claim initially, got %d", len(claimed))
+	}
+	jobID := models.MustRecordIDString(claimed[0].ID)
+
+	// Retry with future run_after
+	future := time.Now().Add(24 * time.Hour)
+	if err := testDB.RetryJob(ctx, jobID, future); err != nil {
+		t.Fatalf("RetryJob failed: %v", err)
+	}
+
+	// Should not be claimable (run_after is in the future)
+	jobs, err := testDB.ClaimJobs(ctx, 10)
+	if err != nil {
+		t.Fatalf("ClaimJobs (second) failed: %v", err)
+	}
+	for _, j := range jobs {
+		if models.MustRecordIDString(j.ID) == jobID {
+			t.Error("job with future run_after should not be claimable")
+		}
+	}
+}
+
+func TestClaimJobs_RespectsLimit(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	for i := range 3 {
+		file, err := testDB.CreateFile(ctx, models.FileInput{
+			VaultID: vaultID,
+			Path:    fmt.Sprintf("/job-limit-%s-%d.md", suffix, i),
+			Title:   fmt.Sprintf("Job Limit %d", i),
+			Content: "content", Labels: []string{},
+		})
+		if err != nil {
+			t.Fatalf("CreateFile %d failed: %v", i, err)
+		}
+		if err := testDB.CreateJob(ctx, models.MustRecordIDString(file.ID), "embed", 1); err != nil {
+			t.Fatalf("CreateJob %d failed: %v", i, err)
+		}
+	}
+
+	jobs, err := testDB.ClaimJobs(ctx, 2)
+	if err != nil {
+		t.Fatalf("ClaimJobs failed: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Errorf("expected exactly 2 jobs claimed (limit=2), got %d", len(jobs))
+	}
+}
+
+func TestCompleteJob(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/job-complete-" + suffix + ".md", Title: "Job Complete",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	if err := testDB.CreateJob(ctx, fileID, "embed", 1); err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	claimed, err := testDB.ClaimJobs(ctx, 1)
+	if err != nil {
+		t.Fatalf("ClaimJobs failed: %v", err)
+	}
+	if len(claimed) != 1 {
+		t.Fatalf("expected 1 claimed job, got %d", len(claimed))
+	}
+	jobID := models.MustRecordIDString(claimed[0].ID)
+
+	if err := testDB.CompleteJob(ctx, jobID); err != nil {
+		t.Fatalf("CompleteJob failed: %v", err)
+	}
+
+	// Completed job should not be returned by ClaimJobs
+	jobs, err := testDB.ClaimJobs(ctx, 10)
+	if err != nil {
+		t.Fatalf("ClaimJobs after complete failed: %v", err)
+	}
+	for _, j := range jobs {
+		if models.MustRecordIDString(j.ID) == jobID {
+			t.Error("completed job should not be claimable again")
+		}
+	}
+}
+
+func TestFailJob(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/job-fail-" + suffix + ".md", Title: "Job Fail",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	if err := testDB.CreateJob(ctx, fileID, "embed", 1); err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	claimed, err := testDB.ClaimJobs(ctx, 1)
+	if err != nil {
+		t.Fatalf("ClaimJobs failed: %v", err)
+	}
+	if len(claimed) != 1 {
+		t.Fatalf("expected 1 claimed job, got %d", len(claimed))
+	}
+	jobID := models.MustRecordIDString(claimed[0].ID)
+
+	errMsg := "embedding model unavailable"
+	if err := testDB.FailJob(ctx, jobID, errMsg); err != nil {
+		t.Fatalf("FailJob failed: %v", err)
+	}
+
+	// Failed job must not be claimable
+	jobs, err := testDB.ClaimJobs(ctx, 10)
+	if err != nil {
+		t.Fatalf("ClaimJobs after fail failed: %v", err)
+	}
+	for _, j := range jobs {
+		if models.MustRecordIDString(j.ID) == jobID {
+			t.Error("failed job should not be claimable")
+		}
+	}
+}
+
+func TestRetryJob(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/job-retry-" + suffix + ".md", Title: "Job Retry",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	if err := testDB.CreateJob(ctx, fileID, "embed", 1); err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	// Claim (attempt=0, status=pending before claim → running after)
+	claimed, err := testDB.ClaimJobs(ctx, 1)
+	if err != nil {
+		t.Fatalf("ClaimJobs failed: %v", err)
+	}
+	if len(claimed) != 1 {
+		t.Fatalf("expected 1 claimed job, got %d", len(claimed))
+	}
+	jobID := models.MustRecordIDString(claimed[0].ID)
+
+	// Retry with a past run_after so the job becomes claimable immediately
+	past := time.Now().Add(-1 * time.Second)
+	if err := testDB.RetryJob(ctx, jobID, past); err != nil {
+		t.Fatalf("RetryJob failed: %v", err)
+	}
+
+	// Should be claimable again (status reset to pending)
+	jobs, err := testDB.ClaimJobs(ctx, 10)
+	if err != nil {
+		t.Fatalf("ClaimJobs after retry failed: %v", err)
+	}
+	var found *models.PipelineJob
+	for i := range jobs {
+		if models.MustRecordIDString(jobs[i].ID) == jobID {
+			found = &jobs[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("retried job should be claimable again")
+	}
+	// RETURN BEFORE gives us the pre-update value; status should be "pending"
+	// and attempt should now be 1 (set by RetryJob before this claim)
+	if found.Attempt != 1 {
+		t.Errorf("expected attempt=1 after retry, got %d", found.Attempt)
+	}
+}
+
+func TestCancelJobsForFile(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/job-cancel-" + suffix + ".md", Title: "Job Cancel",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	// Create 2 pending jobs for the file
+	if err := testDB.CreateJob(ctx, fileID, "embed", 1); err != nil {
+		t.Fatalf("CreateJob 1 failed: %v", err)
+	}
+	if err := testDB.CreateJob(ctx, fileID, "chunk", 1); err != nil {
+		t.Fatalf("CreateJob 2 failed: %v", err)
+	}
+
+	// Create a third job and complete it — completed jobs must not be cancelled
+	if err := testDB.CreateJob(ctx, fileID, "index", 1); err != nil {
+		t.Fatalf("CreateJob 3 failed: %v", err)
+	}
+	doneJobs, err := testDB.ClaimJobs(ctx, 1)
+	if err != nil {
+		t.Fatalf("ClaimJobs for done job failed: %v", err)
+	}
+	if len(doneJobs) > 0 {
+		if err := testDB.CompleteJob(ctx, models.MustRecordIDString(doneJobs[0].ID)); err != nil {
+			t.Fatalf("CompleteJob failed: %v", err)
+		}
+	}
+
+	if err := testDB.CancelJobsForFile(ctx, fileID); err != nil {
+		t.Fatalf("CancelJobsForFile failed: %v", err)
+	}
+
+	// After cancellation the 2 pending jobs must not be claimable
+	jobs, err := testDB.ClaimJobs(ctx, 10)
+	if err != nil {
+		t.Fatalf("ClaimJobs after cancel failed: %v", err)
+	}
+	for _, j := range jobs {
+		if models.MustRecordIDString(j.File) == fileID {
+			t.Errorf("cancelled job for file should not be claimable (job status: %s)", j.Status)
+		}
+	}
+}
+
+func TestReconcileStaleRunningJobs(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/job-reconcile-" + suffix + ".md", Title: "Job Reconcile",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	if err := testDB.CreateJob(ctx, fileID, "embed", 1); err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	// Claim job to put it in running state
+	claimed, err := testDB.ClaimJobs(ctx, 1)
+	if err != nil {
+		t.Fatalf("ClaimJobs failed: %v", err)
+	}
+	if len(claimed) == 0 {
+		t.Fatal("expected at least 1 job to be claimed")
+	}
+
+	// Reconcile: running jobs should be reset to pending
+	count, err := testDB.ReconcileStaleRunningJobs(ctx)
+	if err != nil {
+		t.Fatalf("ReconcileStaleRunningJobs failed: %v", err)
+	}
+	if count == 0 {
+		t.Error("expected at least 1 stale running job to be reconciled")
+	}
+
+	// After reconcile, job should be claimable again
+	jobs, err := testDB.ClaimJobs(ctx, 10)
+	if err != nil {
+		t.Fatalf("ClaimJobs after reconcile failed: %v", err)
+	}
+	var found bool
+	for _, j := range jobs {
+		if models.MustRecordIDString(j.ID) == models.MustRecordIDString(claimed[0].ID) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("reconciled job should be claimable again")
+	}
+}

--- a/internal/db/queries_relation_test.go
+++ b/internal/db/queries_relation_test.go
@@ -227,6 +227,56 @@ func TestDeleteRelationsBySource(t *testing.T) {
 	}
 }
 
+func TestBatchCreateRelations(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	docA, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/batchrel-a-" + suffix + ".md", Title: "BatchRel A",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile A failed: %v", err)
+	}
+	docB, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/batchrel-b-" + suffix + ".md", Title: "BatchRel B",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile B failed: %v", err)
+	}
+	docC, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/batchrel-c-" + suffix + ".md", Title: "BatchRel C",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile C failed: %v", err)
+	}
+	docAID := models.MustRecordIDString(docA.ID)
+	docBID := models.MustRecordIDString(docB.ID)
+	docCID := models.MustRecordIDString(docC.ID)
+
+	err = testDB.BatchCreateRelations(ctx, []models.FileRelationInput{
+		{FromFileID: docAID, ToFileID: docBID, RelType: "relates_to", Source: "api"},
+		{FromFileID: docAID, ToFileID: docCID, RelType: "relates_to", Source: "api"},
+	})
+	if err != nil {
+		t.Fatalf("BatchCreateRelations failed: %v", err)
+	}
+
+	rels, err := testDB.GetRelations(ctx, docAID)
+	if err != nil {
+		t.Fatalf("GetRelations failed: %v", err)
+	}
+	if len(rels) != 2 {
+		t.Errorf("Expected 2 relations after batch create, got %d", len(rels))
+	}
+}
+
 func TestDeleteRelation(t *testing.T) {
 	ctx := context.Background()
 	user := createTestUser(t, ctx)

--- a/internal/db/queries_remote.go
+++ b/internal/db/queries_remote.go
@@ -17,15 +17,15 @@ func (c *Client) CreateRemote(ctx context.Context, userID string, input models.R
 		CREATE remote SET
 			name = $name,
 			url = $url,
-			token = $token,
+			token = $api_token,
 			created_by = type::record("user", $user_id)
 		RETURN AFTER
 	`
 	results, err := surrealdb.Query[[]models.Remote](ctx, c.DB(), sql, map[string]any{
-		"name":    input.Name,
-		"url":     input.URL,
-		"token":   input.Token,
-		"user_id": bareID("user", userID),
+		"name":      input.Name,
+		"url":       input.URL,
+		"api_token": input.Token,
+		"user_id":   bareID("user", userID),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create remote: %w", err)
@@ -56,10 +56,7 @@ func (c *Client) ListRemotes(ctx context.Context) ([]models.Remote, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list remotes: %w", err)
 	}
-	if results == nil || len(*results) == 0 || len((*results)[0].Result) == 0 {
-		return []models.Remote{}, nil
-	}
-	return (*results)[0].Result, nil
+	return allResults(results), nil
 }
 
 // DeleteRemote deletes a remote by name. Returns true if a record was deleted.

--- a/internal/db/queries_remote_test.go
+++ b/internal/db/queries_remote_test.go
@@ -1,0 +1,155 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/raphi011/know/internal/models"
+)
+
+func TestCreateRemote(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+
+	name := fmt.Sprintf("remote-%d", time.Now().UnixNano())
+	input := models.RemoteInput{
+		Name:  name,
+		URL:   "https://know.example.com",
+		Token: "tok-abc123",
+	}
+
+	remote, err := testDB.CreateRemote(ctx, userID, input)
+	if err != nil {
+		t.Fatalf("CreateRemote failed: %v", err)
+	}
+	if remote == nil {
+		t.Fatal("CreateRemote returned nil")
+	}
+	if remote.Name != name {
+		t.Errorf("expected name %q, got %q", name, remote.Name)
+	}
+	if remote.URL != input.URL {
+		t.Errorf("expected URL %q, got %q", input.URL, remote.URL)
+	}
+	if remote.Token != input.Token {
+		t.Errorf("expected token %q, got %q", input.Token, remote.Token)
+	}
+	if models.MustRecordIDString(remote.CreatedBy) != userID {
+		t.Errorf("expected created_by %q, got %q", userID, models.MustRecordIDString(remote.CreatedBy))
+	}
+
+	found, err := testDB.GetRemoteByName(ctx, name)
+	if err != nil {
+		t.Fatalf("GetRemoteByName failed: %v", err)
+	}
+	if found == nil {
+		t.Fatal("GetRemoteByName returned nil")
+	}
+	if found.Name != name {
+		t.Errorf("round-trip: expected name %q, got %q", name, found.Name)
+	}
+}
+
+func TestGetRemoteByName_NotFound(t *testing.T) {
+	ctx := context.Background()
+
+	found, err := testDB.GetRemoteByName(ctx, "nonexistent-remote-"+fmt.Sprint(time.Now().UnixNano()))
+	if err != nil {
+		t.Fatalf("GetRemoteByName failed: %v", err)
+	}
+	if found != nil {
+		t.Errorf("expected nil for nonexistent remote, got %+v", found)
+	}
+}
+
+func TestListRemotes(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+
+	// Use a unique suffix so both names sort together and we can find them.
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	nameA := "remote-a-" + suffix
+	nameB := "remote-b-" + suffix
+
+	_, err := testDB.CreateRemote(ctx, userID, models.RemoteInput{Name: nameA, URL: "https://a.example.com", Token: "tok-a"})
+	if err != nil {
+		t.Fatalf("CreateRemote A failed: %v", err)
+	}
+	_, err = testDB.CreateRemote(ctx, userID, models.RemoteInput{Name: nameB, URL: "https://b.example.com", Token: "tok-b"})
+	if err != nil {
+		t.Fatalf("CreateRemote B failed: %v", err)
+	}
+
+	remotes, err := testDB.ListRemotes(ctx)
+	if err != nil {
+		t.Fatalf("ListRemotes failed: %v", err)
+	}
+
+	names := make(map[string]bool)
+	for _, r := range remotes {
+		names[r.Name] = true
+	}
+	if !names[nameA] {
+		t.Errorf("expected remote %q in list", nameA)
+	}
+	if !names[nameB] {
+		t.Errorf("expected remote %q in list", nameB)
+	}
+
+	// Verify sorted by name ascending (check relative order of our two remotes).
+	idxA, idxB := -1, -1
+	for i, r := range remotes {
+		if r.Name == nameA {
+			idxA = i
+		}
+		if r.Name == nameB {
+			idxB = i
+		}
+	}
+	if idxA == -1 || idxB == -1 {
+		t.Fatal("could not find both remotes in list")
+	}
+	if idxA >= idxB {
+		t.Errorf("expected %q before %q in sorted list", nameA, nameB)
+	}
+}
+
+func TestDeleteRemote(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+
+	name := fmt.Sprintf("remote-del-%d", time.Now().UnixNano())
+	_, err := testDB.CreateRemote(ctx, userID, models.RemoteInput{Name: name, URL: "https://del.example.com", Token: "tok-del"})
+	if err != nil {
+		t.Fatalf("CreateRemote failed: %v", err)
+	}
+
+	deleted, err := testDB.DeleteRemote(ctx, name)
+	if err != nil {
+		t.Fatalf("DeleteRemote failed: %v", err)
+	}
+	if !deleted {
+		t.Error("expected DeleteRemote to return true for existing remote")
+	}
+
+	found, err := testDB.GetRemoteByName(ctx, name)
+	if err != nil {
+		t.Fatalf("GetRemoteByName after delete failed: %v", err)
+	}
+	if found != nil {
+		t.Error("expected nil after deletion")
+	}
+
+	deletedAgain, err := testDB.DeleteRemote(ctx, name)
+	if err != nil {
+		t.Fatalf("DeleteRemote nonexistent failed: %v", err)
+	}
+	if deletedAgain {
+		t.Error("expected DeleteRemote to return false for nonexistent remote")
+	}
+}

--- a/internal/db/queries_share_link.go
+++ b/internal/db/queries_share_link.go
@@ -7,40 +7,7 @@ import (
 
 	"github.com/raphi011/know/internal/models"
 	"github.com/surrealdb/surrealdb.go"
-	surrealmodels "github.com/surrealdb/surrealdb.go/pkg/models"
 )
-
-// CreateShareLink creates a new share link for a doc/folder path.
-func (c *Client) CreateShareLink(ctx context.Context, vaultID, tokenHash, path string, isFolder bool, createdBy string, expiresAt *string) (*models.ShareLink, error) {
-	defer c.logOp(ctx, "share_link.create", time.Now())
-	var expiry any = surrealmodels.None
-	if expiresAt != nil {
-		expiry = *expiresAt
-	}
-
-	sql := `
-		CREATE share_link SET
-			vault = type::record("vault", $vault_id),
-			token_hash = $token_hash,
-			path = $path,
-			is_folder = $is_folder,
-			created_by = type::record("user", $created_by),
-			expires_at = $expires_at
-		RETURN AFTER
-	`
-	results, err := surrealdb.Query[[]models.ShareLink](ctx, c.DB(), sql, map[string]any{
-		"vault_id":   bareID("vault", vaultID),
-		"token_hash": tokenHash,
-		"path":       path,
-		"is_folder":  isFolder,
-		"created_by": bareID("user", createdBy),
-		"expires_at": expiry,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("create share link: %w", err)
-	}
-	return firstResult(results, "create share link")
-}
 
 // GetShareLinkByHash looks up a share link by its token hash.
 func (c *Client) GetShareLinkByHash(ctx context.Context, hash string) (*models.ShareLink, error) {
@@ -53,40 +20,4 @@ func (c *Client) GetShareLinkByHash(ctx context.Context, hash string) (*models.S
 		return nil, fmt.Errorf("get share link by hash: %w", err)
 	}
 	return firstResultOpt(results), nil
-}
-
-// GetShareLink looks up a share link by ID.
-func (c *Client) GetShareLink(ctx context.Context, id string) (*models.ShareLink, error) {
-	defer c.logOp(ctx, "share_link.get", time.Now())
-	sql := `SELECT * FROM type::record("share_link", $id)`
-	results, err := surrealdb.Query[[]models.ShareLink](ctx, c.DB(), sql, map[string]any{
-		"id": bareID("share_link", id),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("get share link: %w", err)
-	}
-	return firstResultOpt(results), nil
-}
-
-// ListShareLinks returns all share links for a vault.
-func (c *Client) ListShareLinks(ctx context.Context, vaultID string) ([]models.ShareLink, error) {
-	defer c.logOp(ctx, "share_link.list", time.Now())
-	sql := `SELECT * FROM share_link WHERE vault = type::record("vault", $vault_id) ORDER BY created_at DESC`
-	results, err := surrealdb.Query[[]models.ShareLink](ctx, c.DB(), sql, map[string]any{
-		"vault_id": bareID("vault", vaultID),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("list share links: %w", err)
-	}
-	return allResults(results), nil
-}
-
-// DeleteShareLink removes a share link by ID.
-func (c *Client) DeleteShareLink(ctx context.Context, id string) error {
-	defer c.logOp(ctx, "share_link.delete", time.Now())
-	sql := `DELETE type::record("share_link", $id)`
-	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"id": bareID("share_link", id)}); err != nil {
-		return fmt.Errorf("delete share link: %w", err)
-	}
-	return nil
 }

--- a/internal/db/queries_share_link_test.go
+++ b/internal/db/queries_share_link_test.go
@@ -1,0 +1,82 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/raphi011/know/internal/models"
+	"github.com/surrealdb/surrealdb.go"
+)
+
+func insertTestShareLink(t *testing.T, ctx context.Context, userID, vaultID, hash, path string) {
+	t.Helper()
+	sql := `INSERT INTO share_link {
+		vault: type::record("vault", $vault_id),
+		token_hash: $hash,
+		path: $path,
+		is_folder: false,
+		created_by: type::record("user", $user_id)
+	}`
+	_, err := surrealdb.Query[any](ctx, testDB.DB(), sql, map[string]any{
+		"vault_id": bareID("vault", vaultID),
+		"hash":     hash,
+		"path":     path,
+		"user_id":  bareID("user", userID),
+	})
+	if err != nil {
+		t.Fatalf("insert share_link failed: %v", err)
+	}
+}
+
+func TestGetShareLinkByHash(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	hash := fmt.Sprintf("share-hash-%d", time.Now().UnixNano())
+	path := "/notes/secret.md"
+
+	insertTestShareLink(t, ctx, userID, vaultID, hash, path)
+
+	link, err := testDB.GetShareLinkByHash(ctx, hash)
+	if err != nil {
+		t.Fatalf("GetShareLinkByHash failed: %v", err)
+	}
+	if link == nil {
+		t.Fatal("GetShareLinkByHash returned nil")
+	}
+	if link.TokenHash != hash {
+		t.Errorf("expected token_hash %q, got %q", hash, link.TokenHash)
+	}
+	if link.Path != path {
+		t.Errorf("expected path %q, got %q", path, link.Path)
+	}
+	if link.IsFolder {
+		t.Error("expected is_folder to be false")
+	}
+	if models.MustRecordIDString(link.Vault) != vaultID {
+		t.Errorf("expected vault %q, got %q", vaultID, models.MustRecordIDString(link.Vault))
+	}
+	if models.MustRecordIDString(link.CreatedBy) != userID {
+		t.Errorf("expected created_by %q, got %q", userID, models.MustRecordIDString(link.CreatedBy))
+	}
+	if link.ExpiresAt != nil {
+		t.Error("expected ExpiresAt to be nil")
+	}
+}
+
+func TestGetShareLinkByHash_NotFound(t *testing.T) {
+	ctx := context.Background()
+
+	link, err := testDB.GetShareLinkByHash(ctx, "nonexistent-hash-"+fmt.Sprint(time.Now().UnixNano()))
+	if err != nil {
+		t.Fatalf("GetShareLinkByHash failed: %v", err)
+	}
+	if link != nil {
+		t.Errorf("expected nil for nonexistent hash, got %+v", link)
+	}
+}

--- a/internal/db/queries_task.go
+++ b/internal/db/queries_task.go
@@ -127,18 +127,6 @@ func (c *Client) DeleteTask(ctx context.Context, id string) error {
 	return nil
 }
 
-// DeleteTasksByFile removes all tasks belonging to a file.
-func (c *Client) DeleteTasksByFile(ctx context.Context, fileID string) error {
-	defer c.logOp(ctx, "task.delete_by_file", time.Now())
-
-	sql := `DELETE FROM task WHERE file = type::record("file", $file_id)`
-	_, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"file_id": bareID("file", fileID)})
-	if err != nil {
-		return fmt.Errorf("delete tasks by file: %w", err)
-	}
-	return nil
-}
-
 // GetTaskByID fetches a single task. Returns nil if not found.
 func (c *Client) GetTaskByID(ctx context.Context, id string) (*models.Task, error) {
 	defer c.logOp(ctx, "task.get", time.Now())

--- a/internal/db/queries_task_test.go
+++ b/internal/db/queries_task_test.go
@@ -1,0 +1,681 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/raphi011/know/internal/models"
+)
+
+func makeTaskInput(fileID, vaultID string, lineNumber int, status models.TaskStatus, text, hash string) models.TaskInput {
+	return models.TaskInput{
+		FileID:      fileID,
+		VaultID:     vaultID,
+		Status:      status,
+		RawLine:     "- [" + string(status[0]) + "] " + text,
+		Text:        text,
+		Labels:      []string{},
+		LineNumber:  lineNumber,
+		ContentHash: hash,
+	}
+}
+
+func TestCreateTask(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/task-create-" + suffix + ".md", Title: "Task Create",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	dueDate := "2026-06-15"
+	heading := "Daily > Tasks"
+	input := models.TaskInput{
+		FileID:      fileID,
+		VaultID:     vaultID,
+		Status:      models.TaskStatusOpen,
+		RawLine:     "- [ ] Buy milk due:2026-06-15 #shopping",
+		Text:        "Buy milk",
+		Labels:      []string{"shopping"},
+		DueDate:     &dueDate,
+		LineNumber:  3,
+		HeadingPath: &heading,
+		ContentHash: "abc123hash",
+	}
+
+	task, err := testDB.CreateTask(ctx, input)
+	if err != nil {
+		t.Fatalf("CreateTask failed: %v", err)
+	}
+	if task == nil {
+		t.Fatal("CreateTask returned nil")
+	}
+
+	taskID := models.MustRecordIDString(task.ID)
+	fetched, err := testDB.GetTaskByID(ctx, taskID)
+	if err != nil {
+		t.Fatalf("GetTaskByID failed: %v", err)
+	}
+	if fetched == nil {
+		t.Fatal("GetTaskByID returned nil for existing task")
+	}
+	if fetched.Status != models.TaskStatusOpen {
+		t.Errorf("expected status 'open', got %q", fetched.Status)
+	}
+	if fetched.Text != "Buy milk" {
+		t.Errorf("expected text 'Buy milk', got %q", fetched.Text)
+	}
+	if fetched.LineNumber != 3 {
+		t.Errorf("expected line_number 3, got %d", fetched.LineNumber)
+	}
+	if fetched.DueDate == nil || *fetched.DueDate != "2026-06-15" {
+		t.Errorf("expected due_date '2026-06-15', got %v", fetched.DueDate)
+	}
+	if fetched.HeadingPath == nil || *fetched.HeadingPath != "Daily > Tasks" {
+		t.Errorf("expected heading_path 'Daily > Tasks', got %v", fetched.HeadingPath)
+	}
+	if len(fetched.Labels) != 1 || fetched.Labels[0] != "shopping" {
+		t.Errorf("expected labels ['shopping'], got %v", fetched.Labels)
+	}
+	if fetched.ContentHash != "abc123hash" {
+		t.Errorf("expected content_hash 'abc123hash', got %q", fetched.ContentHash)
+	}
+}
+
+func TestCreateTask_ValidationError(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/task-validate-" + suffix + ".md", Title: "Task Validate",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	// ContentHash is empty — must fail validation
+	_, err = testDB.CreateTask(ctx, models.TaskInput{
+		FileID:      fileID,
+		VaultID:     vaultID,
+		Status:      models.TaskStatusOpen,
+		RawLine:     "- [ ] missing hash",
+		Text:        "missing hash",
+		Labels:      []string{},
+		LineNumber:  1,
+		ContentHash: "", // invalid
+	})
+	if err == nil {
+		t.Error("expected error for empty ContentHash, got nil")
+	}
+}
+
+func TestUpdateTask(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/task-update-" + suffix + ".md", Title: "Task Update",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	task, err := testDB.CreateTask(ctx, makeTaskInput(fileID, vaultID, 1, models.TaskStatusOpen, "Original task", "hash1"))
+	if err != nil {
+		t.Fatalf("CreateTask failed: %v", err)
+	}
+	taskID := models.MustRecordIDString(task.ID)
+
+	if err := testDB.UpdateTask(ctx, taskID, TaskUpdate{
+		Status:     models.TaskStatusDone,
+		RawLine:    "- [x] Updated task",
+		Text:       "Updated task",
+		Labels:     []string{"done"},
+		LineNumber: 2,
+	}); err != nil {
+		t.Fatalf("UpdateTask failed: %v", err)
+	}
+
+	fetched, err := testDB.GetTaskByID(ctx, taskID)
+	if err != nil {
+		t.Fatalf("GetTaskByID failed: %v", err)
+	}
+	if fetched.Status != models.TaskStatusDone {
+		t.Errorf("expected status 'done', got %q", fetched.Status)
+	}
+	if fetched.Text != "Updated task" {
+		t.Errorf("expected text 'Updated task', got %q", fetched.Text)
+	}
+	if fetched.LineNumber != 2 {
+		t.Errorf("expected line_number 2, got %d", fetched.LineNumber)
+	}
+}
+
+func TestUpdateTask_NotFound(t *testing.T) {
+	ctx := context.Background()
+
+	err := testDB.UpdateTask(ctx, "task:nonexistent_"+fmt.Sprint(time.Now().UnixNano()), TaskUpdate{
+		Status:     models.TaskStatusDone,
+		RawLine:    "- [x] ghost",
+		Text:       "ghost",
+		Labels:     []string{},
+		LineNumber: 1,
+	})
+	if err == nil {
+		t.Error("expected error when updating nonexistent task, got nil")
+	}
+}
+
+func TestDeleteTask(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/task-delete-" + suffix + ".md", Title: "Task Delete",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	task, err := testDB.CreateTask(ctx, makeTaskInput(fileID, vaultID, 1, models.TaskStatusOpen, "Delete me", "hashdelete"))
+	if err != nil {
+		t.Fatalf("CreateTask failed: %v", err)
+	}
+	taskID := models.MustRecordIDString(task.ID)
+
+	if err := testDB.DeleteTask(ctx, taskID); err != nil {
+		t.Fatalf("DeleteTask failed: %v", err)
+	}
+
+	fetched, err := testDB.GetTaskByID(ctx, taskID)
+	if err != nil {
+		t.Fatalf("GetTaskByID after delete failed: %v", err)
+	}
+	if fetched != nil {
+		t.Error("expected nil after delete, got non-nil task")
+	}
+}
+
+func TestGetTasksByFile(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/task-byfile-" + suffix + ".md", Title: "Task ByFile",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	// Create task at line 5 first, then line 1 — GetTasksByFile must sort by line_number ASC
+	if _, err := testDB.CreateTask(ctx, makeTaskInput(fileID, vaultID, 5, models.TaskStatusOpen, "Line five", "hashline5")); err != nil {
+		t.Fatalf("CreateTask line 5 failed: %v", err)
+	}
+	if _, err := testDB.CreateTask(ctx, makeTaskInput(fileID, vaultID, 1, models.TaskStatusDone, "Line one", "hashline1")); err != nil {
+		t.Fatalf("CreateTask line 1 failed: %v", err)
+	}
+
+	tasks, err := testDB.GetTasksByFile(ctx, fileID)
+	if err != nil {
+		t.Fatalf("GetTasksByFile failed: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	}
+	if tasks[0].LineNumber != 1 {
+		t.Errorf("expected first task at line 1 (ASC order), got line %d", tasks[0].LineNumber)
+	}
+	if tasks[1].LineNumber != 5 {
+		t.Errorf("expected second task at line 5, got line %d", tasks[1].LineNumber)
+	}
+}
+
+func TestListTasks_StatusFilter(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/task-status-" + suffix + ".md", Title: "Task Status",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	if _, err := testDB.CreateTask(ctx, makeTaskInput(fileID, vaultID, 1, models.TaskStatusOpen, "Open task", "hashopen")); err != nil {
+		t.Fatalf("CreateTask open failed: %v", err)
+	}
+	if _, err := testDB.CreateTask(ctx, makeTaskInput(fileID, vaultID, 2, models.TaskStatusDone, "Done task", "hashdone")); err != nil {
+		t.Fatalf("CreateTask done failed: %v", err)
+	}
+
+	status := models.TaskStatusOpen
+	tasks, err := testDB.ListTasks(ctx, TaskFilter{VaultID: vaultID, Status: &status})
+	if err != nil {
+		t.Fatalf("ListTasks with status filter failed: %v", err)
+	}
+	for _, task := range tasks {
+		if task.Status != models.TaskStatusOpen {
+			t.Errorf("expected only open tasks, got status %q", task.Status)
+		}
+	}
+	// Must find the open task we created
+	var found bool
+	for _, task := range tasks {
+		if task.Text == "Open task" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("open task not found in status-filtered results")
+	}
+}
+
+func TestListTasks_LabelFilter(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/task-label-" + suffix + ".md", Title: "Task Label",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	// Task with label "work"
+	if _, err := testDB.CreateTask(ctx, models.TaskInput{
+		FileID: fileID, VaultID: vaultID, Status: models.TaskStatusOpen,
+		RawLine: "- [ ] Work task #work", Text: "Work task",
+		Labels: []string{"work"}, LineNumber: 1, ContentHash: "hashwork",
+	}); err != nil {
+		t.Fatalf("CreateTask work failed: %v", err)
+	}
+	// Task with label "personal"
+	if _, err := testDB.CreateTask(ctx, models.TaskInput{
+		FileID: fileID, VaultID: vaultID, Status: models.TaskStatusOpen,
+		RawLine: "- [ ] Personal task #personal", Text: "Personal task",
+		Labels: []string{"personal"}, LineNumber: 2, ContentHash: "hashpersonal",
+	}); err != nil {
+		t.Fatalf("CreateTask personal failed: %v", err)
+	}
+
+	tasks, err := testDB.ListTasks(ctx, TaskFilter{VaultID: vaultID, Labels: []string{"work"}})
+	if err != nil {
+		t.Fatalf("ListTasks with label filter failed: %v", err)
+	}
+	for _, task := range tasks {
+		hasLabel := slices.Contains(task.Labels, "work")
+		if !hasLabel {
+			t.Errorf("task %q does not have label 'work'", task.Text)
+		}
+	}
+	var found bool
+	for _, task := range tasks {
+		if task.Text == "Work task" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("work task not found in label-filtered results")
+	}
+}
+
+func TestListTasks_DueDateFilter(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/task-due-" + suffix + ".md", Title: "Task Due",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	earlyDate := "2026-01-10"
+	lateDate := "2026-12-31"
+
+	if _, err := testDB.CreateTask(ctx, models.TaskInput{
+		FileID: fileID, VaultID: vaultID, Status: models.TaskStatusOpen,
+		RawLine: "- [ ] Early task", Text: "Early task",
+		Labels: []string{}, DueDate: &earlyDate, LineNumber: 1, ContentHash: "hashearly",
+	}); err != nil {
+		t.Fatalf("CreateTask early failed: %v", err)
+	}
+	if _, err := testDB.CreateTask(ctx, models.TaskInput{
+		FileID: fileID, VaultID: vaultID, Status: models.TaskStatusOpen,
+		RawLine: "- [ ] Late task", Text: "Late task",
+		Labels: []string{}, DueDate: &lateDate, LineNumber: 2, ContentHash: "hashlate",
+	}); err != nil {
+		t.Fatalf("CreateTask late failed: %v", err)
+	}
+
+	// due_before=2026-06-01 should only return the early task
+	dueBefore := "2026-06-01"
+	tasks, err := testDB.ListTasks(ctx, TaskFilter{VaultID: vaultID, DueBefore: &dueBefore})
+	if err != nil {
+		t.Fatalf("ListTasks with due_before filter failed: %v", err)
+	}
+	for _, task := range tasks {
+		if task.DueDate != nil && *task.DueDate > dueBefore {
+			t.Errorf("task with due_date %q should not appear with due_before=%q", *task.DueDate, dueBefore)
+		}
+	}
+	var earlyFound bool
+	for _, task := range tasks {
+		if task.Text == "Early task" {
+			earlyFound = true
+			break
+		}
+	}
+	if !earlyFound {
+		t.Error("early task not found with due_before filter")
+	}
+
+	// due_after=2026-06-01 should only return the late task
+	dueAfter := "2026-06-01"
+	tasks, err = testDB.ListTasks(ctx, TaskFilter{VaultID: vaultID, DueAfter: &dueAfter})
+	if err != nil {
+		t.Fatalf("ListTasks with due_after filter failed: %v", err)
+	}
+	var lateFound bool
+	for _, task := range tasks {
+		if task.Text == "Late task" {
+			lateFound = true
+			break
+		}
+	}
+	if !lateFound {
+		t.Error("late task not found with due_after filter")
+	}
+}
+
+func TestListTasks_Pagination(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/task-page-" + suffix + ".md", Title: "Task Page",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	for i := range 3 {
+		if _, err := testDB.CreateTask(ctx, makeTaskInput(
+			fileID, vaultID, i+1, models.TaskStatusOpen,
+			fmt.Sprintf("Task %d", i+1),
+			fmt.Sprintf("hashpage%d", i),
+		)); err != nil {
+			t.Fatalf("CreateTask %d failed: %v", i, err)
+		}
+	}
+
+	// All 3 tasks should be present
+	all, err := testDB.ListTasks(ctx, TaskFilter{VaultID: vaultID})
+	if err != nil {
+		t.Fatalf("ListTasks all failed: %v", err)
+	}
+	if len(all) < 3 {
+		t.Fatalf("expected at least 3 tasks, got %d", len(all))
+	}
+
+	// limit=2, offset=1 → should return 2 tasks
+	paged, err := testDB.ListTasks(ctx, TaskFilter{VaultID: vaultID, Limit: 2, Offset: 1})
+	if err != nil {
+		t.Fatalf("ListTasks with pagination failed: %v", err)
+	}
+	if len(paged) != 2 {
+		t.Errorf("expected 2 tasks with limit=2 offset=1, got %d", len(paged))
+	}
+}
+
+func TestCountTasks(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/task-count-" + suffix + ".md", Title: "Task Count",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	for i := range 4 {
+		if _, err := testDB.CreateTask(ctx, makeTaskInput(
+			fileID, vaultID, i+1, models.TaskStatusOpen,
+			fmt.Sprintf("Count task %d", i+1),
+			fmt.Sprintf("hashcount%d-%s", i, suffix),
+		)); err != nil {
+			t.Fatalf("CreateTask %d failed: %v", i, err)
+		}
+	}
+
+	count, err := testDB.CountTasks(ctx, TaskFilter{VaultID: vaultID})
+	if err != nil {
+		t.Fatalf("CountTasks failed: %v", err)
+	}
+	if count < 4 {
+		t.Errorf("expected at least 4 tasks, got %d", count)
+	}
+
+	// Count and List must agree
+	tasks, err := testDB.ListTasks(ctx, TaskFilter{VaultID: vaultID})
+	if err != nil {
+		t.Fatalf("ListTasks failed: %v", err)
+	}
+	if count != len(tasks) {
+		t.Errorf("CountTasks=%d does not match ListTasks count=%d", count, len(tasks))
+	}
+}
+
+func TestListTasks_FolderFilter(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	fileInFolder, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/daily-" + suffix + "/2026-03-17.md", Title: "Daily Note",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile in folder failed: %v", err)
+	}
+	fileOutside, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/projects-" + suffix + "/readme.md", Title: "Project Readme",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile outside failed: %v", err)
+	}
+	inFolderID := models.MustRecordIDString(fileInFolder.ID)
+	outsideID := models.MustRecordIDString(fileOutside.ID)
+
+	if _, err := testDB.CreateTask(ctx, makeTaskInput(inFolderID, vaultID, 1, models.TaskStatusOpen, "In folder task", "hashinfolder"+suffix)); err != nil {
+		t.Fatalf("CreateTask in folder failed: %v", err)
+	}
+	if _, err := testDB.CreateTask(ctx, makeTaskInput(outsideID, vaultID, 1, models.TaskStatusOpen, "Outside task", "hashoutside"+suffix)); err != nil {
+		t.Fatalf("CreateTask outside failed: %v", err)
+	}
+
+	// Filter by folder prefix
+	folder := "/daily-" + suffix + "/"
+	tasks, err := testDB.ListTasks(ctx, TaskFilter{VaultID: vaultID, Folder: &folder})
+	if err != nil {
+		t.Fatalf("ListTasks with folder filter failed: %v", err)
+	}
+	var found bool
+	for _, task := range tasks {
+		if task.Text == "In folder task" {
+			found = true
+		}
+		if task.Text == "Outside task" {
+			t.Error("outside task should not appear with folder filter")
+		}
+	}
+	if !found {
+		t.Error("in-folder task not found with folder filter")
+	}
+}
+
+func TestListTasks_FilePathFilter(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	filePath := "/exact-file-" + suffix + ".md"
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: filePath, Title: "Exact File",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	otherFile, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/other-file-" + suffix + ".md", Title: "Other File",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile other failed: %v", err)
+	}
+	otherFileID := models.MustRecordIDString(otherFile.ID)
+
+	if _, err := testDB.CreateTask(ctx, makeTaskInput(fileID, vaultID, 1, models.TaskStatusOpen, "Target task", "hashtarget"+suffix)); err != nil {
+		t.Fatalf("CreateTask target failed: %v", err)
+	}
+	if _, err := testDB.CreateTask(ctx, makeTaskInput(otherFileID, vaultID, 1, models.TaskStatusOpen, "Other task", "hashother"+suffix)); err != nil {
+		t.Fatalf("CreateTask other failed: %v", err)
+	}
+
+	tasks, err := testDB.ListTasks(ctx, TaskFilter{VaultID: vaultID, FilePath: &filePath})
+	if err != nil {
+		t.Fatalf("ListTasks with file_path filter failed: %v", err)
+	}
+	var found bool
+	for _, task := range tasks {
+		if task.Text == "Target task" {
+			found = true
+		}
+		if task.Text == "Other task" {
+			t.Error("other task should not appear with exact file_path filter")
+		}
+	}
+	if !found {
+		t.Error("target task not found with file_path filter")
+	}
+}
+
+func TestListTasks_DocPathAndDocTitle(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	filePath := "/denorm-" + suffix + ".md"
+	fileTitle := "Denorm Doc " + suffix
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: filePath, Title: fileTitle,
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	if _, err := testDB.CreateTask(ctx, makeTaskInput(fileID, vaultID, 1, models.TaskStatusOpen, "Denorm task", "hashdenorm"+suffix)); err != nil {
+		t.Fatalf("CreateTask failed: %v", err)
+	}
+
+	tasks, err := testDB.ListTasks(ctx, TaskFilter{VaultID: vaultID})
+	if err != nil {
+		t.Fatalf("ListTasks failed: %v", err)
+	}
+	for _, task := range tasks {
+		if task.Text == "Denorm task" {
+			if task.DocPath != filePath {
+				t.Errorf("expected doc_path %q, got %q", filePath, task.DocPath)
+			}
+			if task.DocTitle != fileTitle {
+				t.Errorf("expected doc_title %q, got %q", fileTitle, task.DocTitle)
+			}
+			return
+		}
+	}
+	t.Error("denorm task not found in results")
+}

--- a/internal/db/queries_user_test.go
+++ b/internal/db/queries_user_test.go
@@ -67,6 +67,45 @@ func TestGetUser(t *testing.T) {
 	}
 }
 
+func TestUpdateUserSystemAdmin(t *testing.T) {
+	ctx := context.Background()
+
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+
+	// Set admin=true
+	if err := testDB.UpdateUserSystemAdmin(ctx, userID, true); err != nil {
+		t.Fatalf("UpdateUserSystemAdmin true failed: %v", err)
+	}
+
+	got, err := testDB.GetUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("GetUser failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetUser returned nil")
+	}
+	if !got.IsSystemAdmin {
+		t.Error("Expected is_system_admin=true")
+	}
+
+	// Set admin=false
+	if err := testDB.UpdateUserSystemAdmin(ctx, userID, false); err != nil {
+		t.Fatalf("UpdateUserSystemAdmin false failed: %v", err)
+	}
+
+	got2, err := testDB.GetUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("GetUser failed: %v", err)
+	}
+	if got2 == nil {
+		t.Fatal("GetUser returned nil")
+	}
+	if got2.IsSystemAdmin {
+		t.Error("Expected is_system_admin=false")
+	}
+}
+
 func TestGetUserByName(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/db/queries_vault_member.go
+++ b/internal/db/queries_vault_member.go
@@ -55,30 +55,3 @@ func (c *Client) GetVaultMembers(ctx context.Context, vaultID string) ([]models.
 	}
 	return allResults(results), nil
 }
-
-// UpdateVaultMemberRole updates the role of a vault member.
-func (c *Client) UpdateVaultMemberRole(ctx context.Context, userID, vaultID string, role models.VaultRole) error {
-	defer c.logOp(ctx, "vault_member.update_role", time.Now())
-	sql := `UPDATE vault_member SET role = $role WHERE user = type::record("user", $user_id) AND vault = type::record("vault", $vault_id)`
-	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
-		"user_id":  bareID("user", userID),
-		"vault_id": bareID("vault", vaultID),
-		"role":     string(role),
-	}); err != nil {
-		return fmt.Errorf("update vault member role: %w", err)
-	}
-	return nil
-}
-
-// DeleteVaultMember removes a user's membership from a vault.
-func (c *Client) DeleteVaultMember(ctx context.Context, userID, vaultID string) error {
-	defer c.logOp(ctx, "vault_member.delete", time.Now())
-	sql := `DELETE FROM vault_member WHERE user = type::record("user", $user_id) AND vault = type::record("vault", $vault_id)`
-	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
-		"user_id":  bareID("user", userID),
-		"vault_id": bareID("vault", vaultID),
-	}); err != nil {
-		return fmt.Errorf("delete vault member: %w", err)
-	}
-	return nil
-}

--- a/internal/db/queries_vault_member_test.go
+++ b/internal/db/queries_vault_member_test.go
@@ -1,0 +1,108 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/raphi011/know/internal/models"
+)
+
+func TestCreateVaultMember(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	member, err := testDB.CreateVaultMember(ctx, userID, vaultID, models.RoleRead)
+	if err != nil {
+		t.Fatalf("CreateVaultMember failed: %v", err)
+	}
+	if member == nil {
+		t.Fatal("CreateVaultMember returned nil")
+	}
+	if member.Role != string(models.RoleRead) {
+		t.Errorf("expected role %q, got %q", models.RoleRead, member.Role)
+	}
+	if models.MustRecordIDString(member.User) != userID {
+		t.Errorf("expected user %q, got %q", userID, models.MustRecordIDString(member.User))
+	}
+	if models.MustRecordIDString(member.Vault) != vaultID {
+		t.Errorf("expected vault %q, got %q", vaultID, models.MustRecordIDString(member.Vault))
+	}
+	if member.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be set")
+	}
+}
+
+func TestGetVaultMemberships(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+
+	vault1 := createTestVault(t, ctx, userID)
+	vault1ID := models.MustRecordIDString(vault1.ID)
+	vault2 := createTestVault(t, ctx, userID)
+	vault2ID := models.MustRecordIDString(vault2.ID)
+
+	_, err := testDB.CreateVaultMember(ctx, userID, vault1ID, models.RoleRead)
+	if err != nil {
+		t.Fatalf("CreateVaultMember vault1 failed: %v", err)
+	}
+	_, err = testDB.CreateVaultMember(ctx, userID, vault2ID, models.RoleWrite)
+	if err != nil {
+		t.Fatalf("CreateVaultMember vault2 failed: %v", err)
+	}
+
+	memberships, err := testDB.GetVaultMemberships(ctx, userID)
+	if err != nil {
+		t.Fatalf("GetVaultMemberships failed: %v", err)
+	}
+
+	vaultIDs := make(map[string]bool)
+	for _, m := range memberships {
+		vaultIDs[models.MustRecordIDString(m.Vault)] = true
+	}
+	if !vaultIDs[vault1ID] {
+		t.Errorf("expected vault1 %q in memberships", vault1ID)
+	}
+	if !vaultIDs[vault2ID] {
+		t.Errorf("expected vault2 %q in memberships", vault2ID)
+	}
+}
+
+func TestGetVaultMembers(t *testing.T) {
+	ctx := context.Background()
+	owner := createTestUser(t, ctx)
+	ownerID := models.MustRecordIDString(owner.ID)
+	vault := createTestVault(t, ctx, ownerID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	user2 := createTestUser(t, ctx)
+	user2ID := models.MustRecordIDString(user2.ID)
+
+	_, err := testDB.CreateVaultMember(ctx, ownerID, vaultID, models.RoleAdmin)
+	if err != nil {
+		t.Fatalf("CreateVaultMember owner failed: %v", err)
+	}
+	_, err = testDB.CreateVaultMember(ctx, user2ID, vaultID, models.RoleRead)
+	if err != nil {
+		t.Fatalf("CreateVaultMember user2 failed: %v", err)
+	}
+
+	members, err := testDB.GetVaultMembers(ctx, vaultID)
+	if err != nil {
+		t.Fatalf("GetVaultMembers failed: %v", err)
+	}
+
+	userIDs := make(map[string]bool)
+	for _, m := range members {
+		userIDs[models.MustRecordIDString(m.User)] = true
+	}
+	if !userIDs[ownerID] {
+		t.Errorf("expected owner %q in members", ownerID)
+	}
+	if !userIDs[user2ID] {
+		t.Errorf("expected user2 %q in members", user2ID)
+	}
+}

--- a/internal/db/queries_vault_test.go
+++ b/internal/db/queries_vault_test.go
@@ -162,6 +162,91 @@ func TestGetVaultByName(t *testing.T) {
 	}
 }
 
+func TestUpdateVaultSettings(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	settings := models.VaultSettings{
+		MemoryPath:   "/custom-memories",
+		TemplatePath: "/custom-templates",
+		RRFK:         80,
+	}
+	updated, err := testDB.UpdateVaultSettings(ctx, vaultID, settings)
+	if err != nil {
+		t.Fatalf("UpdateVaultSettings failed: %v", err)
+	}
+	if updated == nil {
+		t.Fatal("UpdateVaultSettings returned nil")
+	}
+	if updated.Settings == nil {
+		t.Fatal("Expected settings to be set")
+	}
+	if updated.Settings.MemoryPath != "/custom-memories" {
+		t.Errorf("Expected memory_path '/custom-memories', got %q", updated.Settings.MemoryPath)
+	}
+	if updated.Settings.RRFK != 80 {
+		t.Errorf("Expected rrf_k 80, got %d", updated.Settings.RRFK)
+	}
+
+	// Re-fetch to confirm persistence
+	fetched, err := testDB.GetVault(ctx, vaultID)
+	if err != nil {
+		t.Fatalf("GetVault after settings update failed: %v", err)
+	}
+	if fetched == nil || fetched.Settings == nil {
+		t.Fatal("GetVault returned nil or nil settings")
+	}
+	if fetched.Settings.TemplatePath != "/custom-templates" {
+		t.Errorf("Expected template_path '/custom-templates', got %q", fetched.Settings.TemplatePath)
+	}
+}
+
+func TestGetVaultInfo(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+
+	// Create a file with chunks and labels so stats are non-zero
+	doc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID,
+		Path:    "/info-test-" + suffix + ".md",
+		Title:   "Info Test",
+		Content: "content for info test",
+		Labels:  []string{"info-label"},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	if err := testDB.CreateChunks(ctx, []models.ChunkInput{
+		{FileID: docID, Text: "Info chunk", Position: 0, Embedding: dummyEmbedding()},
+	}); err != nil {
+		t.Fatalf("CreateChunks failed: %v", err)
+	}
+
+	info, err := testDB.GetVaultInfo(ctx, vaultID)
+	if err != nil {
+		t.Fatalf("GetVaultInfo failed: %v", err)
+	}
+	if info == nil {
+		t.Fatal("GetVaultInfo returned nil")
+	}
+	if info.DocumentCount < 1 {
+		t.Errorf("Expected DocumentCount >= 1, got %d", info.DocumentCount)
+	}
+	if info.ChunkTotal < 1 {
+		t.Errorf("Expected ChunkTotal >= 1, got %d", info.ChunkTotal)
+	}
+}
+
 func TestListDocumentPaths(t *testing.T) {
 	ctx := context.Background()
 	user := createTestUser(t, ctx)

--- a/internal/db/queries_wikilink_test.go
+++ b/internal/db/queries_wikilink_test.go
@@ -189,3 +189,244 @@ func TestDeleteWikiLinks(t *testing.T) {
 		t.Errorf("Expected 0 wiki links after delete, got %d", len(links))
 	}
 }
+
+func TestResolveDanglingLinksByStem(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	// Source file with a dangling link whose raw_target normalizes to stem "beta-notes"
+	src, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/resolve-src.md", Title: "Resolve Src",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile src failed: %v", err)
+	}
+	srcID := models.MustRecordIDString(src.ID)
+
+	// Target file at path "/beta-notes.md" — stem computed from path
+	target, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/beta-notes.md", Title: "Beta Notes",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile target failed: %v", err)
+	}
+	targetID := models.MustRecordIDString(target.ID)
+
+	// Create dangling link with raw_target "Beta Notes" (no ToFileID)
+	if err := testDB.CreateWikiLinks(ctx, srcID, vaultID, []WikiLinkInput{
+		{RawTarget: "Beta Notes"},
+	}); err != nil {
+		t.Fatalf("CreateWikiLinks failed: %v", err)
+	}
+
+	count, err := testDB.ResolveDanglingLinksByStem(ctx, vaultID, "beta-notes", targetID)
+	if err != nil {
+		t.Fatalf("ResolveDanglingLinksByStem failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("Expected 1 resolved link, got %d", count)
+	}
+
+	links, err := testDB.GetWikiLinksToFile(ctx, targetID)
+	if err != nil {
+		t.Fatalf("GetWikiLinksToFile failed: %v", err)
+	}
+	if len(links) != 1 {
+		t.Errorf("Expected 1 link pointing to target, got %d", len(links))
+	}
+}
+
+func TestUnresolveStemOnlyLinks(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	src, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/unresolve-stem-src.md", Title: "Unresolve Stem Src",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile src failed: %v", err)
+	}
+	srcID := models.MustRecordIDString(src.ID)
+
+	target, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/some-page.md", Title: "Some Page",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile target failed: %v", err)
+	}
+	targetID := models.MustRecordIDString(target.ID)
+
+	// Create a resolved link (with ToFileID set)
+	if err := testDB.CreateWikiLinks(ctx, srcID, vaultID, []WikiLinkInput{
+		{RawTarget: "Some Page", ToFileID: &targetID},
+	}); err != nil {
+		t.Fatalf("CreateWikiLinks failed: %v", err)
+	}
+
+	count, err := testDB.UnresolveStemOnlyLinks(ctx, vaultID, "some-page")
+	if err != nil {
+		t.Fatalf("UnresolveStemOnlyLinks failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("Expected 1 unresolved link, got %d", count)
+	}
+
+	links, err := testDB.GetWikiLinks(ctx, srcID)
+	if err != nil {
+		t.Fatalf("GetWikiLinks failed: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("Expected 1 link preserved, got %d", len(links))
+	}
+	if links[0].ToFile != nil {
+		t.Error("Expected to_file to be nil after unresolve")
+	}
+}
+
+func TestGetWikiLinksToFile(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	docA, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/wlto-a.md", Title: "WLTO A",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile A failed: %v", err)
+	}
+	docB, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/wlto-b.md", Title: "WLTO B",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile B failed: %v", err)
+	}
+	docAID := models.MustRecordIDString(docA.ID)
+	docBID := models.MustRecordIDString(docB.ID)
+
+	if err := testDB.CreateWikiLinks(ctx, docAID, vaultID, []WikiLinkInput{
+		{RawTarget: "WLTO B", ToFileID: &docBID},
+	}); err != nil {
+		t.Fatalf("CreateWikiLinks failed: %v", err)
+	}
+
+	links, err := testDB.GetWikiLinksToFile(ctx, docBID)
+	if err != nil {
+		t.Fatalf("GetWikiLinksToFile failed: %v", err)
+	}
+	if len(links) != 1 {
+		t.Errorf("Expected 1 link to B, got %d", len(links))
+	}
+}
+
+func TestBatchUpdateWikiLinkRawTargets(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	doc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/batch-raw-target.md", Title: "Batch Raw Target",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	if err := testDB.CreateWikiLinks(ctx, docID, vaultID, []WikiLinkInput{
+		{RawTarget: "Old Target One"},
+		{RawTarget: "Old Target Two"},
+	}); err != nil {
+		t.Fatalf("CreateWikiLinks failed: %v", err)
+	}
+
+	links, err := testDB.GetWikiLinks(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetWikiLinks failed: %v", err)
+	}
+	if len(links) != 2 {
+		t.Fatalf("Expected 2 links, got %d", len(links))
+	}
+
+	linkIDs := []string{
+		models.MustRecordIDString(links[0].ID),
+		models.MustRecordIDString(links[1].ID),
+	}
+
+	if err := testDB.BatchUpdateWikiLinkRawTargets(ctx, linkIDs, "New Target"); err != nil {
+		t.Fatalf("BatchUpdateWikiLinkRawTargets failed: %v", err)
+	}
+
+	updated, err := testDB.GetWikiLinks(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetWikiLinks after batch update failed: %v", err)
+	}
+	for _, l := range updated {
+		if l.RawTarget != "New Target" {
+			t.Errorf("Expected raw_target 'New Target', got %q", l.RawTarget)
+		}
+	}
+}
+
+func TestGetWikiLinksWithTargetInfo(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	src, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/wlinfo-src.md", Title: "WLInfo Src",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile src failed: %v", err)
+	}
+	target, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/wlinfo-target.md", Title: "WLInfo Target",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile target failed: %v", err)
+	}
+	srcID := models.MustRecordIDString(src.ID)
+	targetID := models.MustRecordIDString(target.ID)
+
+	if err := testDB.CreateWikiLinks(ctx, srcID, vaultID, []WikiLinkInput{
+		{RawTarget: "WLInfo Target", ToFileID: &targetID},
+	}); err != nil {
+		t.Fatalf("CreateWikiLinks failed: %v", err)
+	}
+
+	infos, err := testDB.GetWikiLinksWithTargetInfo(ctx, srcID)
+	if err != nil {
+		t.Fatalf("GetWikiLinksWithTargetInfo failed: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("Expected 1 link with target info, got %d", len(infos))
+	}
+	if infos[0].RawTarget != "WLInfo Target" {
+		t.Errorf("Expected raw_target 'WLInfo Target', got %q", infos[0].RawTarget)
+	}
+	if infos[0].Path == nil || *infos[0].Path != "/wlinfo-target.md" {
+		t.Errorf("Expected path '/wlinfo-target.md', got %v", infos[0].Path)
+	}
+	if infos[0].Title == nil || *infos[0].Title != "WLInfo Target" {
+		t.Errorf("Expected title 'WLInfo Target', got %v", infos[0].Title)
+	}
+}


### PR DESCRIPTION
Add integration tests covering every public method in `internal/db/queries_*.go`, remove dead code, and fix a SurrealDB reserved variable collision.

## New Features

- 6 new test files: `queries_external_link_test.go`, `queries_job_test.go`, `queries_remote_test.go`, `queries_share_link_test.go`, `queries_task_test.go`, `queries_vault_member_test.go`
- Extended 8 existing test files with coverage for previously untested methods
- Tests cover: CRUD round-trips, edge cases (not-found, empty inputs, validation errors), pagination, ordering, cascading deletes, folder operations (EnsureFolderPath, MoveFoldersByPrefix), ListFiles filters (OrderBy, DocType, MimeType, IsFolder), ListTasks filters (Folder, FilePath, doc_path/doc_title denormalization)
- Added CLAUDE.md guidelines: integration test requirement, N+1 query avoidance

## Breaking Changes
- Removed unused query methods: `UpdateFileAccess`, `ListSyncMetadata`, `ListTombstones`, `SyncMeta`, `SyncTombstone`, `ListFailedJobs`, `CreateShareLink`, `GetShareLink`, `ListShareLinks`, `DeleteShareLink`, `DeleteTasksByFile`, `UpdateVaultMemberRole`, `DeleteVaultMember`
- Renamed SurrealDB bind variable `$token` → `$api_token` in `CreateRemote` (fixes reserved word collision)
- `ListRemotes` now uses standard `allResults()` helper