### PR TITLE
feat: add PDF ingestion pipeline with multimodal embedding

### DIFF
--- a/cmd/know/cmd_info.go
+++ b/cmd/know/cmd_info.go
@@ -43,6 +43,21 @@ type serverInfo struct {
 	ChunkMaxSize           int    `json:"chunkMaxSize"`
 	VersionCoalesceMinutes int    `json:"versionCoalesceMinutes"`
 	VersionRetentionCount  int    `json:"versionRetentionCount"`
+
+	// Audio pipeline
+	STTProvider          string `json:"sttProvider"`
+	STTModel             string `json:"sttModel"`
+	TranscriptionEnabled bool   `json:"transcriptionEnabled"`
+	FFmpegInstalled      bool   `json:"ffmpegInstalled"`
+
+	// PDF pipeline
+	PopplerInstalled        bool   `json:"popplerInstalled"`
+	PDFIngestionEnabled     bool   `json:"pdfIngestionEnabled"`
+	MultimodalEmbedProvider string `json:"multimodalEmbedProvider"`
+	MultimodalEmbedModel    string `json:"multimodalEmbedModel"`
+	MultimodalEmbedEnabled  bool   `json:"multimodalEmbedEnabled"`
+	TextExtractorModel      string `json:"textExtractorModel"`
+	TextExtractorEnabled    bool   `json:"textExtractorEnabled"`
 }
 
 func runInfo(_ *cobra.Command, _ []string) error {
@@ -98,6 +113,20 @@ func runInfo(_ *cobra.Command, _ []string) error {
 			{"Version Coalesce (min)", strconv.Itoa(cfg.VersionCoalesceMinutes)},
 			{"Version Retention", strconv.Itoa(cfg.VersionRetentionCount)},
 		},
+		// Audio Pipeline
+		{
+			{"STT Provider", infoValueOrDisabled(cfg.STTProvider)},
+			{"STT Model", infoValueOrDisabled(cfg.STTModel)},
+			{"Transcription", strconv.FormatBool(cfg.TranscriptionEnabled)},
+			{"FFmpeg", installedOrHint(cfg.FFmpegInstalled, "brew install ffmpeg")},
+		},
+		// PDF Pipeline
+		{
+			{"Poppler", installedOrHint(cfg.PopplerInstalled, "brew install poppler")},
+			{"PDF Ingestion", strconv.FormatBool(cfg.PDFIngestionEnabled)},
+			{"Text Extractor", infoValueOrHint(cfg.TextExtractorModel, cfg.TextExtractorEnabled, "set GOOGLE_AI_API_KEY")},
+			{"Multimodal Embed", infoValueOrHint(cfg.MultimodalEmbedModel, cfg.MultimodalEmbedEnabled, "set KNOW_MULTIMODAL_EMBED_PROVIDER")},
+		},
 	}
 
 	for i, group := range groups {
@@ -109,4 +138,28 @@ func runInfo(_ *cobra.Command, _ []string) error {
 		}
 	}
 	return nil
+}
+
+// infoValueOrDisabled returns the value or "disabled" if empty.
+func infoValueOrDisabled(v string) string {
+	if v == "" || v == "none" {
+		return "disabled"
+	}
+	return v
+}
+
+// installedOrHint returns "installed" or "not found (hint)".
+func installedOrHint(installed bool, hint string) string {
+	if installed {
+		return "installed"
+	}
+	return "not found (" + hint + ")"
+}
+
+// infoValueOrHint returns the value if enabled, or "disabled (hint)" if not.
+func infoValueOrHint(value string, enabled bool, hint string) string {
+	if enabled && value != "" {
+		return value
+	}
+	return "disabled (" + hint + ")"
 }

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -22,5 +22,18 @@ func (s *Server) getConfig(w http.ResponseWriter, r *http.Request) {
 		ChunkMaxSize:           cfg.ChunkMaxSize,
 		VersionCoalesceMinutes: cfg.VersionCoalesceMinutes,
 		VersionRetentionCount:  cfg.VersionRetentionCount,
+
+		STTProvider:          cfg.STTProvider,
+		STTModel:             cfg.STTModel,
+		TranscriptionEnabled: cfg.TranscriptionEnabled,
+		FFmpegInstalled:      cfg.FFmpegInstalled,
+
+		PopplerInstalled:        cfg.PopplerInstalled,
+		PDFIngestionEnabled:     cfg.PDFIngestionEnabled,
+		MultimodalEmbedProvider: cfg.MultimodalEmbedProvider,
+		MultimodalEmbedModel:    cfg.MultimodalEmbedModel,
+		MultimodalEmbedEnabled:  cfg.MultimodalEmbedEnabled,
+		TextExtractorModel:      cfg.TextExtractorModel,
+		TextExtractorEnabled:    cfg.TextExtractorEnabled,
 	})
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -173,4 +173,19 @@ type ServerConfig struct {
 	ChunkMaxSize           int    `json:"chunkMaxSize"`
 	VersionCoalesceMinutes int    `json:"versionCoalesceMinutes"`
 	VersionRetentionCount  int    `json:"versionRetentionCount"`
+
+	// Audio pipeline
+	STTProvider          string `json:"sttProvider"`
+	STTModel             string `json:"sttModel"`
+	TranscriptionEnabled bool   `json:"transcriptionEnabled"`
+	FFmpegInstalled      bool   `json:"ffmpegInstalled"`
+
+	// PDF pipeline
+	PopplerInstalled        bool   `json:"popplerInstalled"`
+	PDFIngestionEnabled     bool   `json:"pdfIngestionEnabled"`
+	MultimodalEmbedProvider string `json:"multimodalEmbedProvider"`
+	MultimodalEmbedModel    string `json:"multimodalEmbedModel"`
+	MultimodalEmbedEnabled  bool   `json:"multimodalEmbedEnabled"`
+	TextExtractorModel      string `json:"textExtractorModel"`
+	TextExtractorEnabled    bool   `json:"textExtractorEnabled"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,10 @@ type Config struct {
 	MultimodalEmbedProvider LLMProvider // KNOW_MULTIMODAL_EMBED_PROVIDER (default: "none")
 	MultimodalEmbedModel    string      // KNOW_MULTIMODAL_EMBED_MODEL
 
+	// PDF processing
+	TextExtractorModel string // KNOW_TEXT_EXTRACTOR_MODEL (default: "gemini-2.0-flash")
+	PDFRenderDPI       int    // KNOW_PDF_RENDER_DPI (default: 300)
+
 	// Audio chunking
 	AudioSegmentSeconds int // max audio segment duration in seconds (default: 60, max 80 for Gemini)
 
@@ -196,6 +200,10 @@ func Load() Config {
 		// Multimodal embedding
 		MultimodalEmbedProvider: LLMProvider(getEnv("KNOW_MULTIMODAL_EMBED_PROVIDER", "none")),
 		MultimodalEmbedModel:    getEnv("KNOW_MULTIMODAL_EMBED_MODEL", ""),
+
+		// PDF processing
+		TextExtractorModel: getEnv("KNOW_TEXT_EXTRACTOR_MODEL", "gemini-2.0-flash"),
+		PDFRenderDPI:       getEnvInt("KNOW_PDF_RENDER_DPI", 300),
 
 		// Audio chunking
 		AudioSegmentSeconds: getEnvInt("KNOW_AUDIO_SEGMENT_SECONDS", 60),

--- a/internal/db/queries_chunk.go
+++ b/internal/db/queries_chunk.go
@@ -36,6 +36,9 @@ func (c *Client) CreateChunks(ctx context.Context, chunks []models.ChunkInput) e
 			"labels":     labels,
 			"mime_type":  ch.MimeType,
 		}
+		if ch.DataHash != nil {
+			row["data_hash"] = *ch.DataHash
+		}
 
 		if len(ch.Embedding) > 0 {
 			row["embedding"] = ch.Embedding

--- a/internal/db/queries_chunk_test.go
+++ b/internal/db/queries_chunk_test.go
@@ -51,6 +51,80 @@ func TestCreateAndGetChunks(t *testing.T) {
 	}
 }
 
+func TestCreateChunksWithDataHash(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	doc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID,
+		Path:    "/chunk-datahash-test.pdf",
+		Title:   "DataHash Test",
+		Content: "",
+		Labels:  []string{"test"},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	hash := "abc123def456"
+	sourceLoc := "Page 1"
+	err = testDB.CreateChunks(ctx, []models.ChunkInput{
+		{
+			FileID:    docID,
+			Text:      "PDF page text",
+			MimeType:  "image/png",
+			Position:  1,
+			SourceLoc: &sourceLoc,
+			DataHash:  &hash,
+			Labels:    []string{"test"},
+		},
+		{
+			FileID:   docID,
+			Text:     "Text-only chunk",
+			MimeType: "text/plain",
+			Position: 2,
+			Labels:   []string{"test"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateChunks failed: %v", err)
+	}
+
+	chunks, err := testDB.GetChunks(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetChunks failed: %v", err)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("Expected 2 chunks, got %d", len(chunks))
+	}
+
+	// Chunk with DataHash should round-trip.
+	if chunks[0].DataHash == nil {
+		t.Fatal("Expected DataHash to be set on chunk 0")
+	}
+	if *chunks[0].DataHash != hash {
+		t.Errorf("Expected DataHash %q, got %q", hash, *chunks[0].DataHash)
+	}
+	if chunks[0].MimeType != "image/png" {
+		t.Errorf("Expected MimeType 'image/png', got %q", chunks[0].MimeType)
+	}
+	if !chunks[0].IsMultimodal() {
+		t.Error("Expected chunk with DataHash+image/png to be multimodal")
+	}
+
+	// Chunk without DataHash.
+	if chunks[1].DataHash != nil {
+		t.Errorf("Expected DataHash to be nil on chunk 1, got %v", *chunks[1].DataHash)
+	}
+	if chunks[1].IsMultimodal() {
+		t.Error("Expected text-only chunk to not be multimodal")
+	}
+}
+
 func TestDeleteChunks(t *testing.T) {
 	ctx := context.Background()
 	user := createTestUser(t, ctx)

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -145,6 +145,7 @@ func SchemaSQL(dimension int) string {
     DEFINE FIELD IF NOT EXISTS position   ON chunk TYPE int;
     DEFINE FIELD IF NOT EXISTS source_loc ON chunk TYPE option<string>;
     DEFINE FIELD IF NOT EXISTS labels     ON chunk TYPE array<string> DEFAULT [];
+    DEFINE FIELD IF NOT EXISTS data_hash  ON chunk TYPE option<string>;
     DEFINE FIELD IF NOT EXISTS embedding  ON chunk TYPE option<array<float>>;
     DEFINE FIELD IF NOT EXISTS created_at ON chunk TYPE datetime DEFAULT time::now();
 

--- a/internal/file/pdf_handler.go
+++ b/internal/file/pdf_handler.go
@@ -1,0 +1,245 @@
+package file
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/raphi011/know/internal/blob"
+	"github.com/raphi011/know/internal/event"
+	"github.com/raphi011/know/internal/llm"
+	"github.com/raphi011/know/internal/logutil"
+	"github.com/raphi011/know/internal/models"
+	"github.com/raphi011/know/internal/pipeline"
+)
+
+// PDFHandler returns a pipeline.Handler that processes PDF files:
+// renders pages as PNGs, extracts text via LLM (or pdftotext fallback),
+// stores page images in the blob store, and creates chunks.
+// Returns an error if poppler is not installed so the job stays in the queue.
+func PDFHandler(svc *Service, bus *event.Bus) pipeline.Handler {
+	return func(ctx context.Context, job models.PipelineJob) error {
+		logger := logutil.FromCtx(ctx)
+
+		fileID, err := models.RecordIDString(job.File)
+		if err != nil {
+			return fmt.Errorf("extract file id: %w", err)
+		}
+
+		doc, err := svc.db.GetFileByID(ctx, fileID)
+		if err != nil {
+			return fmt.Errorf("get file: %w", err)
+		}
+		if doc == nil {
+			logger.Warn("pdf job references missing file, skipping", "file_id", fileID)
+			return nil
+		}
+
+		logger = logger.With("path", doc.Path, "file_id", fileID)
+
+		// Check poppler availability — return error so the job stays in the
+		// queue and can be retried after installing poppler.
+		if err := pipeline.CheckPoppler(); err != nil {
+			return fmt.Errorf("poppler not installed (install with: brew install poppler): %w", err)
+		}
+
+		if err := svc.processPDF(ctx, doc, fileID); err != nil {
+			return fmt.Errorf("process pdf: %w", err)
+		}
+
+		// Enqueue embed job if any embedder is configured.
+		if svc.getEmbedder() != nil || svc.getMultimodalEmbedder() != nil {
+			if err := svc.db.CreateJob(ctx, fileID, "embed", 0); err != nil {
+				return fmt.Errorf("create embed job for %s: %w", doc.Path, err)
+			}
+			if bus != nil {
+				bus.Publish(event.ChangeEvent{Type: "job.created"})
+			}
+		}
+
+		vaultID, err := models.RecordIDString(doc.Vault)
+		if err != nil {
+			logger.Warn("failed to extract vault id after pdf processing", "file_id", fileID, "error", err)
+		} else {
+			svc.publishFileEvent("file.processed", vaultID, doc)
+		}
+		return nil
+	}
+}
+
+// processPDF renders each page of a PDF as PNG, extracts text, stores page
+// images in the blob store, and creates one chunk per page.
+func (s *Service) processPDF(ctx context.Context, f *models.File, fileID string) error {
+	logger := logutil.FromCtx(ctx).With("path", f.Path)
+
+	if f.ContentHash == nil {
+		return fmt.Errorf("file has no content hash")
+	}
+
+	// Resolve PDF to a local file path for poppler CLI tools.
+	pdfPath, cleanup, err := s.resolveBlobPath(ctx, f)
+	if err != nil {
+		return fmt.Errorf("resolve blob path: %w", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	// Create temp directory for rendered PNGs.
+	tmpDir, err := os.MkdirTemp("", "know-pdf-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Render all pages as PNGs.
+	dpi := s.pdfRenderDPI
+	if dpi <= 0 {
+		dpi = 300
+	}
+	pngPaths, err := pipeline.RenderPages(ctx, pdfPath, dpi, tmpDir)
+	if err != nil {
+		return fmt.Errorf("render pages: %w", err)
+	}
+
+	logger.Info("rendered pdf pages", "page_count", len(pngPaths))
+
+	// Get labels for chunks.
+	labels := f.Labels
+	if labels == nil {
+		labels = []string{}
+	}
+
+	// Process each page: extract text + store PNG.
+	var chunks []models.ChunkInput
+	var allText strings.Builder
+
+	textExtractor := s.getTextExtractor()
+
+	for i, pngPath := range pngPaths {
+		pageNum := i + 1
+
+		// Read PNG bytes.
+		pngData, err := os.ReadFile(pngPath)
+		if err != nil {
+			return fmt.Errorf("read page %d png: %w", pageNum, err)
+		}
+
+		// Store PNG in blob store.
+		pngHash := sha256Hex(pngData)
+		if err := s.blobStore.Put(ctx, pngHash, bytes.NewReader(pngData), int64(len(pngData))); err != nil {
+			return fmt.Errorf("store page %d png: %w", pageNum, err)
+		}
+
+		// Extract text: try LLM first, fall back to pdftotext.
+		text := s.extractPageText(ctx, textExtractor, pngData, pdfPath, pageNum)
+
+		if allText.Len() > 0 {
+			allText.WriteString("\n\n")
+		}
+		allText.WriteString(text)
+
+		sourceLoc := fmt.Sprintf("Page %d", pageNum)
+		chunks = append(chunks, models.ChunkInput{
+			FileID:    fileID,
+			Text:      text,
+			MimeType:  "image/png",
+			Position:  pageNum,
+			SourceLoc: &sourceLoc,
+			DataHash:  &pngHash,
+			Labels:    labels,
+		})
+	}
+
+	// Delete existing chunks and create new ones.
+	if err := s.db.DeleteChunks(ctx, fileID); err != nil {
+		return fmt.Errorf("delete old chunks: %w", err)
+	}
+	if err := s.db.CreateChunks(ctx, chunks); err != nil {
+		return fmt.Errorf("create chunks: %w", err)
+	}
+
+	// Store concatenated extracted text on the file for full-text display.
+	if allText.Len() > 0 {
+		if err := s.db.UpdateFileTranscript(ctx, fileID, allText.String()); err != nil {
+			return fmt.Errorf("update file transcript: %w", err)
+		}
+	}
+
+	logger.Info("pdf processing complete", "chunks", len(chunks))
+	return nil
+}
+
+// extractPageText tries the LLM TextExtractor first, falling back to pdftotext.
+func (s *Service) extractPageText(ctx context.Context, extractor *llm.TextExtractor, pngData []byte, pdfPath string, pageNum int) string {
+	logger := logutil.FromCtx(ctx)
+
+	// Try LLM text extraction from page image.
+	if extractor != nil {
+		text, err := (*extractor).Extract(ctx, pngData, "image/png")
+		if err != nil {
+			logger.Warn("llm text extraction failed, falling back to pdftotext",
+				"page", pageNum, "error", err)
+		} else if text != "" {
+			return text
+		} else {
+			logger.Debug("llm text extraction returned empty, falling back to pdftotext",
+				"page", pageNum)
+		}
+	}
+
+	// Fallback: extract raw text with pdftotext.
+	text, err := pipeline.ExtractPageText(ctx, pdfPath, pageNum)
+	if err != nil {
+		logger.Warn("pdftotext extraction failed", "page", pageNum, "error", err)
+		return fmt.Sprintf("[Page %d: text extraction failed]", pageNum)
+	}
+	return strings.TrimSpace(text)
+}
+
+// resolveBlobPath returns a local file path for a blob.
+// If the blob store supports local paths, returns it directly.
+// Otherwise, downloads to a temp file and returns a cleanup function.
+func (s *Service) resolveBlobPath(ctx context.Context, f *models.File) (string, func(), error) {
+	if local, ok := s.blobStore.(blob.LocalPathStore); ok {
+		return local.LocalPath(*f.ContentHash), nil, nil
+	}
+
+	// Download to temp file for S3-backed stores.
+	rc, err := s.blobStore.Get(ctx, *f.ContentHash)
+	if err != nil {
+		return "", nil, fmt.Errorf("get blob: %w", err)
+	}
+	defer rc.Close()
+
+	ext := filepath.Ext(f.Path)
+	tmp, err := os.CreateTemp("", "know-blob-*"+ext)
+	if err != nil {
+		return "", nil, fmt.Errorf("create temp file: %w", err)
+	}
+
+	if _, err := io.Copy(tmp, rc); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("copy blob to temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("close temp file: %w", err)
+	}
+
+	cleanup := func() { os.Remove(tmp.Name()) }
+	return tmp.Name(), cleanup, nil
+}
+
+// sha256Hex returns the hex-encoded SHA256 hash of the given data.
+func sha256Hex(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}

--- a/internal/file/service.go
+++ b/internal/file/service.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -37,15 +38,18 @@ type VersionConfig struct {
 type Service struct {
 	db                  *db.Client
 	blobStore           blob.Store
-	embedder            atomic.Pointer[llm.Embedder]    // optional — nil disables embedding
-	transcriber         atomic.Pointer[stt.Transcriber] // optional — nil disables transcription
-	model               atomic.Pointer[llm.Model]       // optional — nil disables LLM summarization
+	embedder            atomic.Pointer[llm.Embedder]           // optional — nil disables embedding
+	multimodalEmbedder  atomic.Pointer[llm.MultimodalEmbedder] // optional — nil disables multimodal embedding
+	textExtractor       atomic.Pointer[llm.TextExtractor]      // optional — nil disables LLM text extraction
+	transcriber         atomic.Pointer[stt.Transcriber]        // optional — nil disables transcription
+	model               atomic.Pointer[llm.Model]              // optional — nil disables LLM summarization
 	resolver            *LinkResolver
 	chunkConfig         parser.ChunkConfig
 	versionConfig       VersionConfig
 	bus                 *event.Bus // optional — nil disables change events
 	embedMaxInputChars  int        // hard limit for embedding API input (0 = no limit)
 	audioSegmentSeconds int        // max audio segment duration for chunking (default 60)
+	pdfRenderDPI        int        // DPI for PDF page rendering (default 300)
 }
 
 // SetEmbedder atomically replaces the embedder (used by SIGHUP reload).
@@ -82,12 +86,38 @@ func (s *Service) getModel() *llm.Model {
 	return s.model.Load()
 }
 
+// SetMultimodalEmbedder atomically replaces the multimodal embedder (used by SIGHUP reload).
+func (s *Service) SetMultimodalEmbedder(e *llm.MultimodalEmbedder) {
+	s.multimodalEmbedder.Store(e)
+}
+
+func (s *Service) getMultimodalEmbedder() *llm.MultimodalEmbedder {
+	return s.multimodalEmbedder.Load()
+}
+
+// SetTextExtractor atomically replaces the text extractor (used by SIGHUP reload).
+func (s *Service) SetTextExtractor(e *llm.TextExtractor) {
+	s.textExtractor.Store(e)
+}
+
+func (s *Service) getTextExtractor() *llm.TextExtractor {
+	return s.textExtractor.Load()
+}
+
 // SetAudioSegmentSeconds updates the audio segment duration from config.
 func (s *Service) SetAudioSegmentSeconds(seconds int) {
 	if seconds <= 0 {
 		seconds = 60
 	}
 	s.audioSegmentSeconds = seconds
+}
+
+// SetPDFRenderDPI updates the DPI used for PDF page rendering (used by SIGHUP reload).
+func (s *Service) SetPDFRenderDPI(dpi int) {
+	if dpi <= 0 {
+		dpi = 300
+	}
+	s.pdfRenderDPI = dpi
 }
 
 // BlobStore returns the blob store used by this service.
@@ -367,6 +397,10 @@ func (s *Service) enqueueJob(ctx context.Context, doc *models.File, created bool
 		// the handler skips silently. This ensures files are processed if a
 		// transcriber is later enabled via SIGHUP reload.
 		jobType = "transcribe"
+	} else if isBinary && models.IsPDFFile(doc.Path) {
+		// Always enqueue PDF processing — the handler checks for poppler
+		// availability and degrades gracefully if not installed.
+		jobType = "pdf"
 	} else if !isBinary {
 		jobType = "parse"
 	}
@@ -653,11 +687,15 @@ func stripMarkdownHeadingPrefixes(path string) string {
 }
 
 // EmbedPendingChunksForFile embeds all un-embedded chunks for a specific file.
-// Uses the same batch-first, one-by-one-fallback strategy as EmbedPendingChunks.
+// Text chunks use the regular Embedder; multimodal chunks (with DataHash and
+// non-text MIME type) use the MultimodalEmbedder, falling back to text embedding.
 // Returns the number of chunks successfully embedded.
 func (s *Service) EmbedPendingChunksForFile(ctx context.Context, fileID string) (int, error) {
 	embedder := s.getEmbedder()
-	if embedder == nil {
+	mmEmbedder := s.getMultimodalEmbedder()
+
+	if embedder == nil && mmEmbedder == nil {
+		logutil.FromCtx(ctx).Debug("skipping embedding, no embedders configured", "file_id", fileID)
 		return 0, nil
 	}
 
@@ -673,21 +711,71 @@ func (s *Service) EmbedPendingChunksForFile(ctx context.Context, fileID string) 
 		fileTitle = doc.Title
 	}
 
-	var pending []embeddingTask
+	// Partition chunks into text and multimodal tasks.
+	var textPending []embeddingTask
+	var mmPending []multimodalEmbeddingTask
+
 	for _, chunk := range chunks {
 		chunkID, err := models.RecordIDString(chunk.ID)
 		if err != nil {
 			logger.Warn("failed to extract chunk ID for embedding", "error", err)
 			continue
 		}
-		pending = append(pending, embeddingTask{
-			chunkID: chunkID,
-			text:    buildEmbeddingContext(chunk, fileTitle, s.embedMaxInputChars),
-		})
+
+		if chunk.IsMultimodal() {
+			mmPending = append(mmPending, multimodalEmbeddingTask{
+				chunkID:  chunkID,
+				dataHash: *chunk.DataHash,
+				mimeType: chunk.MimeType,
+				text:     buildEmbeddingContext(chunk, fileTitle, s.embedMaxInputChars),
+			})
+		} else {
+			textPending = append(textPending, embeddingTask{
+				chunkID: chunkID,
+				text:    buildEmbeddingContext(chunk, fileTitle, s.embedMaxInputChars),
+			})
+		}
 	}
-	if len(pending) == 0 {
-		return 0, nil
+
+	var (
+		total int
+		errs  []error
+	)
+
+	// Embed text chunks via regular embedder.
+	if len(textPending) > 0 && embedder != nil {
+		n, err := s.embedTextChunks(ctx, embedder, textPending)
+		if err != nil {
+			logger.Warn("text chunk embedding failed", "error", err)
+			errs = append(errs, fmt.Errorf("text chunks: %w", err))
+		}
+		total += n
 	}
+
+	// Embed multimodal chunks.
+	if len(mmPending) > 0 {
+		n, err := s.embedMultimodalChunks(ctx, mmEmbedder, embedder, mmPending)
+		if err != nil {
+			logger.Warn("multimodal chunk embedding failed", "error", err)
+			errs = append(errs, fmt.Errorf("multimodal chunks: %w", err))
+		}
+		total += n
+	}
+
+	return total, errors.Join(errs...)
+}
+
+// multimodalEmbeddingTask holds the data needed to embed a multimodal chunk.
+type multimodalEmbeddingTask struct {
+	chunkID  string
+	dataHash string // blob store reference for the binary data
+	mimeType string // MIME type of the binary data
+	text     string // extracted text (fallback for text-only embedding)
+}
+
+// embedTextChunks embeds text chunks using the regular text embedder.
+func (s *Service) embedTextChunks(ctx context.Context, embedder *llm.Embedder, pending []embeddingTask) (int, error) {
+	logger := logutil.FromCtx(ctx)
 
 	texts := make([]string, len(pending))
 	for i, p := range pending {
@@ -719,6 +807,107 @@ func (s *Service) EmbedPendingChunksForFile(ctx context.Context, fileID string) 
 	}
 
 	return len(vectors), nil
+}
+
+// embedMultimodalChunks embeds chunks using the MultimodalEmbedder (reading binary
+// data from the blob store), or falls back to text embedding if no multimodal
+// embedder is configured. Blob reads are batched alongside embedding calls to
+// avoid loading all page images into memory at once.
+func (s *Service) embedMultimodalChunks(ctx context.Context, mmEmbedder *llm.MultimodalEmbedder, textEmbedder *llm.Embedder, tasks []multimodalEmbeddingTask) (int, error) {
+	// Fallback: if no multimodal embedder, use text embedder on chunk.text.
+	if mmEmbedder == nil {
+		if textEmbedder == nil {
+			return 0, nil
+		}
+		textTasks := make([]embeddingTask, len(tasks))
+		for i, t := range tasks {
+			textTasks[i] = embeddingTask{chunkID: t.chunkID, text: t.text}
+		}
+		return s.embedTextChunks(ctx, textEmbedder, textTasks)
+	}
+
+	logger := logutil.FromCtx(ctx)
+	embedder := *mmEmbedder
+
+	// Process in batches to avoid loading all page images into memory.
+	const batchSize = 6 // matches geminiEmbedBatchLimit
+	var (
+		total     int
+		errs      []error
+		failedIDs []string
+	)
+
+	for offset := 0; offset < len(tasks); offset += batchSize {
+		end := min(offset+batchSize, len(tasks))
+		batch := tasks[offset:end]
+
+		// Read binary data from blob store for this batch.
+		var inputs []llm.MultimodalInput
+		var chunkIDs []string
+
+		for _, task := range batch {
+			rc, err := s.blobStore.Get(ctx, task.dataHash)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("read blob %s (chunk %s): %w", task.dataHash, task.chunkID, err))
+				failedIDs = append(failedIDs, task.chunkID)
+				continue
+			}
+			data, err := io.ReadAll(rc)
+			rc.Close()
+			if err != nil {
+				errs = append(errs, fmt.Errorf("read blob data %s (chunk %s): %w", task.dataHash, task.chunkID, err))
+				failedIDs = append(failedIDs, task.chunkID)
+				continue
+			}
+
+			inputs = append(inputs, llm.MultimodalInput{
+				Data:     data,
+				MimeType: task.mimeType,
+			})
+			chunkIDs = append(chunkIDs, task.chunkID)
+		}
+
+		if len(inputs) == 0 {
+			continue
+		}
+
+		vectors, err := embedder.EmbedMultimodal(ctx, inputs)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("multimodal embedding batch [%d:%d]: %w", offset, end, err))
+			continue
+		}
+
+		if len(vectors) != len(inputs) {
+			errs = append(errs, fmt.Errorf("multimodal embedding returned wrong vector count: expected %d, got %d", len(inputs), len(vectors)))
+			continue
+		}
+
+		updates := make([]db.ChunkEmbeddingUpdate, len(vectors))
+		for j, vec := range vectors {
+			f32 := make([]float32, len(vec))
+			for k, v := range vec {
+				f32[k] = float32(v)
+			}
+			updates[j] = db.ChunkEmbeddingUpdate{
+				ID:        chunkIDs[j],
+				Embedding: f32,
+			}
+		}
+
+		if err := s.db.BatchUpdateChunkEmbeddings(ctx, updates); err != nil {
+			errs = append(errs, fmt.Errorf("store multimodal embeddings: %w", err))
+			continue
+		}
+
+		total += len(vectors)
+	}
+
+	if len(failedIDs) > 0 {
+		logger.Warn("some blobs could not be read for multimodal embedding",
+			"failed_count", len(failedIDs), "failed_chunk_ids", failedIDs, "succeeded", total)
+	}
+
+	return total, errors.Join(errs...)
 }
 
 // Get returns a file by vault+path, or nil if not found.

--- a/internal/llm/gemini_multimodal_embedder.go
+++ b/internal/llm/gemini_multimodal_embedder.go
@@ -1,0 +1,120 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/raphi011/know/internal/logutil"
+	"google.golang.org/genai"
+)
+
+// geminiEmbedBatchLimit is the maximum number of items per EmbedContent call.
+// Gemini limits multimodal embedding requests to 6 items per batch.
+const geminiEmbedBatchLimit = 6
+
+// GeminiMultimodalEmbedder embeds images, audio, PDFs and text
+// using the Gemini embedding API with native multimodal support.
+type GeminiMultimodalEmbedder struct {
+	client    *genai.Client
+	modelName string
+	dimension int
+}
+
+// NewGeminiMultimodalEmbedder creates a multimodal embedder backed by Gemini.
+func NewGeminiMultimodalEmbedder(ctx context.Context, apiKey, modelName string, dimension int) (*GeminiMultimodalEmbedder, error) {
+	if modelName == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+	client, err := genai.NewClient(ctx, &genai.ClientConfig{
+		APIKey:  apiKey,
+		Backend: genai.BackendGeminiAPI,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create gemini client: %w", err)
+	}
+	return &GeminiMultimodalEmbedder{
+		client:    client,
+		modelName: modelName,
+		dimension: dimension,
+	}, nil
+}
+
+// EmbedMultimodal embeds a batch of multimodal items using the Gemini embedding API.
+// Items are split into sub-batches of at most geminiEmbedBatchLimit items each.
+func (g *GeminiMultimodalEmbedder) EmbedMultimodal(ctx context.Context, items []MultimodalInput) ([][]float64, error) {
+	if len(items) == 0 {
+		return [][]float64{}, nil
+	}
+
+	logger := logutil.FromCtx(ctx).With("model", g.modelName)
+	logger.Debug("multimodal embedding starting", "batch_size", len(items), "dimension", g.dimension)
+
+	start := time.Now()
+	result := make([][]float64, 0, len(items))
+
+	for offset := 0; offset < len(items); offset += geminiEmbedBatchLimit {
+		end := min(offset+geminiEmbedBatchLimit, len(items))
+		sub := items[offset:end]
+
+		vecs, err := g.embedBatch(ctx, sub)
+		if err != nil {
+			return nil, fmt.Errorf("embed batch [%d:%d]: %w", offset, end, err)
+		}
+		result = append(result, vecs...)
+	}
+
+	logger.Debug("multimodal embedding complete",
+		"batch_size", len(items),
+		"duration_ms", time.Since(start).Milliseconds(),
+		"dimension", g.dimension,
+	)
+
+	return result, nil
+}
+
+// embedBatch sends a single sub-batch (≤ geminiEmbedBatchLimit items) to the API.
+func (g *GeminiMultimodalEmbedder) embedBatch(ctx context.Context, items []MultimodalInput) ([][]float64, error) {
+	contents := make([]*genai.Content, len(items))
+	for i, item := range items {
+		parts := make([]*genai.Part, 0, 2)
+		parts = append(parts, genai.NewPartFromBytes(item.Data, item.MimeType))
+		if item.Text != "" {
+			parts = append(parts, genai.NewPartFromText(item.Text))
+		}
+		contents[i] = genai.NewContentFromParts(parts, genai.RoleUser)
+	}
+
+	cfg := &genai.EmbedContentConfig{
+		TaskType: "RETRIEVAL_DOCUMENT",
+	}
+	if g.dimension > 0 {
+		dim := int32(g.dimension)
+		cfg.OutputDimensionality = &dim
+	}
+
+	resp, err := g.client.Models.EmbedContent(ctx, g.modelName, contents, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("gemini embed content: %w", err)
+	}
+
+	if len(resp.Embeddings) != len(items) {
+		return nil, fmt.Errorf("embedding count mismatch: got %d, want %d", len(resp.Embeddings), len(items))
+	}
+
+	result := make([][]float64, len(resp.Embeddings))
+	for i, emb := range resp.Embeddings {
+		result[i] = float32sToFloat64s(emb.Values)
+	}
+	return result, nil
+}
+
+// SupportsMIME returns true if Gemini can natively embed the given MIME type.
+func (g *GeminiMultimodalEmbedder) SupportsMIME(mimeType string) bool {
+	switch mimeType {
+	case "image/png", "image/jpeg", "application/pdf":
+		return true
+	}
+	return strings.HasPrefix(mimeType, "audio/")
+}

--- a/internal/llm/gemini_multimodal_embedder_test.go
+++ b/internal/llm/gemini_multimodal_embedder_test.go
@@ -1,0 +1,111 @@
+package llm
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestGeminiMultimodalEmbedder_SupportsMIME(t *testing.T) {
+	g := &GeminiMultimodalEmbedder{}
+
+	tests := []struct {
+		mimeType string
+		want     bool
+	}{
+		{"image/png", true},
+		{"image/jpeg", true},
+		{"application/pdf", true},
+		{"audio/mpeg", true},
+		{"audio/wav", true},
+		{"audio/ogg", true},
+		{"audio/", true},
+		{"image/gif", false},
+		{"image/webp", false},
+		{"video/mp4", false},
+		{"text/plain", false},
+		{"application/json", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mimeType, func(t *testing.T) {
+			got := g.SupportsMIME(tt.mimeType)
+			if got != tt.want {
+				t.Errorf("SupportsMIME(%q) = %v, want %v", tt.mimeType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGeminiMultimodalEmbedder_EmptyInput(t *testing.T) {
+	g := &GeminiMultimodalEmbedder{}
+
+	vecs, err := g.EmbedMultimodal(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("EmbedMultimodal(nil) returned error: %v", err)
+	}
+	if len(vecs) != 0 {
+		t.Errorf("expected empty result for nil input, got %d vectors", len(vecs))
+	}
+
+	vecs, err = g.EmbedMultimodal(context.Background(), []MultimodalInput{})
+	if err != nil {
+		t.Fatalf("EmbedMultimodal([]) returned error: %v", err)
+	}
+	if len(vecs) != 0 {
+		t.Errorf("expected empty result for empty input, got %d vectors", len(vecs))
+	}
+}
+
+func TestGeminiEmbedBatchLimit(t *testing.T) {
+	// Verify the batch limit constant hasn't accidentally changed.
+	if geminiEmbedBatchLimit != 6 {
+		t.Fatalf("expected geminiEmbedBatchLimit == 6, got %d", geminiEmbedBatchLimit)
+	}
+}
+
+func TestGeminiMultimodalEmbedder_Integration(t *testing.T) {
+	apiKey := os.Getenv("GOOGLE_AI_API_KEY")
+	if apiKey == "" {
+		t.Skip("GOOGLE_AI_API_KEY not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	embedder, err := NewGeminiMultimodalEmbedder(ctx, apiKey, "gemini-embedding-exp-03-07", 768)
+	if err != nil {
+		t.Fatalf("NewGeminiMultimodalEmbedder: %v", err)
+	}
+
+	if !embedder.SupportsMIME("image/png") {
+		t.Error("expected SupportsMIME(image/png) == true")
+	}
+
+	// Minimal 1x1 white PNG.
+	pngBytes := []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+		0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41,
+		0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
+		0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21, 0xbc,
+		0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e,
+		0x44, 0xae, 0x42, 0x60, 0x82,
+	}
+
+	items := []MultimodalInput{
+		{Data: pngBytes, MimeType: "image/png", Text: "a white pixel"},
+	}
+
+	vecs, err := embedder.EmbedMultimodal(ctx, items)
+	if err != nil {
+		t.Fatalf("EmbedMultimodal: %v", err)
+	}
+	if len(vecs) != 1 {
+		t.Fatalf("expected 1 vector, got %d", len(vecs))
+	}
+	if len(vecs[0]) != 768 {
+		t.Errorf("expected dimension 768, got %d", len(vecs[0]))
+	}
+}

--- a/internal/llm/gemini_text_extractor.go
+++ b/internal/llm/gemini_text_extractor.go
@@ -1,0 +1,102 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/raphi011/know/internal/logutil"
+	"google.golang.org/genai"
+)
+
+const textExtractorPrompt = `You are a document text extractor. Extract all content from this page image as structured markdown.
+
+Rules:
+- Preserve heading hierarchy using ## and ### markdown headings
+- Render tables as markdown tables with headers preserved
+- Describe figures, charts, and diagrams in [Figure: description] with detail
+- Include all visible text exactly as it appears
+- If content continues from a previous page, start with [CONTINUES]
+- If a table spans this page, preserve column headers
+- If there is no readable text, describe the visual content
+- Do not add any commentary or meta-text, only the extracted content`
+
+// GeminiTextExtractor extracts structured text from images and PDFs
+// using Gemini's vision capabilities.
+type GeminiTextExtractor struct {
+	client    *genai.Client
+	modelName string
+}
+
+// NewGeminiTextExtractor creates a text extractor backed by Gemini.
+func NewGeminiTextExtractor(ctx context.Context, apiKey, modelName string) (*GeminiTextExtractor, error) {
+	if modelName == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+	client, err := genai.NewClient(ctx, &genai.ClientConfig{
+		APIKey:  apiKey,
+		Backend: genai.BackendGeminiAPI,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create gemini client: %w", err)
+	}
+	return &GeminiTextExtractor{
+		client:    client,
+		modelName: modelName,
+	}, nil
+}
+
+// Extract sends an image to Gemini and returns structured markdown text.
+func (g *GeminiTextExtractor) Extract(ctx context.Context, data []byte, mimeType string) (string, error) {
+	logger := logutil.FromCtx(ctx).With("model", g.modelName)
+	logger.Debug("text extraction starting", "mime_type", mimeType, "input_bytes", len(data))
+
+	start := time.Now()
+
+	contents := []*genai.Content{
+		genai.NewContentFromParts([]*genai.Part{
+			genai.NewPartFromText(textExtractorPrompt),
+			genai.NewPartFromBytes(data, mimeType),
+		}, genai.RoleUser),
+	}
+
+	resp, err := g.client.Models.GenerateContent(ctx, g.modelName, contents, nil)
+	if err != nil {
+		return "", fmt.Errorf("gemini generate content: %w", err)
+	}
+
+	if len(resp.Candidates) == 0 {
+		return "", fmt.Errorf("gemini returned no candidates (possible content safety block or quota issue)")
+	}
+
+	var text strings.Builder
+	for _, candidate := range resp.Candidates {
+		if candidate.Content == nil {
+			continue
+		}
+		for _, part := range candidate.Content.Parts {
+			if part.Text != "" {
+				text.WriteString(part.Text)
+			}
+		}
+	}
+
+	result := strings.TrimSpace(text.String())
+
+	logger.Debug("text extraction complete",
+		"output_chars", len(result),
+		"duration_ms", time.Since(start).Milliseconds(),
+	)
+
+	return result, nil
+}
+
+// SupportsMIME returns true if this extractor can process the given MIME type.
+func (g *GeminiTextExtractor) SupportsMIME(mimeType string) bool {
+	switch mimeType {
+	case "image/png", "image/jpeg", "application/pdf":
+		return true
+	}
+	return false
+}

--- a/internal/models/chunk.go
+++ b/internal/models/chunk.go
@@ -11,8 +11,15 @@ type Chunk struct {
 	MimeType  string                 `json:"mime_type"`
 	Position  int                    `json:"position"`
 	SourceLoc *string                `json:"source_loc,omitempty"`
+	DataHash  *string                `json:"data_hash,omitempty"`
 	Labels    []string               `json:"labels"`
 	Embedding []float32              `json:"embedding"`
+}
+
+// IsMultimodal returns true if this chunk has binary data (e.g. a PDF page image)
+// that should be embedded via the multimodal embedder rather than text-only.
+func (c Chunk) IsMultimodal() bool {
+	return c.DataHash != nil && c.MimeType != "" && c.MimeType != "text/plain"
 }
 
 type ChunkInput struct {
@@ -21,6 +28,7 @@ type ChunkInput struct {
 	MimeType  string    `json:"mime_type"`
 	Position  int       `json:"position"`
 	SourceLoc *string   `json:"source_loc,omitempty"`
+	DataHash  *string   `json:"data_hash,omitempty"`
 	Labels    []string  `json:"labels,omitempty"`
 	Embedding []float32 `json:"embedding"`
 }

--- a/internal/pipeline/poppler.go
+++ b/internal/pipeline/poppler.go
@@ -1,0 +1,132 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/raphi011/know/internal/logutil"
+)
+
+// CheckPoppler verifies that pdftoppm and pdftotext are available in PATH.
+func CheckPoppler() error {
+	if _, err := exec.LookPath("pdftoppm"); err != nil {
+		return fmt.Errorf("pdftoppm not found: %w", err)
+	}
+	if _, err := exec.LookPath("pdftotext"); err != nil {
+		return fmt.Errorf("pdftotext not found: %w", err)
+	}
+	return nil
+}
+
+// PageCount returns the number of pages in a PDF via pdfinfo.
+func PageCount(ctx context.Context, pdfPath string) (int, error) {
+	logger := logutil.FromCtx(ctx)
+	start := time.Now()
+	defer func() {
+		logger.Debug("pdfinfo complete", "path", pdfPath, "duration_ms", time.Since(start).Milliseconds())
+	}()
+
+	out, err := exec.CommandContext(ctx, "pdfinfo", pdfPath).Output()
+	if err != nil {
+		return 0, fmt.Errorf("pdfinfo: %w", err)
+	}
+
+	for line := range strings.SplitSeq(string(out), "\n") {
+		if after, ok := strings.CutPrefix(line, "Pages:"); ok {
+			parts := strings.TrimSpace(after)
+			n, err := strconv.Atoi(parts)
+			if err != nil {
+				return 0, fmt.Errorf("parse page count %q: %w", parts, err)
+			}
+			return n, nil
+		}
+	}
+	return 0, fmt.Errorf("pages field not found in pdfinfo output")
+}
+
+// RenderPages renders all pages of a PDF to PNGs at the given DPI.
+// Returns paths to the rendered PNG files sorted by page number.
+func RenderPages(ctx context.Context, pdfPath string, dpi int, outDir string) ([]string, error) {
+	logger := logutil.FromCtx(ctx)
+	start := time.Now()
+
+	prefix := filepath.Join(outDir, "page")
+	cmd := exec.CommandContext(ctx, "pdftoppm",
+		"-png",
+		"-r", strconv.Itoa(dpi),
+		pdfPath,
+		prefix,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("pdftoppm: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+
+	// Glob for rendered PNGs and sort by name (page order).
+	matches, err := filepath.Glob(prefix + "-*.png")
+	if err != nil {
+		return nil, fmt.Errorf("glob rendered pages: %w", err)
+	}
+	if len(matches) == 0 {
+		// pdftoppm may use different naming for single-page PDFs.
+		matches, err = filepath.Glob(prefix + "*.png")
+		if err != nil {
+			return nil, fmt.Errorf("glob rendered pages (fallback): %w", err)
+		}
+	}
+
+	sort.Strings(matches)
+
+	logger.Debug("pdftoppm complete",
+		"path", pdfPath,
+		"pages", len(matches),
+		"dpi", dpi,
+		"duration_ms", time.Since(start).Milliseconds(),
+	)
+
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("pdftoppm produced no output files for %s", pdfPath)
+	}
+
+	return matches, nil
+}
+
+// ExtractPageText extracts raw text from a single page using pdftotext.
+func ExtractPageText(ctx context.Context, pdfPath string, page int) (string, error) {
+	logger := logutil.FromCtx(ctx)
+	start := time.Now()
+
+	pageStr := strconv.Itoa(page)
+	out, err := exec.CommandContext(ctx, "pdftotext",
+		"-f", pageStr,
+		"-l", pageStr,
+		pdfPath,
+		"-", // output to stdout
+	).Output()
+	if err != nil {
+		return "", fmt.Errorf("pdftotext page %d: %w", page, err)
+	}
+
+	logger.Debug("pdftotext page complete",
+		"path", pdfPath,
+		"page", page,
+		"chars", len(out),
+		"duration_ms", time.Since(start).Milliseconds(),
+	)
+
+	return string(out), nil
+}
+
+// ExtractAllText extracts raw text from all pages of a PDF.
+func ExtractAllText(ctx context.Context, pdfPath string) (string, error) {
+	out, err := exec.CommandContext(ctx, "pdftotext", pdfPath, "-").Output()
+	if err != nil {
+		return "", fmt.Errorf("pdftotext: %w", err)
+	}
+	return string(out), nil
+}

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -58,6 +59,16 @@ type ServerConfig struct {
 	STTProvider            string `json:"sttProvider"`
 	STTModel               string `json:"sttModel"`
 	TranscriptionEnabled   bool   `json:"transcriptionEnabled"`
+	FFmpegInstalled        bool   `json:"ffmpegInstalled"`
+
+	// PDF pipeline
+	PopplerInstalled        bool   `json:"popplerInstalled"`
+	PDFIngestionEnabled     bool   `json:"pdfIngestionEnabled"`
+	MultimodalEmbedProvider string `json:"multimodalEmbedProvider"`
+	MultimodalEmbedModel    string `json:"multimodalEmbedModel"`
+	MultimodalEmbedEnabled  bool   `json:"multimodalEmbedEnabled"`
+	TextExtractorModel      string `json:"textExtractorModel"`
+	TextExtractorEnabled    bool   `json:"textExtractorEnabled"`
 }
 
 // App holds all application services and dependencies.
@@ -181,6 +192,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	bus := event.New()
 	fileSvc := file.NewService(dbClient, blobStore, embedder, chunkConfig, versionConfig, bus, cfg.EmbedMaxInputChars)
 	fileSvc.SetAudioSegmentSeconds(cfg.AudioSegmentSeconds)
+	fileSvc.SetPDFRenderDPI(cfg.PDFRenderDPI)
 
 	// STT transcriber is optional — nil disables transcription
 	var transcriber stt.Transcriber
@@ -198,6 +210,34 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	if model != nil {
 		fileSvc.SetModel(model)
 	}
+
+	// Multimodal embedder is optional — nil disables native image/PDF embedding.
+	// Falls back to text embedding of extracted content.
+	if cfg.MultimodalEmbedProvider.Enabled() {
+		me, err := llm.NewGeminiMultimodalEmbedder(ctx, cfg.GoogleAIAPIKey, cfg.MultimodalEmbedModel, cfg.EmbedDimension)
+		if err != nil {
+			slog.Warn("multimodal embedder initialization failed, multimodal embedding disabled", "error", err)
+		} else {
+			var iface llm.MultimodalEmbedder = me
+			fileSvc.SetMultimodalEmbedder(&iface)
+		}
+	}
+
+	// Text extractor is optional — nil disables LLM-based text extraction from images/PDFs.
+	// Falls back to pdftotext for PDF processing.
+	var textExtractorOK bool
+	if cfg.GoogleAIAPIKey != "" && cfg.TextExtractorModel != "" {
+		te, err := llm.NewGeminiTextExtractor(ctx, cfg.GoogleAIAPIKey, cfg.TextExtractorModel)
+		if err != nil {
+			slog.Warn("text extractor initialization failed, PDF text extraction will use pdftotext fallback", "error", err)
+		} else {
+			var iface llm.TextExtractor = te
+			fileSvc.SetTextExtractor(&iface)
+			textExtractorOK = true
+		}
+	}
+
+	popplerOK := pipeline.CheckPoppler() == nil
 
 	// pipelineWorkerDone defaults to a closed channel so <-pipelineWorkerDone is a no-op in Close
 	pipelineWorkerDone := make(chan struct{})
@@ -236,26 +276,34 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		bus:                bus,
 		pipelineWorkerDone: pipelineWorkerDone,
 		serverConfig: ServerConfig{
-			Version:                cfg.Version,
-			Commit:                 cfg.Commit,
-			SurrealDBURL:           cfg.SurrealDBURL,
-			AuthEnabled:            !cfg.NoAuth,
-			LLMProvider:            string(cfg.LLMProvider),
-			LLMModel:               cfg.LLMModel,
-			EmbedProvider:          string(cfg.EmbedProvider),
-			EmbedModel:             cfg.EmbedModel,
-			EmbedDimension:         cfg.EmbedDimension,
-			SemanticSearchEnabled:  embedder != nil,
-			AgentChatEnabled:       model != nil,
-			WebSearchEnabled:       cfg.TavilyAPIKey != "",
-			ChunkThreshold:         chunkConfig.Threshold,
-			ChunkTargetSize:        chunkConfig.TargetSize,
-			ChunkMaxSize:           chunkConfig.MaxSize,
-			VersionCoalesceMinutes: cfg.VersionCoalesceMinutes,
-			VersionRetentionCount:  cfg.VersionRetentionCount,
-			STTProvider:            string(cfg.STTProvider),
-			STTModel:               cfg.STTModel,
-			TranscriptionEnabled:   transcriber != nil,
+			Version:                 cfg.Version,
+			Commit:                  cfg.Commit,
+			SurrealDBURL:            cfg.SurrealDBURL,
+			AuthEnabled:             !cfg.NoAuth,
+			LLMProvider:             string(cfg.LLMProvider),
+			LLMModel:                cfg.LLMModel,
+			EmbedProvider:           string(cfg.EmbedProvider),
+			EmbedModel:              cfg.EmbedModel,
+			EmbedDimension:          cfg.EmbedDimension,
+			SemanticSearchEnabled:   embedder != nil,
+			AgentChatEnabled:        model != nil,
+			WebSearchEnabled:        cfg.TavilyAPIKey != "",
+			ChunkThreshold:          chunkConfig.Threshold,
+			ChunkTargetSize:         chunkConfig.TargetSize,
+			ChunkMaxSize:            chunkConfig.MaxSize,
+			VersionCoalesceMinutes:  cfg.VersionCoalesceMinutes,
+			VersionRetentionCount:   cfg.VersionRetentionCount,
+			STTProvider:             string(cfg.STTProvider),
+			STTModel:                cfg.STTModel,
+			TranscriptionEnabled:    transcriber != nil,
+			FFmpegInstalled:         isCommandAvailable("ffmpeg"),
+			PopplerInstalled:        popplerOK,
+			PDFIngestionEnabled:     popplerOK,
+			MultimodalEmbedProvider: string(cfg.MultimodalEmbedProvider),
+			MultimodalEmbedModel:    cfg.MultimodalEmbedModel,
+			MultimodalEmbedEnabled:  cfg.MultimodalEmbedProvider.Enabled(),
+			TextExtractorModel:      cfg.TextExtractorModel,
+			TextExtractorEnabled:    textExtractorOK,
 		},
 	}
 
@@ -502,6 +550,59 @@ func (a *App) ReloadLLM() error {
 		a.fileService.SetAudioSegmentSeconds(cfg.AudioSegmentSeconds)
 	}
 
+	// PDF render DPI is independent of the transcriber — always reload.
+	a.fileService.SetPDFRenderDPI(cfg.PDFRenderDPI)
+
+	// Reload multimodal embedder
+	mmEmbedWanted := cfg.MultimodalEmbedProvider.Enabled()
+	var newMMEmbedder *llm.MultimodalEmbedder
+	mmEmbedChanged := false
+
+	if mmEmbedWanted {
+		me, err := llm.NewGeminiMultimodalEmbedder(ctx, cfg.GoogleAIAPIKey, cfg.MultimodalEmbedModel, cfg.EmbedDimension)
+		if err != nil {
+			slog.Error("multimodal embedder reload failed, keeping existing", "error", err)
+			errs = append(errs, fmt.Sprintf("multimodal embedder: %v", err))
+		} else {
+			var iface llm.MultimodalEmbedder = me
+			newMMEmbedder = &iface
+			mmEmbedChanged = true
+		}
+	} else {
+		mmEmbedChanged = true
+		newMMEmbedder = nil
+	}
+
+	if mmEmbedChanged {
+		a.fileService.SetMultimodalEmbedder(newMMEmbedder)
+	}
+
+	// Reload text extractor
+	textExtractorWanted := cfg.GoogleAIAPIKey != "" && cfg.TextExtractorModel != ""
+	var newTextExtractor *llm.TextExtractor
+	textExtractorChanged := false
+
+	if textExtractorWanted {
+		te, err := llm.NewGeminiTextExtractor(ctx, cfg.GoogleAIAPIKey, cfg.TextExtractorModel)
+		if err != nil {
+			slog.Error("text extractor reload failed, keeping existing", "error", err)
+			errs = append(errs, fmt.Sprintf("text extractor: %v", err))
+		} else {
+			var iface llm.TextExtractor = te
+			newTextExtractor = &iface
+			textExtractorChanged = true
+		}
+	} else {
+		textExtractorChanged = true
+		newTextExtractor = nil
+	}
+
+	if textExtractorChanged {
+		a.fileService.SetTextExtractor(newTextExtractor)
+	}
+
+	popplerOK := pipeline.CheckPoppler() == nil
+
 	// Update server config
 	a.mu.Lock()
 	if embedderChanged {
@@ -520,6 +621,18 @@ func (a *App) ReloadLLM() error {
 		a.serverConfig.STTProvider = string(cfg.STTProvider)
 		a.serverConfig.STTModel = cfg.STTModel
 	}
+	if mmEmbedChanged {
+		a.serverConfig.MultimodalEmbedProvider = string(cfg.MultimodalEmbedProvider)
+		a.serverConfig.MultimodalEmbedModel = cfg.MultimodalEmbedModel
+		a.serverConfig.MultimodalEmbedEnabled = newMMEmbedder != nil
+	}
+	if textExtractorChanged {
+		a.serverConfig.TextExtractorModel = cfg.TextExtractorModel
+		a.serverConfig.TextExtractorEnabled = newTextExtractor != nil
+	}
+	a.serverConfig.FFmpegInstalled = isCommandAvailable("ffmpeg")
+	a.serverConfig.PopplerInstalled = popplerOK
+	a.serverConfig.PDFIngestionEnabled = popplerOK
 	a.serverConfig.WebSearchEnabled = cfg.TavilyAPIKey != ""
 	a.serverConfig.ChunkThreshold = chunkConfig.Threshold
 	a.serverConfig.ChunkTargetSize = chunkConfig.TargetSize
@@ -566,6 +679,7 @@ func (a *App) startPipelineWorker(cfg config.Config) {
 	w := pipeline.NewWorker(a.db, a.bus, interval, cfg.PipelineWorkerBatch)
 	w.Register("parse", file.ParseHandler(a.fileService, a.bus))
 	w.Register("transcribe", file.TranscribeHandler(a.fileService, a.bus))
+	w.Register("pdf", file.PDFHandler(a.fileService, a.bus))
 	w.Register("summarize", file.SummarizeHandler(a.fileService, a.bus))
 	w.Register("embed", file.EmbedHandler(a.fileService))
 	go func() {
@@ -811,4 +925,10 @@ func resolveVaultIDs(ctx context.Context, vaultService *vault.Service) ([]string
 		ids = append(ids, id)
 	}
 	return ids, nil
+}
+
+// isCommandAvailable checks if a command is available in PATH.
+func isCommandAvailable(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
 }


### PR DESCRIPTION
Adds end-to-end PDF processing: renders pages as PNGs via poppler, extracts text via Gemini LLM (with pdftotext fallback), stores page images in blob store, and creates multimodal chunks that can be embedded using Gemini's native image embedding API.

## New Features
- **PDF page rendering**: Uses poppler (`pdftoppm`) to render each page as PNG at configurable DPI (`KNOW_PDF_RENDER_DPI`)
- **LLM text extraction**: Gemini vision extracts structured markdown from page images, with `pdftotext` fallback
- **Multimodal embedding**: Gemini Embedding API natively embeds page images into the same vector space as text
- **Multimodal chunk model**: New `data_hash` field on chunks links to blob store PNGs; `IsMultimodal()` routes embedding
- **Pipeline integration**: New `pdf` job type, auto-enqueued on PDF import
- **SIGHUP reload**: Multimodal embedder and text extractor hot-swap on config reload
- **`know info` display**: Shows poppler status, PDF ingestion, multimodal embed, and text extractor config

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)