### PR TITLE
feat: add EPUB export for documents and folders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,7 @@ The server exposes a REST API at `/api/` for CLI and TUI communication:
 - `POST /api/import/manifest` — send file manifest (paths+hashes), get back which files need uploading
 - `POST /api/import/upload` — upload needed files (multipart, streams binaries to blob store)
 - `GET /api/export?vault={id}` — download vault export as .tar.gz archive
+- `GET /api/export/epub?vault={id}&path={path}&title=...&author=...` — export document or folder as EPUB
 - `GET /api/config` — server configuration
 - `GET /api/tasks?vault={id}&status=open&labels=work&due_before=2026-03-20&folder=/daily/` — list tasks
 - `POST /api/tasks/{id}/toggle` — toggle task status (modifies source document)

--- a/cmd/know/cmd_epub.go
+++ b/cmd/know/cmd_epub.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	epubAPI     *apiFlags
+	epubVaultID *string
+	epubPath    string
+	epubTitle   string
+	epubAuthor  string
+	epubOutput  string
+)
+
+var epubCmd = &cobra.Command{
+	Use:   "epub",
+	Short: "Export a document or folder as an EPUB file",
+	Long: `Creates an .epub file from a single document or all markdown files in a folder.
+
+Examples:
+  know epub --vault default --path /books/my-book.md
+  know epub --vault default --path /books/ --title "My Book" --author "Me"
+  know epub --vault default --path /notes/ -o notes.epub`,
+	RunE: runEpub,
+}
+
+func init() {
+	epubAPI = addAPIFlags(epubCmd)
+	epubVaultID = addVaultFlag(epubCmd, epubAPI)
+	epubCmd.Flags().StringVar(&epubPath, "path", "", "document or folder path to export (required)")
+	epubCmd.Flags().StringVar(&epubTitle, "title", "", "EPUB title (default: auto-detected from document/folder)")
+	epubCmd.Flags().StringVar(&epubAuthor, "author", "", "EPUB author (default: Know)")
+	epubCmd.Flags().StringVarP(&epubOutput, "output", "o", "", "output file path (default: <title>.epub)")
+	epubCmd.MarkFlagRequired("path")
+}
+
+func runEpub(cmd *cobra.Command, args []string) error {
+	if epubOutput == "" {
+		// Derive output filename from title or path.
+		name := epubTitle
+		if name == "" {
+			name = path.Base(strings.TrimSuffix(epubPath, "/"))
+		}
+		if name == "" || name == "." || name == "/" {
+			name = "export"
+		}
+		epubOutput = name + ".epub"
+	}
+
+	client := epubAPI.newClient()
+
+	n, err := client.DownloadExportEPUB(cmd.Context(), *epubVaultID, epubPath, epubTitle, epubAuthor, epubOutput)
+	if err != nil {
+		return fmt.Errorf("epub export: %w", err)
+	}
+
+	fmt.Printf("EPUB saved to %s (%s)\n", epubOutput, formatBytes(n))
+	return nil
+}

--- a/cmd/know/main.go
+++ b/cmd/know/main.go
@@ -77,6 +77,7 @@ func main() {
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(labelsCmd)
 	rootCmd.AddCommand(exportCmd)
+	rootCmd.AddCommand(epubCmd)
 	rootCmd.AddCommand(lsCmd)
 	rootCmd.AddCommand(noteCmd)
 	rootCmd.AddCommand(rmCmd)

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/cloudwego/eino-ext/components/model/ollama v0.1.8
 	github.com/cloudwego/eino-ext/components/model/openai v0.1.8
 	github.com/go-git/go-billy/v5 v5.8.0
+	github.com/go-shiori/go-epub v1.2.1
 	github.com/modelcontextprotocol/go-sdk v1.4.0
 	github.com/pkg/sftp v1.13.10
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
@@ -29,6 +30,7 @@ require (
 	github.com/surrealdb/surrealdb.go v1.4.0
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/tmc/langchaingo v0.1.14
+	github.com/vincent-petithory/dataurl v1.0.0
 	github.com/willscott/go-nfs v0.0.3
 	github.com/yuin/goldmark v1.7.16
 	github.com/yuin/goldmark-meta v1.1.0
@@ -45,6 +47,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.20 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
+	github.com/gofrs/uuid/v5 v5.0.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,8 @@ github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
+github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127 h1:0gkP6mzaMqkmpcJYCFOLkIBwI7xFExG03bbkOkCvUPI=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
@@ -212,9 +214,13 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
+github.com/go-shiori/go-epub v1.2.1 h1:+K/WxrvmfFQY69cpryiObrT6X7WhkwpqhHY65AHs2Rg=
+github.com/go-shiori/go-epub v1.2.1/go.mod h1:3rCTODnigEgy2j3ksndClrGT9h/dcz3js9q4yPX7hf8=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
 github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/gofrs/uuid/v5 v5.0.0 h1:p544++a97kEL+svbcFbCQVM9KFu0Yo25UoISXGNNH9M=
+github.com/gofrs/uuid/v5 v5.0.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -441,6 +447,8 @@ github.com/tmc/langchaingo v0.1.14 h1:o1qWBPigAIuFvrG6cjTFo0cZPFEZ47ZqpOYMjM15yZ
 github.com/tmc/langchaingo v0.1.14/go.mod h1:aKKYXYoqhIDEv7WKdpnnCLRaqXic69cX9MnDUk72378=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
+github.com/vincent-petithory/dataurl v1.0.0 h1:cXw+kPto8NLuJtlMsI152irrVw9fRDX8AbShPRpg2CI=
+github.com/vincent-petithory/dataurl v1.0.0/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9CvnvxyvZy6I1MrG/U=
 github.com/willscott/go-nfs v0.0.3 h1:Z5fHVxMsppgEucdkKBN26Vou19MtEM875NmRwj156RE=
 github.com/willscott/go-nfs v0.0.3/go.mod h1:VhNccO67Oug787VNXcyx9JDI3ZoSpqoKMT/lWMhUIDg=
 github.com/willscott/go-nfs-client v0.0.0-20240104095149-b44639837b00 h1:U0DnHRZFzoIV1oFEZczg5XyPut9yxk9jjtax/9Bxr/o=

--- a/internal/api/export_epub.go
+++ b/internal/api/export_epub.go
@@ -1,0 +1,304 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/db"
+	"github.com/raphi011/know/internal/epub"
+	"github.com/raphi011/know/internal/logutil"
+	"github.com/raphi011/know/internal/models"
+)
+
+func (s *Server) exportEPUB(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := logutil.FromCtx(ctx)
+
+	vaultID := r.URL.Query().Get("vault")
+	if vaultID == "" {
+		writeError(w, http.StatusBadRequest, "vault query parameter is required")
+		return
+	}
+	filePath := r.URL.Query().Get("path")
+	if filePath == "" {
+		writeError(w, http.StatusBadRequest, "path query parameter is required")
+		return
+	}
+
+	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleRead); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
+
+	dbClient := s.app.DBClient()
+
+	// Determine if path is a file or folder.
+	var chapters []epub.Chapter
+	f, err := dbClient.GetFileByPath(ctx, vaultID, filePath)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("get file: %v", err))
+		return
+	}
+
+	if f != nil && !f.IsFolder {
+		// Single document mode.
+		chapters = append(chapters, epub.Chapter{
+			Title:   f.Title,
+			Content: f.Content,
+			Path:    f.Path,
+		})
+	} else if f == nil && path.Ext(filePath) != "" {
+		// Specific file requested but not found.
+		writeError(w, http.StatusNotFound, fmt.Sprintf("document not found: %s", filePath))
+		return
+	} else {
+		// Folder mode — list markdown files under this path.
+		folderPath := filePath
+		if !strings.HasSuffix(folderPath, "/") {
+			folderPath += "/"
+		}
+
+		mimeType := "text/markdown"
+		const pageSize = 1000
+		for offset := 0; ; offset += pageSize {
+			batch, err := dbClient.ListFiles(ctx, db.ListFilesFilter{
+				VaultID:  vaultID,
+				Folder:   &folderPath,
+				MimeType: &mimeType,
+				OrderBy:  db.OrderByPathAsc,
+				Limit:    pageSize,
+				Offset:   offset,
+			})
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, fmt.Sprintf("list files: %v", err))
+				return
+			}
+			for _, file := range batch {
+				chapters = append(chapters, epub.Chapter{
+					Title:   file.Title,
+					Content: file.Content,
+					Path:    file.Path,
+				})
+			}
+			if len(batch) < pageSize {
+				break
+			}
+		}
+
+		if len(chapters) == 0 {
+			writeError(w, http.StatusNotFound, "no markdown files found at path")
+			return
+		}
+	}
+
+	// Collect unique image paths from all chapters, tracking the chapter directory
+	// for relative path resolution.
+	imagePaths := make(map[string]bool)
+	chapterDirs := make(map[string]string) // relative imagePath → chapter dir
+	for _, ch := range chapters {
+		for _, imgPath := range epub.ExtractImagePaths(ch.Content) {
+			if imagePaths[imgPath] {
+				continue
+			}
+			imagePaths[imgPath] = true
+			if !path.IsAbs(imgPath) && !strings.HasPrefix(imgPath, "http://") && !strings.HasPrefix(imgPath, "https://") {
+				chapterDirs[imgPath] = path.Dir(ch.Path)
+			}
+		}
+	}
+
+	// Resolve images.
+	images, err := s.resolveImages(ctx, vaultID, imagePaths, chapterDirs)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("resolve images: %v", err))
+		return
+	}
+
+	// Determine title and author.
+	title := r.URL.Query().Get("title")
+	if title == "" {
+		if len(chapters) == 1 {
+			title = chapters[0].Title
+		} else {
+			title = path.Base(strings.TrimSuffix(filePath, "/"))
+		}
+	}
+	if title == "" {
+		title = "Export"
+	}
+
+	author := r.URL.Query().Get("author")
+
+	opts := epub.Options{
+		Title:  title,
+		Author: author,
+	}
+
+	data, err := epub.Generate(opts, chapters, images)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("generate epub: %v", err))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/epub+zip")
+	w.Header().Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{"filename": sanitizeFilename(title) + ".epub"}))
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
+	if _, err := w.Write(data); err != nil {
+		logger.Warn("failed to write epub response", "error", err)
+	}
+}
+
+const maxImageSize = 10 << 20 // 10MB per image
+
+func (s *Server) resolveImages(ctx context.Context, vaultID string, imagePaths map[string]bool, chapterDirs map[string]string) ([]epub.Image, error) {
+	logger := logutil.FromCtx(ctx)
+	dbClient := s.app.DBClient()
+	var images []epub.Image
+	var failCount int
+
+	for imgPath := range imagePaths {
+		if strings.HasPrefix(imgPath, "https://") {
+			img, err := fetchExternalImage(ctx, imgPath, len(images))
+			if err != nil {
+				logger.Warn("failed to fetch external image", "url", imgPath, "error", err)
+				failCount++
+				continue
+			}
+			images = append(images, *img)
+			continue
+		}
+		if strings.HasPrefix(imgPath, "http://") {
+			logger.Warn("skipping insecure image URL", "url", imgPath)
+			failCount++
+			continue
+		}
+
+		// Resolve vault path.
+		vaultPath := imgPath
+		if !path.IsAbs(vaultPath) {
+			if dir, ok := chapterDirs[imgPath]; ok {
+				vaultPath = path.Join(dir, vaultPath)
+			}
+		}
+
+		f, err := dbClient.GetFileByPath(ctx, vaultID, vaultPath)
+		if err != nil {
+			logger.Warn("failed to look up image", "path", vaultPath, "error", err)
+			failCount++
+			continue
+		}
+		if f == nil {
+			logger.Warn("image not found in vault", "path", vaultPath)
+			failCount++
+			continue
+		}
+
+		var data []byte
+		if f.ContentHash != nil {
+			rc, err := s.app.BlobStore().Get(ctx, *f.ContentHash)
+			if err != nil {
+				logger.Warn("failed to read image blob", "path", vaultPath, "error", err)
+				failCount++
+				continue
+			}
+			data, err = io.ReadAll(io.LimitReader(rc, maxImageSize))
+			if closeErr := rc.Close(); closeErr != nil {
+				logger.Warn("failed to close image blob reader", "path", vaultPath, "error", closeErr)
+			}
+			if err != nil {
+				logger.Warn("failed to read image data", "path", vaultPath, "error", err)
+				failCount++
+				continue
+			}
+		} else {
+			data = []byte(f.Content)
+		}
+
+		filename := fmt.Sprintf("img%04d%s", len(images), path.Ext(f.Path))
+		images = append(images, epub.Image{
+			VaultPath: imgPath,
+			Filename:  filename,
+			Data:      data,
+			MimeType:  f.MimeType,
+		})
+	}
+
+	if failCount > 0 && len(images) == 0 {
+		return nil, fmt.Errorf("all %d images failed to resolve", failCount)
+	}
+
+	return images, nil
+}
+
+func fetchExternalImage(ctx context.Context, imgURL string, counter int) (*epub.Image, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imgURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxImageSize))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	mimeType := resp.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = http.DetectContentType(data)
+	}
+
+	ext := extFromMIME(mimeType)
+	filename := fmt.Sprintf("img%04d%s", counter, ext)
+
+	return &epub.Image{
+		VaultPath: imgURL,
+		Filename:  filename,
+		Data:      data,
+		MimeType:  mimeType,
+	}, nil
+}
+
+func extFromMIME(mimeType string) string {
+	mediaType, _, _ := mime.ParseMediaType(mimeType)
+	switch mediaType {
+	case "image/jpeg":
+		return ".jpg"
+	case "image/png":
+		return ".png"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	case "image/svg+xml":
+		return ".svg"
+	default:
+		return ".png"
+	}
+}
+
+func sanitizeFilename(name string) string {
+	replacer := strings.NewReplacer(
+		"/", "-", "\\", "-", ":", "-", `"`, "", "<", "", ">", "",
+		"|", "", "?", "", "*", "", "\r", "", "\n", "", ";", "",
+	)
+	return replacer.Replace(name)
+}

--- a/internal/api/jobs.go
+++ b/internal/api/jobs.go
@@ -12,8 +12,8 @@ import (
 )
 
 type jobStatusResponse struct {
-	Stats        models.JobStats           `json:"stats"`
-	Durations    []models.JobTypeDuration  `json:"durations"`
+	Stats        models.JobStats            `json:"stats"`
+	Durations    []models.JobTypeDuration   `json:"durations"`
 	Active       []models.PipelineJobDetail `json:"active"`
 	RecentFailed []models.PipelineJobDetail `json:"recent_failed"`
 }
@@ -88,8 +88,8 @@ func parseSinceDuration(s string) (time.Duration, error) {
 	var d time.Duration
 	var err error
 
-	if strings.HasSuffix(s, "d") {
-		n, parseErr := strconv.Atoi(strings.TrimSuffix(s, "d"))
+	if before, ok := strings.CutSuffix(s, "d"); ok {
+		n, parseErr := strconv.Atoi(before)
 		if parseErr != nil {
 			return 0, fmt.Errorf("invalid day count %q", s)
 		}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -85,6 +85,7 @@ func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Han
 
 	// Export
 	mux.Handle("GET /api/export", authMw(http.HandlerFunc(s.export)))
+	mux.Handle("GET /api/export/epub", authMw(http.HandlerFunc(s.exportEPUB)))
 
 	// Jobs (pipeline status)
 	mux.Handle("GET /api/jobs", authMw(http.HandlerFunc(s.getJobStatus)))

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -699,7 +699,26 @@ func (c *Client) FetchWebpage(ctx context.Context, req FetchWebpageRequest) (*Fe
 // DownloadExport downloads a vault export archive to the given output path.
 // Returns the number of bytes written.
 func (c *Client) DownloadExport(ctx context.Context, vaultID, outputPath string) (int64, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/export?vault="+url.QueryEscape(vaultID), nil)
+	return c.downloadToFile(ctx, "/api/export?vault="+url.QueryEscape(vaultID), outputPath)
+}
+
+// DownloadExportEPUB downloads an EPUB export to the given output path.
+// Returns the number of bytes written.
+func (c *Client) DownloadExportEPUB(ctx context.Context, vaultID, path, title, author, outputPath string) (int64, error) {
+	params := url.Values{"vault": {vaultID}, "path": {path}}
+	if title != "" {
+		params.Set("title", title)
+	}
+	if author != "" {
+		params.Set("author", author)
+	}
+	return c.downloadToFile(ctx, "/api/export/epub?"+params.Encode(), outputPath)
+}
+
+// downloadToFile performs a GET request and streams the response body to a file.
+// Uses no HTTP timeout — context controls cancellation for large downloads.
+func (c *Client) downloadToFile(ctx context.Context, apiPath, outputPath string) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+apiPath, nil)
 	if err != nil {
 		return 0, fmt.Errorf("create request: %w", err)
 	}
@@ -707,10 +726,8 @@ func (c *Client) DownloadExport(ctx context.Context, vaultID, outputPath string)
 		req.Header.Set("Authorization", "Bearer "+c.token)
 	}
 
-	// Use a client with no timeout — large vaults may take a while.
-	// Context controls cancellation instead.
-	noTimeoutClient := &http.Client{}
-	resp, err := noTimeoutClient.Do(req)
+	// No timeout — large exports may take a while. Context controls cancellation.
+	resp, err := (&http.Client{}).Do(req)
 	if err != nil {
 		return 0, fmt.Errorf("send request: %w", err)
 	}
@@ -741,7 +758,7 @@ func (c *Client) DownloadExport(ctx context.Context, vaultID, outputPath string)
 	}
 	if copyErr != nil {
 		if removeErr := os.Remove(outputPath); removeErr != nil {
-			logutil.FromCtx(ctx).Warn("failed to clean up partial export file", "path", outputPath, "error", removeErr)
+			logutil.FromCtx(ctx).Warn("failed to clean up partial file", "path", outputPath, "error", removeErr)
 		}
 		return 0, fmt.Errorf("write output file: %w", copyErr)
 	}

--- a/internal/epub/epub.go
+++ b/internal/epub/epub.go
@@ -1,0 +1,153 @@
+package epub
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+
+	goepub "github.com/go-shiori/go-epub"
+	"github.com/vincent-petithory/dataurl"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	gmhtml "github.com/yuin/goldmark/renderer/html"
+)
+
+// Chapter represents a single document to include in the EPUB.
+type Chapter struct {
+	Title   string // chapter/document title
+	Content string // raw markdown
+	Path    string // vault path (for ordering)
+}
+
+// Image is a resolved image ready to embed.
+type Image struct {
+	VaultPath string // original reference path (e.g. "/images/photo.png")
+	Filename  string // unique filename for EPUB internal use
+	Data      []byte // raw image bytes
+	MimeType  string // e.g. "image/png"
+}
+
+// Options configures EPUB generation.
+type Options struct {
+	Title  string
+	Author string
+}
+
+var md = goldmark.New(
+	goldmark.WithExtensions(
+		extension.Table,
+		extension.TaskList,
+		extension.Strikethrough,
+		extension.Linkify,
+	),
+	goldmark.WithRendererOptions(
+		gmhtml.WithUnsafe(),
+	),
+)
+
+// imageRefRe matches markdown image references: ![alt](path)
+var imageRefRe = regexp.MustCompile(`!\[[^\]]*\]\(([^)]+)\)`)
+
+// htmlImgRe matches HTML img src attributes.
+var htmlImgRe = regexp.MustCompile(`<img\s[^>]*src="([^"]+)"`)
+
+// imgSrcRe matches img src attributes for rewriting.
+var imgSrcRe = regexp.MustCompile(`(<img\s[^>]*?src=")([^"]+)(")`)
+
+// Generate creates an EPUB from the given chapters and images.
+func Generate(opts Options, chapters []Chapter, images []Image) ([]byte, error) {
+	if opts.Title == "" {
+		return nil, fmt.Errorf("title is required")
+	}
+	if opts.Author == "" {
+		opts.Author = "Know"
+	}
+
+	e, err := goepub.NewEpub(opts.Title)
+	if err != nil {
+		return nil, fmt.Errorf("create epub: %w", err)
+	}
+	e.SetAuthor(opts.Author)
+
+	// Add images via data URIs (no temp files needed).
+	pathToInternal := make(map[string]string)
+	for _, img := range images {
+		uri := dataurl.New(img.Data, img.MimeType).String()
+		internalPath, err := e.AddImage(uri, img.Filename)
+		if err != nil {
+			return nil, fmt.Errorf("add image %s: %w", img.Filename, err)
+		}
+		pathToInternal[img.VaultPath] = internalPath
+	}
+
+	// Add each chapter as a section.
+	for _, ch := range chapters {
+		html, err := markdownToHTML(ch.Content)
+		if err != nil {
+			return nil, fmt.Errorf("convert chapter %q: %w", ch.Title, err)
+		}
+		html = rewriteImageSrc(html, pathToInternal)
+		if _, err := e.AddSection(html, ch.Title, "", ""); err != nil {
+			return nil, fmt.Errorf("add section %q: %w", ch.Title, err)
+		}
+	}
+
+	var buf bytes.Buffer
+	if _, err := e.WriteTo(&buf); err != nil {
+		return nil, fmt.Errorf("write epub: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// ExtractImagePaths returns all image paths referenced in the markdown content.
+// This includes both markdown image syntax ![alt](path) and HTML <img src="path">.
+func ExtractImagePaths(content string) []string {
+	seen := make(map[string]bool)
+	var paths []string
+
+	for _, m := range imageRefRe.FindAllStringSubmatch(content, -1) {
+		path := m[1]
+		if !seen[path] {
+			seen[path] = true
+			paths = append(paths, path)
+		}
+	}
+	for _, m := range htmlImgRe.FindAllStringSubmatch(content, -1) {
+		path := m[1]
+		if !seen[path] {
+			seen[path] = true
+			paths = append(paths, path)
+		}
+	}
+	return paths
+}
+
+func markdownToHTML(content string) (string, error) {
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(content), &buf); err != nil {
+		return "", fmt.Errorf("goldmark convert: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// rewriteImageSrc replaces image source paths in HTML with EPUB-internal paths.
+func rewriteImageSrc(html string, pathMap map[string]string) string {
+	return imgSrcRe.ReplaceAllStringFunc(html, func(match string) string {
+		sub := imgSrcRe.FindStringSubmatch(match)
+		if len(sub) < 4 {
+			return match
+		}
+		src := sub[2]
+		if internal, ok := pathMap[src]; ok {
+			return sub[1] + internal + sub[3]
+		}
+		// Try without leading slash for relative paths.
+		if strings.HasPrefix(src, "/") {
+			if internal, ok := pathMap[src[1:]]; ok {
+				return sub[1] + internal + sub[3]
+			}
+		}
+		return match
+	})
+}

--- a/internal/epub/epub_test.go
+++ b/internal/epub/epub_test.go
@@ -1,0 +1,246 @@
+package epub
+
+import (
+	"archive/zip"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestMarkdownToHTML(t *testing.T) {
+	tests := []struct {
+		name     string
+		markdown string
+		contains []string
+	}{
+		{
+			name:     "heading and paragraph",
+			markdown: "# Hello\n\nWorld",
+			contains: []string{"<h1>Hello</h1>", "<p>World</p>"},
+		},
+		{
+			name:     "table",
+			markdown: "| A | B |\n|---|---|\n| 1 | 2 |",
+			contains: []string{"<table>", "<td>1</td>", "<td>2</td>"},
+		},
+		{
+			name:     "task list",
+			markdown: "- [x] Done\n- [ ] Todo",
+			contains: []string{`<input`, `checked`},
+		},
+		{
+			name:     "strikethrough",
+			markdown: "~~deleted~~",
+			contains: []string{"<del>deleted</del>"},
+		},
+		{
+			name:     "image reference",
+			markdown: "![photo](/images/test.png)",
+			contains: []string{`<img src="/images/test.png"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			html, err := markdownToHTML(tt.markdown)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(html, want) {
+					t.Errorf("HTML missing %q\ngot: %s", want, html)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractImagePaths(t *testing.T) {
+	content := `# Doc
+
+![photo](/images/photo.png)
+![logo](./logo.svg)
+![external](https://example.com/img.jpg)
+
+<img src="/assets/banner.webp" alt="banner">
+
+Regular [link](/not-an-image) should not match.
+`
+
+	paths := ExtractImagePaths(content)
+	want := []string{
+		"/images/photo.png",
+		"./logo.svg",
+		"https://example.com/img.jpg",
+		"/assets/banner.webp",
+	}
+
+	if len(paths) != len(want) {
+		t.Fatalf("got %d paths, want %d: %v", len(paths), len(want), paths)
+	}
+	for i, p := range paths {
+		if p != want[i] {
+			t.Errorf("path[%d] = %q, want %q", i, p, want[i])
+		}
+	}
+}
+
+func TestExtractImagePaths_NoDuplicates(t *testing.T) {
+	content := "![a](/img.png)\n![b](/img.png)"
+	paths := ExtractImagePaths(content)
+	if len(paths) != 1 {
+		t.Errorf("got %d paths, want 1 (deduped): %v", len(paths), paths)
+	}
+}
+
+func TestRewriteImageSrc(t *testing.T) {
+	html := `<p><img src="/images/photo.png" alt="photo"></p><p><img src="unknown.png" alt="x"></p>`
+	pathMap := map[string]string{
+		"/images/photo.png": "../images/img0001.png",
+	}
+
+	result := rewriteImageSrc(html, pathMap)
+
+	if !strings.Contains(result, `src="../images/img0001.png"`) {
+		t.Errorf("expected rewritten src, got: %s", result)
+	}
+	// Unknown image should remain unchanged.
+	if !strings.Contains(result, `src="unknown.png"`) {
+		t.Errorf("expected unknown src unchanged, got: %s", result)
+	}
+}
+
+func TestRewriteImageSrc_LeadingSlashFallback(t *testing.T) {
+	html := `<img src="/images/photo.png" alt="photo">`
+	pathMap := map[string]string{
+		"images/photo.png": "../images/img0001.png",
+	}
+
+	result := rewriteImageSrc(html, pathMap)
+
+	if !strings.Contains(result, `src="../images/img0001.png"`) {
+		t.Errorf("expected leading-slash fallback to match, got: %s", result)
+	}
+}
+
+func TestGenerate_SingleChapter(t *testing.T) {
+	data, err := Generate(
+		Options{Title: "Test Book", Author: "Test Author"},
+		[]Chapter{{Title: "Chapter 1", Content: "# Hello\n\nWorld", Path: "/ch1.md"}},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	assertValidEPUB(t, data)
+}
+
+func TestGenerate_MultipleChapters(t *testing.T) {
+	chapters := []Chapter{
+		{Title: "Chapter 1", Content: "First chapter", Path: "/ch1.md"},
+		{Title: "Chapter 2", Content: "Second chapter", Path: "/ch2.md"},
+		{Title: "Chapter 3", Content: "Third chapter", Path: "/ch3.md"},
+	}
+
+	data, err := Generate(
+		Options{Title: "Multi-Chapter Book"},
+		chapters,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	assertValidEPUB(t, data)
+}
+
+func TestGenerate_WithImages(t *testing.T) {
+	// 1x1 red pixel PNG
+	pngData := []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+		0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00,
+		0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
+		0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21, 0xbc, 0x33, 0x00, 0x00, 0x00,
+		0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+	}
+
+	chapters := []Chapter{
+		{Title: "With Image", Content: "# Doc\n\n![test](/images/test.png)", Path: "/doc.md"},
+	}
+	images := []Image{
+		{VaultPath: "/images/test.png", Filename: "test.png", Data: pngData, MimeType: "image/png"},
+	}
+
+	data, err := Generate(Options{Title: "Image Book"}, chapters, images)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	assertValidEPUB(t, data)
+
+	// Verify image is in the ZIP.
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	found := false
+	for _, f := range r.File {
+		if strings.Contains(f.Name, "test.png") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("image test.png not found in EPUB")
+	}
+}
+
+func TestGenerate_EmptyTitle(t *testing.T) {
+	_, err := Generate(Options{}, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for empty title")
+	}
+}
+
+func TestGenerate_DefaultAuthor(t *testing.T) {
+	data, err := Generate(
+		Options{Title: "No Author"},
+		[]Chapter{{Title: "Ch", Content: "text", Path: "/ch.md"}},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	assertValidEPUB(t, data)
+}
+
+func assertValidEPUB(t *testing.T, data []byte) {
+	t.Helper()
+
+	if len(data) == 0 {
+		t.Fatal("EPUB data is empty")
+	}
+
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("not a valid ZIP: %v", err)
+	}
+
+	requiredFiles := map[string]bool{
+		"META-INF/container.xml": false,
+	}
+
+	for _, f := range r.File {
+		if _, ok := requiredFiles[f.Name]; ok {
+			requiredFiles[f.Name] = true
+		}
+	}
+
+	for name, found := range requiredFiles {
+		if !found {
+			t.Errorf("required EPUB file %q not found", name)
+		}
+	}
+}

--- a/internal/file/service.go
+++ b/internal/file/service.go
@@ -591,49 +591,6 @@ func (s *Service) embedChunksOneByOne(ctx context.Context, embedder *llm.Embedde
 	return stored, nil
 }
 
-// fetchFileTitles collects unique file IDs from a batch of chunks and
-// batch-fetches their titles. Returns a map of fileID → title.
-func (s *Service) fetchFileTitles(ctx context.Context, chunks []models.Chunk) map[string]string {
-	logger := logutil.FromCtx(ctx)
-	titles := make(map[string]string)
-
-	// Collect unique file IDs
-	fileIDSet := make(map[string]struct{})
-	for _, chunk := range chunks {
-		fileID, err := models.RecordIDString(chunk.File)
-		if err != nil {
-			logger.Warn("failed to extract file ID for title lookup", "error", err)
-			continue
-		}
-		fileIDSet[fileID] = struct{}{}
-	}
-	fileIDs := make([]string, 0, len(fileIDSet))
-	for id := range fileIDSet {
-		fileIDs = append(fileIDs, id)
-	}
-
-	if len(fileIDs) == 0 {
-		return titles
-	}
-
-	docs, err := s.db.GetFilesByIDs(ctx, fileIDs)
-	if err != nil {
-		logger.Warn("failed to fetch file titles for contextual embedding", "error", err)
-		return titles
-	}
-
-	for _, doc := range docs {
-		fileID, err := models.RecordIDString(doc.ID)
-		if err != nil {
-			logger.Warn("failed to extract file ID from fetched file", "error", err)
-			continue
-		}
-		titles[fileID] = doc.Title
-	}
-
-	return titles
-}
-
 // buildEmbeddingContext prepends file and section context to chunk content
 // for better embedding quality (contextual retrieval technique).
 // The context prefix is only used at embedding time, not stored in the chunk.

--- a/internal/file/service_test.go
+++ b/internal/file/service_test.go
@@ -77,69 +77,69 @@ func TestBuildEmbeddingContext(t *testing.T) {
 	hp := func(s string) *string { return &s }
 
 	tests := []struct {
-		name     string
-		chunk    models.Chunk
+		name      string
+		chunk     models.Chunk
 		fileTitle string
-		maxChars int
-		want     string
+		maxChars  int
+		want      string
 	}{
 		{
-			name:     "full context",
-			chunk:    models.Chunk{Text: "Install with pip.", SourceLoc: hp("## Setup > ### Install")},
+			name:      "full context",
+			chunk:     models.Chunk{Text: "Install with pip.", SourceLoc: hp("## Setup > ### Install")},
 			fileTitle: "Getting Started",
-			want:     "File: Getting Started\nSection: Setup > Install\n\nInstall with pip.",
+			want:      "File: Getting Started\nSection: Setup > Install\n\nInstall with pip.",
 		},
 		{
-			name:     "no title",
-			chunk:    models.Chunk{Text: "Some content.", SourceLoc: hp("## Section")},
+			name:      "no title",
+			chunk:     models.Chunk{Text: "Some content.", SourceLoc: hp("## Section")},
 			fileTitle: "",
-			want:     "Section: Section\n\nSome content.",
+			want:      "Section: Section\n\nSome content.",
 		},
 		{
-			name:     "no heading path",
-			chunk:    models.Chunk{Text: "Preamble text."},
+			name:      "no heading path",
+			chunk:     models.Chunk{Text: "Preamble text."},
 			fileTitle: "My Doc",
-			want:     "File: My Doc\n\nPreamble text.",
+			want:      "File: My Doc\n\nPreamble text.",
 		},
 		{
-			name:     "no context at all",
-			chunk:    models.Chunk{Text: "Raw content."},
+			name:      "no context at all",
+			chunk:     models.Chunk{Text: "Raw content."},
 			fileTitle: "",
-			want:     "Raw content.",
+			want:      "Raw content.",
 		},
 		{
-			name:     "empty heading path",
-			chunk:    models.Chunk{Text: "Some text.", SourceLoc: hp("")},
+			name:      "empty heading path",
+			chunk:     models.Chunk{Text: "Some text.", SourceLoc: hp("")},
 			fileTitle: "My Doc",
-			want:     "File: My Doc\n\nSome text.",
+			want:      "File: My Doc\n\nSome text.",
 		},
 		{
-			name:     "truncation preserves prefix",
-			chunk:    models.Chunk{Text: "word1 word2 word3 word4 word5", SourceLoc: hp("## Section")},
+			name:      "truncation preserves prefix",
+			chunk:     models.Chunk{Text: "word1 word2 word3 word4 word5", SourceLoc: hp("## Section")},
 			fileTitle: "Doc",
-			maxChars: 40, // "File: Doc\nSection: Section\n\n" = 29 chars, leaves 11 for content
-			want:     "File: Doc\nSection: Section\n\nword1 word2",
+			maxChars:  40, // "File: Doc\nSection: Section\n\n" = 29 chars, leaves 11 for content
+			want:      "File: Doc\nSection: Section\n\nword1 word2",
 		},
 		{
-			name:     "no truncation when within limit",
-			chunk:    models.Chunk{Text: "short"},
+			name:      "no truncation when within limit",
+			chunk:     models.Chunk{Text: "short"},
 			fileTitle: "D",
-			maxChars: 100,
-			want:     "File: D\n\nshort",
+			maxChars:  100,
+			want:      "File: D\n\nshort",
 		},
 		{
-			name:     "no truncation when maxChars is zero",
-			chunk:    models.Chunk{Text: "anything goes"},
+			name:      "no truncation when maxChars is zero",
+			chunk:     models.Chunk{Text: "anything goes"},
 			fileTitle: "Title",
-			maxChars: 0,
-			want:     "File: Title\n\nanything goes",
+			maxChars:  0,
+			want:      "File: Title\n\nanything goes",
 		},
 		{
-			name:     "prefix exceeds maxChars truncates entire string",
-			chunk:    models.Chunk{Text: "body text here", SourceLoc: hp("## Long Section Name")},
+			name:      "prefix exceeds maxChars truncates entire string",
+			chunk:     models.Chunk{Text: "body text here", SourceLoc: hp("## Long Section Name")},
 			fileTitle: "A Document With A Long Title",
-			maxChars: 20, // prefix "File: A Document With A Long Title\nSection: Long Section Name\n\n" >> 20
-			want:     "File: A Document Wit",
+			maxChars:  20, // prefix "File: A Document With A Long Title\nSection: Long Section Name\n\n" >> 20
+			want:      "File: A Document Wit",
 		},
 	}
 

--- a/internal/integration/export_epub_test.go
+++ b/internal/integration/export_epub_test.go
@@ -1,0 +1,251 @@
+package integration
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestExportEPUB_SingleDocument(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "epub-single")
+
+	bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/docs/hello.md": []byte("# Hello World\n\nSome content here."),
+	})
+
+	resp, err := http.Get(srv.URL + "/api/export/epub?vault=" + vaultID + "&path=/docs/hello.md")
+	if err != nil {
+		t.Fatalf("GET export/epub: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	if ct := resp.Header.Get("Content-Type"); ct != "application/epub+zip" {
+		t.Errorf("Content-Type = %q, want application/epub+zip", ct)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	assertValidEPUBZip(t, data)
+}
+
+func TestExportEPUB_FolderMultiChapter(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "epub-folder")
+
+	bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/book/01-intro.md":      []byte("# Introduction\n\nWelcome."),
+		"/book/02-chapter.md":    []byte("# Chapter 1\n\nContent."),
+		"/book/03-conclusion.md": []byte("# Conclusion\n\nThe end."),
+	})
+
+	resp, err := http.Get(srv.URL + "/api/export/epub?vault=" + vaultID + "&path=/book/")
+	if err != nil {
+		t.Fatalf("GET export/epub: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	assertValidEPUBZip(t, data)
+
+	// Verify the EPUB contains multiple XHTML section files.
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	xhtmlCount := 0
+	for _, f := range r.File {
+		if strings.HasSuffix(f.Name, ".xhtml") {
+			xhtmlCount++
+		}
+	}
+	// go-epub adds a title page + our 3 chapters = at least 3 section files.
+	if xhtmlCount < 3 {
+		t.Errorf("expected at least 3 xhtml files, got %d", xhtmlCount)
+	}
+}
+
+func TestExportEPUB_WithImages(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "epub-images")
+
+	// Minimal valid PNG (1x1 red pixel).
+	pngData := []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+		0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00,
+		0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
+		0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21, 0xbc, 0x33, 0x00, 0x00, 0x00,
+		0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+	}
+
+	bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/docs/with-image.md": []byte("# Doc\n\n![logo](/images/logo.png)\n"),
+		"/images/logo.png":    pngData,
+	})
+
+	resp, err := http.Get(srv.URL + "/api/export/epub?vault=" + vaultID + "&path=/docs/with-image.md")
+	if err != nil {
+		t.Fatalf("GET export/epub: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	assertValidEPUBZip(t, data)
+
+	// Verify the EPUB contains the image.
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	found := false
+	for _, f := range r.File {
+		if strings.Contains(f.Name, ".png") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected image file in EPUB, none found")
+	}
+}
+
+func TestExportEPUB_TitleAuthorOverride(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "epub-meta")
+
+	bulkUploadRequest(t, srv, map[string]any{
+		"vaultId": vaultID,
+		"force":   true,
+	}, map[string][]byte{
+		"/doc.md": []byte("# Original Title\n\nContent."),
+	})
+
+	params := url.Values{
+		"vault":  {vaultID},
+		"path":   {"/doc.md"},
+		"title":  {"Custom Title"},
+		"author": {"Custom Author"},
+	}
+	resp, err := http.Get(srv.URL + "/api/export/epub?" + params.Encode())
+	if err != nil {
+		t.Fatalf("GET export/epub: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Verify Content-Disposition uses custom title.
+	cd := resp.Header.Get("Content-Disposition")
+	if !strings.Contains(cd, "Custom Title.epub") {
+		t.Errorf("Content-Disposition = %q, want filename containing 'Custom Title.epub'", cd)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	assertValidEPUBZip(t, data)
+}
+
+func TestExportEPUB_MissingPath(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "epub-no-path")
+
+	resp, err := http.Get(srv.URL + "/api/export/epub?vault=" + vaultID)
+	if err != nil {
+		t.Fatalf("GET export/epub: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if errResp.Error == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func TestExportEPUB_NonexistentPath(t *testing.T) {
+	srv, vaultID := setupBulkServer(t, "epub-404")
+
+	resp, err := http.Get(srv.URL + "/api/export/epub?vault=" + vaultID + "&path=/nonexistent/")
+	if err != nil {
+		t.Fatalf("GET export/epub: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("expected 404, got %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+func assertValidEPUBZip(t *testing.T, data []byte) {
+	t.Helper()
+
+	if len(data) == 0 {
+		t.Fatal("EPUB data is empty")
+	}
+
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("not a valid ZIP: %v", err)
+	}
+
+	foundContainer := false
+	for _, f := range r.File {
+		if f.Name == "META-INF/container.xml" {
+			foundContainer = true
+			break
+		}
+	}
+	if !foundContainer {
+		t.Error("missing META-INF/container.xml in EPUB")
+	}
+}

--- a/internal/integration/processing_test.go
+++ b/internal/integration/processing_test.go
@@ -140,7 +140,6 @@ func TestProcessAllPending_ProcessesMultipleFiles(t *testing.T) {
 	}
 }
 
-
 func TestProcessDocument_Idempotent(t *testing.T) {
 	ctx := context.Background()
 	vaultID, fileSvc := setupProcessingTest(t, ctx)

--- a/internal/memory/service_test.go
+++ b/internal/memory/service_test.go
@@ -285,11 +285,6 @@ func TestExtractProject(t *testing.T) {
 	}
 }
 
-//go:fix inline
-func timePtr(t time.Time) *time.Time {
-	return new(t)
-}
-
 func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
 }

--- a/internal/stt/openai.go
+++ b/internal/stt/openai.go
@@ -134,11 +134,7 @@ func (t *OpenAITranscriber) Transcribe(ctx context.Context, audio []byte, mimeTy
 		Segments: make([]Segment, len(vr.Segments)),
 	}
 	for i, s := range vr.Segments {
-		result.Segments[i] = Segment{
-			Start: s.Start,
-			End:   s.End,
-			Text:  s.Text,
-		}
+		result.Segments[i] = Segment(s)
 	}
 
 	return result, nil

--- a/internal/webdav/file.go
+++ b/internal/webdav/file.go
@@ -18,10 +18,9 @@ import (
 
 // readFile provides read-only access to a document's content.
 type readFile struct {
-	name    string
-	doc     *models.File
-	reader  *bytes.Reader
-	closeFn func()
+	name   string
+	doc    *models.File
+	reader *bytes.Reader
 }
 
 func newReadFile(name string, doc *models.File) *readFile {


### PR DESCRIPTION
Export documents and folders as EPUB files via a new REST endpoint and CLI command. Supports single-document and multi-chapter folder exports, embedded images (vault-local and external HTTPS), and custom title/author metadata.

## New Features
- `GET /api/export/epub?vault={id}&path={path}&title=...&author=...` endpoint
- `know epub --vault default --path /books/` CLI command
- Image extraction from markdown and HTML img tags, with vault blob and HTTPS resolution
- Goldmark-based markdown-to-XHTML conversion with tables, task lists, strikethrough support
- Refactored `apiclient.downloadToFile` helper (shared between tar.gz and EPUB exports)

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)