### PR TITLE
feat: add web clipping via Jina Reader

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,9 @@ KNOW_EMBED_DIMENSION=768
 # Apify (YouTube transcript fetching and other scraping)
 # KNOW_APIFY_TOKEN=apify_api_...
 
+# Jina Reader (web page to markdown, free tier works without key)
+# KNOW_JINA_API_KEY=jina_...
+
 # AWS Bedrock (Claude models only for LLM, see bedrock-setup.sh for Teleport setup)
 # KNOW_BEDROCK_EMBED_MODEL_PROVIDER=amazon     # For embedding inference profiles
 # KNOW_TLS_SKIP_VERIFY=false                   # Skip TLS verification for local Teleport proxy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ The server exposes a REST API at `/api/` for CLI and TUI communication:
 - `GET /api/external-links/stats?vault={id}` — aggregated external link counts by hostname
 - `GET /api/external-links?vault={id}&hostname=...&limit=...&offset=...` — list external links
 - `GET /api/jobs?since=24h&limit=10` — pipeline job stats, active jobs, recent failures
+- `POST /api/fetch` — fetch web page as markdown and save to vault (`{url, vault_id, path}`)
 
 Agent endpoints (background execution):
 - `POST /agent/chat` — start agent, returns 202 `{conversationId, status}`
@@ -187,6 +188,7 @@ Each major feature has its own documentation file:
 - `docs/feature-ssh-sftp.md` - SSH/SFTP file access, CLI and GUI client setup
 - `docs/feature-nfs.md` - NFS file access, mount instructions for macOS/Linux/Windows
 - `docs/feature-tasks.md` - Task extraction from checkboxes, filtering, toggling, API
+- `docs/feature-web-clipping.md` - Web page fetching via Jina Reader, CLI/MCP/API, vault settings
 
 ### Project-Specific Docs (`docs/`)
 

--- a/cmd/know/cmd_fetch.go
+++ b/cmd/know/cmd_fetch.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/raphi011/know/internal/apiclient"
+	"github.com/spf13/cobra"
+)
+
+var (
+	fetchAPI     *apiFlags
+	fetchVaultID *string
+	fetchPath    string
+)
+
+var fetchCmd = &cobra.Command{
+	Use:   "fetch <url>",
+	Short: "Fetch a web page as markdown and save to vault",
+	Long: `Fetch a web page via Jina Reader, convert it to markdown, and save it
+to the vault's web clip folder (default: /web/). The page is saved with
+frontmatter containing the title, source URL, and fetch timestamp.
+
+Fetched pages go through the full ingestion pipeline (chunking, embedding,
+wiki-link resolution) just like any other document.
+
+Examples:
+  know fetch https://example.com
+  know fetch https://example.com --path /articles/custom.md
+  know fetch https://example.com --vault my-vault`,
+	Args: cobra.ExactArgs(1),
+	RunE: runFetch,
+}
+
+func init() {
+	fetchAPI = addAPIFlags(fetchCmd)
+	fetchVaultID = addVaultFlag(fetchCmd, fetchAPI)
+	fetchCmd.Flags().StringVar(&fetchPath, "path", "", "custom vault path (default: auto-derived from page title)")
+}
+
+func runFetch(cmd *cobra.Command, args []string) error {
+	url := args[0]
+
+	client := fetchAPI.newClient()
+
+	req := apiclient.FetchWebpageRequest{
+		URL:     url,
+		VaultID: *fetchVaultID,
+	}
+	if fetchPath != "" {
+		req.Path = &fetchPath
+	}
+
+	resp, err := client.FetchWebpage(cmd.Context(), req)
+	if err != nil {
+		return fmt.Errorf("fetch: %w", err)
+	}
+
+	fmt.Printf("Saved: %s → %s\n", resp.Title, resp.Path)
+	return nil
+}

--- a/cmd/know/cmd_serve.go
+++ b/cmd/know/cmd_serve.go
@@ -189,12 +189,14 @@ func runServe(_ *cobra.Command, _ []string) error {
 				DB:      app.DBClient(),
 				Search:  app.SearchService(),
 				FileSvc: app.FileService(),
+				Jina:    app.JinaClient(),
 			},
 			app.DBClient(),
 			app.VaultService(),
 			app.RemoteService(),
 			app.MemoryService(),
 			app.ApifyClient(),
+			app.JinaClient(),
 		)
 		mux.Handle("/mcp", authMw(mcpHandler))
 		slog.Info("MCP endpoint enabled", "path", "/mcp")

--- a/cmd/know/main.go
+++ b/cmd/know/main.go
@@ -85,6 +85,7 @@ func main() {
 	rootCmd.AddCommand(taskCmd)
 	rootCmd.AddCommand(browseCmd)
 	rootCmd.AddCommand(jobCmd)
+	rootCmd.AddCommand(fetchCmd)
 	rootCmd.AddCommand(completionCmd)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/docs/feature-web-clipping.md
+++ b/docs/feature-web-clipping.md
@@ -1,0 +1,123 @@
+# Web Clipping
+
+Know can fetch web pages, convert them to clean markdown via [Jina Reader](https://jina.ai/reader/), and optionally save them to your vault. Saved pages go through the full ingestion pipeline (chunking, embedding, wiki-link resolution) just like any other document.
+
+## Configuration
+
+```bash
+# Optional — enables higher rate limits. Free tier works without a key.
+KNOW_JINA_API_KEY=jina_...
+```
+
+## How It Works
+
+1. The Jina Reader API fetches the target URL and converts it to clean markdown
+2. In save mode, frontmatter is prepended with title, source URL, fetch timestamp, and a `web-clip` label
+3. The document is saved to the vault's web clip folder (default: `/web/`)
+4. The ingestion pipeline processes it like any other document
+
+### Web clip folder
+
+The default save path is `/web/<slugified-title>.md`. You can customize the folder per vault via the `web_clip_path` vault setting, or override the full path per request.
+
+### Frontmatter
+
+Saved pages include YAML frontmatter:
+
+```yaml
+---
+title: "Page Title"
+source: "https://example.com/article"
+canonical_url: "https://example.com/article"  # if different from source
+description: "Page meta description"
+fetched_at: "2026-03-18T09:00:00Z"
+labels:
+  - web-clip
+---
+```
+
+## CLI
+
+```bash
+# Fetch and save to default web clip folder
+know fetch https://example.com/article
+
+# Save to a custom path
+know fetch https://example.com/article --path /articles/custom.md
+
+# Specify vault
+know fetch https://example.com/article --vault my-vault
+```
+
+## REST API
+
+### Fetch and save a web page
+
+```
+POST /api/fetch
+```
+
+Request body:
+
+```json
+{
+  "url": "https://example.com/article",
+  "vault_id": "default",
+  "path": "/articles/custom.md"
+}
+```
+
+- `url` (required) — URL to fetch
+- `vault_id` (optional) — target vault, defaults to first accessible vault
+- `path` (optional) — custom save path, defaults to `/web/<slug>.md`
+
+Response:
+
+```json
+{
+  "path": "/web/example-article.md",
+  "title": "Example Article",
+  "vault_id": "default"
+}
+```
+
+## MCP Tool
+
+The `fetch_webpage` tool is available in the MCP server:
+
+### Read-only mode (default)
+
+Fetches the page and returns markdown without saving:
+
+```
+"Fetch https://example.com and summarize it"
+```
+
+### Save mode
+
+Fetches and persists to the vault:
+
+```
+"Fetch https://example.com/guide and save it to my vault"
+"Clip this article to /references/guide.md: https://example.com/guide"
+```
+
+### Example prompts
+
+- "Fetch https://docs.example.com/api and summarize the authentication section"
+- "Save this article to my vault: https://blog.example.com/post"
+- "Fetch https://example.com/changelog and compare it with my notes in /notes/changelog.md"
+- "Clip these pages and label them for later review: https://example.com/page1, https://example.com/page2"
+
+## Vault Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `web_clip_path` | `/web` | Folder where clipped pages are saved |
+
+Update via API:
+
+```bash
+curl -X PATCH /api/vaults/default/settings \
+  -d '{"web_clip_path": "/clippings"}'
+```

--- a/internal/api/fetch.go
+++ b/internal/api/fetch.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/logutil"
+	"github.com/raphi011/know/internal/webclip"
+)
+
+type fetchRequest struct {
+	URL     string  `json:"url"`
+	VaultID string  `json:"vault_id"`
+	Path    *string `json:"path,omitempty"`
+}
+
+type fetchResponse struct {
+	Path    string `json:"path"`
+	Title   string `json:"title"`
+	VaultID string `json:"vault_id"`
+}
+
+func (s *Server) fetchWebpage(w http.ResponseWriter, r *http.Request) {
+	req, ok := decodeBody[fetchRequest](w, r, 1<<16) // 64KB max
+	if !ok {
+		return
+	}
+
+	if strings.TrimSpace(req.URL) == "" {
+		writeError(w, http.StatusBadRequest, "url is required")
+		return
+	}
+
+	ctx := r.Context()
+	logger := logutil.FromCtx(ctx)
+
+	// Resolve vault.
+	vaultID := req.VaultID
+	if vaultID == "" {
+		ac, err := auth.FromContext(ctx)
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		if len(ac.Vaults) > 0 {
+			vaultID = ac.Vaults[0].VaultID
+		}
+	}
+	if vaultID == "" {
+		writeError(w, http.StatusBadRequest, "vault_id is required")
+		return
+	}
+
+	jinaClient := s.app.JinaClient()
+
+	// Load vault settings for web clip path.
+	v, err := s.app.DBClient().GetVault(ctx, vaultID)
+	if err != nil {
+		logger.Warn("fetch: load vault failed", "vault", vaultID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to load vault")
+		return
+	}
+	if v == nil {
+		writeError(w, http.StatusNotFound, "vault not found")
+		return
+	}
+	settings := v.Defaults()
+
+	result, err := webclip.FetchAndSave(ctx, jinaClient, s.app.FileService(), vaultID, req.URL, req.Path, settings)
+	if err != nil {
+		logger.Warn("fetch: fetch and save failed", "url", req.URL, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to fetch and save page")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, fetchResponse{
+		Path:    result.Path,
+		Title:   result.Title,
+		VaultID: vaultID,
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -89,6 +89,9 @@ func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Han
 	// Jobs (pipeline status)
 	mux.Handle("GET /api/jobs", authMw(http.HandlerFunc(s.getJobStatus)))
 
+	// Web clipping
+	mux.Handle("POST /api/fetch", authMw(http.HandlerFunc(s.fetchWebpage)))
+
 	// Config
 	mux.Handle("GET /api/config", authMw(http.HandlerFunc(s.getConfig)))
 }

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -593,8 +593,8 @@ func (c *Client) ListLabelsWithCounts(ctx context.Context, vaultID string) ([]mo
 
 // JobStatusResponse is the response from GET /api/jobs.
 type JobStatusResponse struct {
-	Stats        models.JobStats           `json:"stats"`
-	Durations    []models.JobTypeDuration  `json:"durations"`
+	Stats        models.JobStats            `json:"stats"`
+	Durations    []models.JobTypeDuration   `json:"durations"`
 	Active       []models.PipelineJobDetail `json:"active"`
 	RecentFailed []models.PipelineJobDetail `json:"recent_failed"`
 }
@@ -671,6 +671,29 @@ func (c *Client) UpdateVaultSettings(ctx context.Context, vaultName string, patc
 		return nil, fmt.Errorf("update vault settings: %w", err)
 	}
 	return &settings, nil
+}
+
+// FetchWebpageRequest is the body for the fetch webpage endpoint.
+type FetchWebpageRequest struct {
+	URL     string  `json:"url"`
+	VaultID string  `json:"vault_id"`
+	Path    *string `json:"path,omitempty"`
+}
+
+// FetchWebpageResponse is the response from the fetch webpage endpoint.
+type FetchWebpageResponse struct {
+	Path    string `json:"path"`
+	Title   string `json:"title"`
+	VaultID string `json:"vault_id"`
+}
+
+// FetchWebpage fetches a web page via the server and saves it to the vault.
+func (c *Client) FetchWebpage(ctx context.Context, req FetchWebpageRequest) (*FetchWebpageResponse, error) {
+	var resp FetchWebpageResponse
+	if err := c.Post(ctx, "/api/fetch", req, &resp); err != nil {
+		return nil, fmt.Errorf("fetch webpage: %w", err)
+	}
+	return &resp, nil
 }
 
 // DownloadExport downloads a vault export archive to the given output path.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,6 +109,9 @@ type Config struct {
 	// Apify
 	ApifyToken string // KNOW_APIFY_TOKEN — enables YouTube transcript tool
 
+	// Jina Reader
+	JinaAPIKey string // KNOW_JINA_API_KEY — optional, enables higher rate limits for web clipping
+
 	// TLS settings
 	TLSSkipVerify bool // skip TLS verification for Bedrock proxy (KNOW_TLS_SKIP_VERIFY)
 
@@ -259,6 +262,9 @@ func Load() Config {
 
 		// Apify
 		ApifyToken: getEnv("KNOW_APIFY_TOKEN", ""),
+
+		// Jina Reader
+		JinaAPIKey: getEnv("KNOW_JINA_API_KEY", ""),
 
 		// TLS
 		TLSSkipVerify: getEnvBool("KNOW_TLS_SKIP_VERIFY", false),

--- a/internal/integration/mcp_http_test.go
+++ b/internal/integration/mcp_http_test.go
@@ -35,7 +35,7 @@ func setupMCPServer(t *testing.T, suffix string) (*httptest.Server, string, *fil
 		FileSvc: docSvc,
 	}
 
-	handler := mcptools.NewHandler(executor, testDB, vaultSvc, nil, nil, nil)
+	handler := mcptools.NewHandler(executor, testDB, vaultSvc, nil, nil, nil, nil)
 	wrappedHandler := auth.NoAuthMiddleware(handler)
 
 	srv := httptest.NewServer(wrappedHandler)

--- a/internal/jina/reader.go
+++ b/internal/jina/reader.go
@@ -1,0 +1,108 @@
+// Package jina provides a client for the Jina Reader API (r.jina.ai)
+// which converts web pages to clean markdown.
+package jina
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const baseURL = "https://r.jina.ai"
+
+// Client is a thin wrapper around the Jina Reader API.
+type Client struct {
+	apiKey     string // optional — enables higher rate limits
+	httpClient *http.Client
+}
+
+// New creates a Jina Reader client. apiKey is optional (empty = free tier).
+func New(apiKey string) *Client {
+	return &Client{
+		apiKey: apiKey,
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+}
+
+// ReadResult holds the converted markdown and metadata from a fetched page.
+type ReadResult struct {
+	Title       string
+	Description string
+	URL         string // canonical/final URL
+	Markdown    string
+}
+
+// response is the JSON structure returned by Jina Reader.
+type response struct {
+	Code int          `json:"code"`
+	Data responseData `json:"data"`
+}
+
+type responseData struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+	Content     string `json:"content"`
+}
+
+// Read fetches a URL via Jina Reader and returns the markdown content with metadata.
+func (c *Client) Read(ctx context.Context, targetURL string) (*ReadResult, error) {
+	reqURL := baseURL + "/" + targetURL
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch page: %w", err)
+	}
+	defer resp.Body.Close()
+
+	const maxResponseSize = 10 << 20 // 10 MB
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("jina API error (HTTP %d): %s", resp.StatusCode, truncate(string(body), 200))
+	}
+
+	var r response
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	if r.Code != 0 && r.Code != 200 {
+		return nil, fmt.Errorf("jina returned error code %d for %s", r.Code, targetURL)
+	}
+
+	if r.Data.Content == "" {
+		return nil, fmt.Errorf("empty content returned for %s", targetURL)
+	}
+
+	return &ReadResult{
+		Title:       r.Data.Title,
+		Description: r.Data.Description,
+		URL:         r.Data.URL,
+		Markdown:    r.Data.Content,
+	}, nil
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/internal/mcptools/server.go
+++ b/internal/mcptools/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/raphi011/know/internal/apify"
 	"github.com/raphi011/know/internal/db"
+	"github.com/raphi011/know/internal/jina"
 	"github.com/raphi011/know/internal/memory"
 	"github.com/raphi011/know/internal/remote"
 	"github.com/raphi011/know/internal/tools"
@@ -18,7 +19,7 @@ import (
 // NewHandler creates the MCP HTTP handler that serves know tools at the
 // given path. Auth is handled externally via auth.Middleware wrapping this handler.
 // remoteService and memoryService may be nil if not configured.
-func NewHandler(executor tools.ToolExecutor, dbClient *db.Client, vaultService *vault.Service, remoteService *remote.Service, memoryService *memory.Service, apifyClient *apify.Client) http.Handler {
+func NewHandler(executor tools.ToolExecutor, dbClient *db.Client, vaultService *vault.Service, remoteService *remote.Service, memoryService *memory.Service, apifyClient *apify.Client, jinaClient *jina.Client) http.Handler {
 	t := &mcpTools{
 		executor:      executor,
 		db:            dbClient,
@@ -26,6 +27,7 @@ func NewHandler(executor tools.ToolExecutor, dbClient *db.Client, vaultService *
 		remoteService: remoteService,
 		memoryService: memoryService,
 		apifyClient:   apifyClient,
+		jinaClient:    jinaClient,
 		cache:         newCache(60 * time.Second),
 	}
 

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -12,11 +12,13 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/raphi011/know/internal/apify"
 	"github.com/raphi011/know/internal/db"
+	"github.com/raphi011/know/internal/jina"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/memory"
 	"github.com/raphi011/know/internal/remote"
 	"github.com/raphi011/know/internal/tools"
 	"github.com/raphi011/know/internal/vault"
+	"github.com/raphi011/know/internal/webclip"
 )
 
 type mcpTools struct {
@@ -26,6 +28,7 @@ type mcpTools struct {
 	remoteService *remote.Service
 	memoryService *memory.Service
 	apifyClient   *apify.Client
+	jinaClient    *jina.Client
 	cache         *cache
 }
 
@@ -146,6 +149,16 @@ func (t *mcpTools) register(server *mcp.Server) {
 			Annotations: openWorld,
 		}, t.fetchYouTubeTranscript)
 	}
+
+	openWorldWrite := &mcp.ToolAnnotations{
+		DestructiveHint: new(false),
+		OpenWorldHint:   new(true),
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "fetch_webpage",
+		Description: "Fetch a web page and convert it to markdown. Set save=true to persist the page to the vault's web clip folder with proper frontmatter (title, source URL, fetched_at, web-clip label). Without save, returns markdown content only.",
+		Annotations: openWorldWrite,
+	}, t.fetchWebpage)
 }
 
 // ---------- Read tool handlers (iterate all vaults) ----------
@@ -668,6 +681,34 @@ func (t *mcpTools) fetchYouTubeTranscript(ctx context.Context, req *mcp.CallTool
 	}
 
 	return textResult(apify.FormatTranscript(result)), nil, nil
+}
+
+// ---------- Web fetch handler ----------
+
+type fetchWebpageInput struct {
+	URL  string  `json:"url" jsonschema:"URL of the web page to fetch"`
+	Save bool    `json:"save,omitempty" jsonschema:"Save the fetched page to the vault's web clip folder (default: false)"`
+	Path *string `json:"path,omitempty" jsonschema:"Custom vault path for saving (only used when save=true)"`
+}
+
+func (t *mcpTools) fetchWebpage(ctx context.Context, req *mcp.CallToolRequest, input fetchWebpageInput) (*mcp.CallToolResult, any, error) {
+	if strings.TrimSpace(input.URL) == "" {
+		return errorResult("url is required"), nil, nil
+	}
+
+	if !input.Save {
+		// Read-only mode — fetch directly without going through executor.
+		result, err := webclip.Fetch(ctx, t.jinaClient, input.URL)
+		if err != nil {
+			logutil.FromCtx(ctx).Warn("fetch webpage failed", "url", input.URL, "error", err)
+			return errorResult(fmt.Sprintf("failed to fetch page: %v", err)), nil, nil
+		}
+
+		return textResult(webclip.FormatAsMarkdown(result)), nil, nil
+	}
+
+	// Save mode — delegate to the Tier 1 tool via the executor.
+	return t.executeWriteTool(ctx, "fetch_webpage", "", input)
 }
 
 // ---------- helpers ----------

--- a/internal/models/vault.go
+++ b/internal/models/vault.go
@@ -36,6 +36,9 @@ type VaultSettings struct {
 	// Versioning
 	VersionCoalesceMinutes int `json:"version_coalesce_minutes,omitempty"`
 	VersionRetentionCount  int `json:"version_retention_count,omitempty"`
+
+	// Web clipping
+	WebClipPath string `json:"web_clip_path,omitempty"`
 }
 
 const (
@@ -63,6 +66,8 @@ const (
 	DefaultVersionCoalesceMinutes = 10
 	// DefaultVersionRetentionCount is the default max versions per file.
 	DefaultVersionRetentionCount = 50
+	// DefaultWebClipPath is the default folder for web-clipped pages.
+	DefaultWebClipPath = "/web"
 )
 
 // Validate checks that all non-zero fields in VaultSettings are within valid ranges.
@@ -143,6 +148,9 @@ func (s VaultSettings) Merge(patch VaultSettings) VaultSettings {
 	if patch.VersionRetentionCount > 0 {
 		s.VersionRetentionCount = patch.VersionRetentionCount
 	}
+	if patch.WebClipPath != "" {
+		s.WebClipPath = patch.WebClipPath
+	}
 	return s
 }
 
@@ -161,6 +169,7 @@ func (v *Vault) Defaults() VaultSettings {
 		MaxSearchLimit:         DefaultMaxSearchLimit,
 		VersionCoalesceMinutes: DefaultVersionCoalesceMinutes,
 		VersionRetentionCount:  DefaultVersionRetentionCount,
+		WebClipPath:            DefaultWebClipPath,
 	}
 	if v.Settings == nil {
 		return s

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -25,6 +25,7 @@ import (
 	"github.com/raphi011/know/internal/db"
 	"github.com/raphi011/know/internal/event"
 	"github.com/raphi011/know/internal/file"
+	"github.com/raphi011/know/internal/jina"
 	"github.com/raphi011/know/internal/llm"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/memory"
@@ -88,6 +89,7 @@ type App struct {
 	remoteService        *remote.Service
 	memoryService        *memory.Service
 	apifyClient          *apify.Client
+	jinaClient           *jina.Client
 	bus                  *event.Bus
 	pipelineWorkerCancel context.CancelFunc // guarded by mu
 	pipelineWorkerDone   chan struct{}      // guarded by mu
@@ -251,18 +253,22 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	searchSvc := search.NewService(dbClient, embedder)
 	remoteSvc := remote.NewService(dbClient)
 
+	// External API clients.
+	var apifyClient *apify.Client
+	if cfg.ApifyToken != "" {
+		apifyClient = apify.New(cfg.ApifyToken)
+	}
+	jinaClient := jina.New(cfg.JinaAPIKey)
+
 	// Build multi-vault tool resolvers for the agent.
 	localExecutor := &tools.Executor{
 		DB:      dbClient,
 		Search:  searchSvc,
 		FileSvc: fileSvc,
+		Jina:    jinaClient,
 	}
 	vaultSvc := vault.NewService(dbClient)
 	agentTools := buildAgentTools(localExecutor, vaultSvc, remoteSvc)
-	var apifyClient *apify.Client
-	if cfg.ApifyToken != "" {
-		apifyClient = apify.New(cfg.ApifyToken)
-	}
 	agentSvc := agent.NewService(dbClient, model, agentTools, cfg.TavilyAPIKey, apifyClient)
 	agentRunner := agent.NewRunner(agentSvc, dbClient)
 	memorySvc := memory.NewService(dbClient, fileSvc, model)
@@ -279,6 +285,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		agentService:       agentSvc,
 		agentRunner:        agentRunner,
 		apifyClient:        apifyClient,
+		jinaClient:         jinaClient,
 		bus:                bus,
 		pipelineWorkerDone: pipelineWorkerDone,
 		serverConfig: ServerConfig{
@@ -386,6 +393,11 @@ func (a *App) MemoryService() *memory.Service {
 // ApifyClient returns the Apify client, or nil if not configured.
 func (a *App) ApifyClient() *apify.Client {
 	return a.apifyClient
+}
+
+// JinaClient returns the Jina Reader client.
+func (a *App) JinaClient() *jina.Client {
+	return a.jinaClient
 }
 
 // BlobStore returns the blob store.

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/raphi011/know/internal/db"
 	"github.com/raphi011/know/internal/file"
+	"github.com/raphi011/know/internal/jina"
 	"github.com/raphi011/know/internal/memory"
 	"github.com/raphi011/know/internal/models"
 	"github.com/raphi011/know/internal/search"
@@ -25,6 +26,7 @@ type Executor struct {
 	DB      *db.Client
 	Search  *search.Service
 	FileSvc *file.Service
+	Jina    *jina.Client
 
 	once     sync.Once
 	registry map[string]tool.InvokableTool
@@ -52,6 +54,8 @@ func (e *Executor) initRegistry() {
 			e.registry["create_memory"] = &CreateMemoryTool{db: e.DB, docService: e.FileSvc}
 			e.registry["toggle_task"] = &ToggleTaskTool{docService: e.FileSvc}
 		}
+
+		e.registry["fetch_webpage"] = &FetchWebpageTool{jina: e.Jina, db: e.DB, fileSvc: e.FileSvc}
 	})
 }
 

--- a/internal/tools/tool_fetch_webpage.go
+++ b/internal/tools/tool_fetch_webpage.go
@@ -1,0 +1,97 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/schema"
+	"github.com/raphi011/know/internal/db"
+	"github.com/raphi011/know/internal/file"
+	"github.com/raphi011/know/internal/jina"
+	"github.com/raphi011/know/internal/webclip"
+)
+
+// FetchWebpageTool fetches a web page as markdown via Jina Reader.
+type FetchWebpageTool struct {
+	jina    *jina.Client
+	db      *db.Client
+	fileSvc *file.Service
+}
+
+func (t *FetchWebpageTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{
+		Name: "fetch_webpage",
+		Desc: "Fetch a web page and convert it to markdown. Set save=true to persist the page to the vault's web clip folder with proper frontmatter. Without save, returns the markdown content only.",
+		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+			"url": {
+				Type:     schema.String,
+				Desc:     "URL of the web page to fetch",
+				Required: true,
+			},
+			"save": {
+				Type: schema.Boolean,
+				Desc: "Save the fetched page to the vault (default: false)",
+			},
+			"path": {
+				Type: schema.String,
+				Desc: "Custom vault path for saving (optional, only used when save=true). Defaults to the vault's web clip folder.",
+			},
+		}),
+	}, nil
+}
+
+func (t *FetchWebpageTool) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
+	o := getToolOptions(opts...)
+
+	args, err := parseInput[struct {
+		URL  string  `json:"url"`
+		Save bool    `json:"save"`
+		Path *string `json:"path"`
+	}](argumentsInJSON, "fetch_webpage")
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(args.URL) == "" {
+		return "", &ToolError{Message: "url is required"}
+	}
+
+	if !args.Save {
+		start := time.Now()
+		result, err := webclip.Fetch(ctx, t.jina, args.URL)
+		if err != nil {
+			return "", fmt.Errorf("fetch webpage: %w", err)
+		}
+
+		durationMs := time.Since(start).Milliseconds()
+		SetResultMeta(ctx, &ToolResultMeta{DurationMs: durationMs})
+
+		return webclip.FormatAsMarkdown(result), nil
+	}
+
+	// Save mode — persist to vault.
+	v, err := t.db.GetVault(ctx, o.VaultID)
+	if err != nil {
+		return "", fmt.Errorf("fetch webpage: load vault: %w", err)
+	}
+	if v == nil {
+		return "", &ToolError{Message: "vault not found"}
+	}
+	settings := v.Defaults()
+
+	start := time.Now()
+	result, err := webclip.FetchAndSave(ctx, t.jina, t.fileSvc, o.VaultID, args.URL, args.Path, settings)
+	if err != nil {
+		return "", fmt.Errorf("fetch webpage: %w", err)
+	}
+
+	durationMs := time.Since(start).Milliseconds()
+	SetResultMeta(ctx, &ToolResultMeta{
+		DurationMs:   durationMs,
+		DocumentPath: &result.Path,
+	})
+
+	return fmt.Sprintf("Fetched and saved: %s → %s", result.Title, result.Path), nil
+}

--- a/internal/webclip/webclip.go
+++ b/internal/webclip/webclip.go
@@ -1,0 +1,149 @@
+// Package webclip provides shared logic for fetching web pages as markdown
+// and optionally persisting them to a vault. Used by both the agent tool
+// and the REST API handler.
+package webclip
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/raphi011/know/internal/file"
+	"github.com/raphi011/know/internal/jina"
+	"github.com/raphi011/know/internal/models"
+)
+
+// Result holds the outcome of a web fetch, with optional save path.
+type Result struct {
+	Title    string `json:"title"`
+	URL      string `json:"url"`
+	Markdown string `json:"markdown,omitempty"`
+	Path     string `json:"path,omitempty"` // vault path (empty if not saved)
+}
+
+// Fetch fetches a URL via Jina Reader and returns the result without persisting.
+func Fetch(ctx context.Context, client *jina.Client, url string) (*Result, error) {
+	r, err := client.Read(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("fetch: %w", err)
+	}
+
+	return &Result{
+		Title:    r.Title,
+		URL:      r.URL,
+		Markdown: r.Markdown,
+	}, nil
+}
+
+// FormatAsMarkdown formats a Result as a markdown string with title and source header.
+func FormatAsMarkdown(r *Result) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# %s\n", r.Title)
+	fmt.Fprintf(&sb, "Source: %s\n\n", r.URL)
+	sb.WriteString(r.Markdown)
+	return sb.String()
+}
+
+// FetchAndSave fetches a URL, builds frontmatter, and persists the document
+// to the vault via FileService.Create. If customPath is nil or empty, the path
+// is derived from the page title and the vault's WebClipPath setting.
+func FetchAndSave(ctx context.Context, client *jina.Client, fileSvc *file.Service, vaultID, url string, customPath *string, settings models.VaultSettings) (*Result, error) {
+	r, err := client.Read(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("fetch: %w", err)
+	}
+
+	// Derive save path.
+	savePath := ""
+	if customPath != nil {
+		savePath = *customPath
+	}
+	if savePath == "" {
+		folder := settings.WebClipPath
+		if folder == "" {
+			folder = models.DefaultWebClipPath
+		}
+		folder = strings.TrimSuffix(folder, "/")
+		slug := slugify(r.Title)
+		if slug == "" {
+			slug = slugify(url)
+		}
+		if slug == "" {
+			slug = "untitled"
+		}
+		savePath = folder + "/" + slug + ".md"
+	}
+
+	// Build frontmatter + content.
+	content := buildContent(r, url)
+
+	_, err = fileSvc.Create(ctx, models.FileInput{
+		VaultID: vaultID,
+		Path:    savePath,
+		Content: content,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("save: %w", err)
+	}
+
+	return &Result{
+		Title:    r.Title,
+		URL:      r.URL,
+		Markdown: r.Markdown,
+		Path:     savePath,
+	}, nil
+}
+
+// buildContent prepends YAML frontmatter to the fetched markdown.
+func buildContent(r *jina.ReadResult, sourceURL string) string {
+	var sb strings.Builder
+
+	sb.WriteString("---\n")
+	sb.WriteString(fmt.Sprintf("title: %q\n", r.Title))
+	sb.WriteString(fmt.Sprintf("source: %q\n", sourceURL))
+	if r.URL != "" && r.URL != sourceURL {
+		sb.WriteString(fmt.Sprintf("canonical_url: %q\n", r.URL))
+	}
+	if r.Description != "" {
+		sb.WriteString(fmt.Sprintf("description: %q\n", r.Description))
+	}
+	sb.WriteString(fmt.Sprintf("fetched_at: %q\n", time.Now().UTC().Format(time.RFC3339)))
+	sb.WriteString("labels:\n  - web-clip\n")
+	sb.WriteString("---\n\n")
+	sb.WriteString(r.Markdown)
+
+	return sb.String()
+}
+
+// multiHyphen collapses consecutive hyphens.
+var multiHyphen = regexp.MustCompile(`-{2,}`)
+
+// slugify converts a string to a URL-safe ASCII slug.
+func slugify(s string) string {
+	// Strip protocol prefix for URLs.
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+
+	// Map to lowercase ASCII letters/digits, everything else becomes a hyphen.
+	s = strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			return r
+		}
+		if r >= 'A' && r <= 'Z' {
+			return r + ('a' - 'A')
+		}
+		return '-'
+	}, s)
+
+	s = multiHyphen.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+
+	if len(s) > 80 {
+		s = s[:80]
+		s = strings.TrimRight(s, "-")
+	}
+
+	return s
+}


### PR DESCRIPTION
Add web page fetching and saving via the Jina Reader API. Pages are converted
to clean markdown and can optionally be persisted to a vault with frontmatter
metadata (title, source URL, fetched_at, web-clip label).

## New Features
- **MCP tool** (`fetch_webpage`): read-only mode returns markdown, save mode persists to vault
- **REST API** (`POST /api/fetch`): fetch and save web pages with vault/path options
- **CLI command** (`know fetch <url>`): fetch and save from the command line
- **Vault setting** (`web_clip_path`): configurable folder for saved clips (default: `/web`)
- **Jina Reader client** (`internal/jina`): thin wrapper with 10MB response limit and error code checking
- **Shared webclip package** (`internal/webclip`): fetch, format, slugify, and save logic used by all interfaces

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)