### PR TITLE
feat: restructure REST API with vault-scoped routes

### DIFF
--- a/cmd/know/cmd_browse.go
+++ b/cmd/know/cmd_browse.go
@@ -192,9 +192,9 @@ func editAndSave(ctx context.Context, client *apiclient.Client, vaultID, path, c
 	}
 
 	if _, err := client.EditDocument(ctx, apiclient.EditDocumentRequest{
-		VaultID: vaultID,
-		Path:    path,
-		Content: updated,
+		VaultName: vaultID,
+		Path:      path,
+		Content:   updated,
 	}); err != nil {
 		return fmt.Errorf("save: %w", err)
 	}

--- a/cmd/know/cmd_fetch.go
+++ b/cmd/know/cmd_fetch.go
@@ -43,8 +43,8 @@ func runFetch(cmd *cobra.Command, args []string) error {
 	client := fetchAPI.newClient()
 
 	req := apiclient.FetchWebpageRequest{
-		URL:     url,
-		VaultID: *fetchVaultID,
+		URL:       url,
+		VaultName: *fetchVaultID,
 	}
 	if fetchPath != "" {
 		req.Path = &fetchPath

--- a/cmd/know/cmd_import.go
+++ b/cmd/know/cmd_import.go
@@ -282,11 +282,10 @@ func importWithManifest(ctx context.Context, mappings []fileMapping, localErrors
 		manifestFiles[i] = apiclient.ImportManifestFile{Path: m.targetPath, Hash: m.hash}
 	}
 
-	manifestResp, err := client.ImportManifest(ctx, apiclient.ImportManifestRequest{
-		VaultID: importVaultID,
-		Force:   importForce,
-		DryRun:  importDryRun,
-		Files:   manifestFiles,
+	manifestResp, err := client.ImportManifest(ctx, importVaultID, apiclient.ImportManifestRequest{
+		Force:  importForce,
+		DryRun: importDryRun,
+		Files:  manifestFiles,
 	})
 	if err != nil {
 		return fmt.Errorf("import manifest: %w", err)

--- a/cmd/know/cmd_info.go
+++ b/cmd/know/cmd_info.go
@@ -64,7 +64,7 @@ func runInfo(_ *cobra.Command, _ []string) error {
 	client := infoAPI.newClient()
 
 	var cfg serverInfo
-	if err := client.Get(context.Background(), "/api/config", &cfg); err != nil {
+	if err := client.Get(context.Background(), "/api/v1/config", &cfg); err != nil {
 		return fmt.Errorf("info: %w", err)
 	}
 

--- a/cmd/know/cmd_note.go
+++ b/cmd/know/cmd_note.go
@@ -138,9 +138,9 @@ func ensureDailyNote(ctx context.Context, client *apiclient.Client, vaultID, pat
 		return nil, fmt.Errorf("daily note content: %w", err)
 	}
 	doc, err = client.CreateDocument(ctx, apiclient.CreateDocumentRequest{
-		VaultID: vaultID,
-		Path:    path,
-		Content: content,
+		VaultName: vaultID,
+		Path:      path,
+		Content:   content,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create daily note: %w", err)

--- a/cmd/know/cmd_remote.go
+++ b/cmd/know/cmd_remote.go
@@ -58,7 +58,7 @@ func runRemoteList(_ *cobra.Command, _ []string) error {
 	client := remoteAPIFlags.newClient()
 
 	var remotes []remoteListResponse
-	if err := client.Get(context.Background(), "/api/remotes", &remotes); err != nil {
+	if err := client.Get(context.Background(), "/api/v1/remotes", &remotes); err != nil {
 		return fmt.Errorf("list remotes: %w", err)
 	}
 
@@ -92,7 +92,7 @@ func runRemoteAdd(_ *cobra.Command, args []string) error {
 	}
 
 	var result json.RawMessage
-	if err := client.Post(context.Background(), "/api/remotes", body, &result); err != nil {
+	if err := client.Post(context.Background(), "/api/v1/remotes", body, &result); err != nil {
 		return fmt.Errorf("add remote: %w", err)
 	}
 

--- a/cmd/know/cmd_serve.go
+++ b/cmd/know/cmd_serve.go
@@ -169,68 +169,85 @@ func runServe(_ *cobra.Command, _ []string) error {
 		authMw = auth.Middleware(app.DBClient())
 	}
 
-	// Agent endpoints
-	mux.Handle("POST /agent/chat", authMw(app.AgentRunner().HandleChat()))
-	mux.Handle("GET /agent/events/{id}", authMw(app.AgentRunner().HandleEvents()))
-	mux.Handle("POST /agent/cancel/{id}", authMw(app.AgentRunner().HandleCancel()))
-	mux.Handle("POST /agent/approval", authMw(app.AgentRunner().HandleApproval()))
-
-	// Document change events (SSE)
-	mux.Handle("GET /events", authMw(event.HandleEvents(app.EventBus())))
-
-	// REST API
+	// REST API (includes agent routes)
 	apiServer := api.NewServer(app)
-	apiServer.Register(mux, authMw)
+	apiServer.Register(mux, authMw, app.AgentRunner())
 
-	// MCP endpoint for Model Context Protocol
-	if cfg.MCPEnabled {
-		mcpHandler := mcptools.NewHandler(
-			&tools.Executor{
-				DB:        app.DBClient(),
-				Search:    app.SearchService(),
-				FileSvc:   app.FileService(),
-				RenderSvc: app.RenderService(),
-				Jina:      app.JinaClient(),
-			},
+	// Document change events (SSE) — vault-scoped
+	// Uses the apiServer's vault scope middleware for consistent vault resolution.
+	mux.Handle("GET /api/v1/vaults/{vault}/events", authMw(apiServer.VaultScopeHandler(event.HandleEvents(app.EventBus()))))
+
+	// Protocol server (WebDAV + MCP) — separate port, own auth
+	var protoSrv *http.Server
+	{
+		protoMux := http.NewServeMux()
+
+		// MCP endpoint for Model Context Protocol
+		if cfg.MCPEnabled {
+			mcpHandler := mcptools.NewHandler(
+				&tools.Executor{
+					DB:        app.DBClient(),
+					Search:    app.SearchService(),
+					FileSvc:   app.FileService(),
+					RenderSvc: app.RenderService(),
+					Jina:      app.JinaClient(),
+				},
+				app.DBClient(),
+				app.FileService(),
+				app.VaultService(),
+				app.RemoteService(),
+				app.MemoryService(),
+				app.ApifyClient(),
+				app.JinaClient(),
+			)
+			protoMux.Handle("/mcp", authMw(mcpHandler))
+			slog.Info("MCP endpoint enabled", "port", cfg.ProtocolPort, "path", "/mcp")
+		}
+
+		// WebDAV endpoint for document editing with any editor
+		var davHandler http.Handler = knowdav.NewHandler(
+			serverCtx,
+			"/dav/",
 			app.DBClient(),
 			app.FileService(),
 			app.VaultService(),
-			app.RemoteService(),
-			app.MemoryService(),
-			app.ApifyClient(),
-			app.JinaClient(),
+			app.BlobStore(),
+			cfg.NoAuth,
+			10*1024*1024, // 10 MB max PUT body
 		)
-		mux.Handle("/mcp", authMw(mcpHandler))
-		slog.Info("MCP endpoint enabled", "path", "/mcp")
-	}
 
-	// WebDAV endpoint for document editing with any editor
-	var davHandler http.Handler = knowdav.NewHandler(
-		serverCtx,
-		"/dav/",
-		app.DBClient(),
-		app.FileService(),
-		app.VaultService(),
-		app.BlobStore(),
-		cfg.NoAuth,
-		10*1024*1024, // 10 MB max PUT body
-	)
-
-	// Optional debug log: KNOW_DAV_DEBUG_LOG=/tmp/dav-debug.log
-	davDebugLog := os.Getenv("KNOW_DAV_DEBUG_LOG")
-	if davDebugLog != "" {
-		davLogger, davLogFile, logErr := knowdav.NewDebugLogger(davDebugLog)
-		if logErr != nil {
-			slog.Error("failed to open DAV debug log", "path", davDebugLog, "error", logErr)
-		} else {
-			defer davLogFile.Close()
-			davHandler = knowdav.DebugLogMiddleware(davLogger, davHandler)
-			slog.Info("WebDAV debug logging enabled", "path", davDebugLog)
+		// Optional debug log: KNOW_DAV_DEBUG_LOG=/tmp/dav-debug.log
+		davDebugLog := os.Getenv("KNOW_DAV_DEBUG_LOG")
+		if davDebugLog != "" {
+			davLogger, davLogFile, logErr := knowdav.NewDebugLogger(davDebugLog)
+			if logErr != nil {
+				slog.Error("failed to open DAV debug log", "path", davDebugLog, "error", logErr)
+			} else {
+				defer davLogFile.Close()
+				davHandler = knowdav.DebugLogMiddleware(davLogger, davHandler)
+				slog.Info("WebDAV debug logging enabled", "path", davDebugLog)
+			}
 		}
-	}
 
-	mux.Handle("/dav/", davHandler)
-	slog.Info("WebDAV endpoint enabled", "path", "/dav/{vaultName}/")
+		protoMux.Handle("/dav/", davHandler)
+		slog.Info("WebDAV endpoint enabled", "port", cfg.ProtocolPort, "path", "/dav/{vaultName}/")
+
+		protoLn, listenErr := net.Listen("tcp", listenHost+":"+cfg.ProtocolPort)
+		if listenErr != nil {
+			return fmt.Errorf("bind protocol port %s: %w", cfg.ProtocolPort, listenErr)
+		}
+		protoSrv = &http.Server{
+			Handler:           protoMux,
+			ReadHeaderTimeout: 5 * time.Second,
+			IdleTimeout:       120 * time.Second,
+		}
+		go func() {
+			if err := protoSrv.Serve(protoLn); err != nil && err != http.ErrServerClosed {
+				slog.Error("protocol server error", "error", err)
+			}
+		}()
+		slog.Info("protocol server started (WebDAV + MCP)", "port", cfg.ProtocolPort)
+	}
 
 	// SSH/SFTP server (optional)
 	var sshSrv *sshd.Server
@@ -312,7 +329,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
-		slog.Info("REST API available", "url", fmt.Sprintf("http://localhost:%s/api/", port))
+		slog.Info("REST API available", "url", fmt.Sprintf("http://localhost:%s/api/v1/", port))
 
 		if err := httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
 			slog.Error("server error", "error", err)
@@ -334,7 +351,15 @@ func runServe(_ *cobra.Command, _ []string) error {
 	slog.Info("cancelling background goroutines")
 	serverCancel()
 
-	// 3. Metrics server shutdown
+	// 3. Protocol server shutdown (WebDAV + MCP)
+	if protoSrv != nil {
+		slog.Info("protocol: shutting down")
+		if err := protoSrv.Shutdown(shutdownCtx); err != nil {
+			slog.Error("protocol: shutdown error", "error", err)
+		}
+	}
+
+	// 4. Metrics server shutdown
 	if metricsSrv != nil {
 		slog.Info("metrics: shutting down")
 		if err := metricsSrv.Shutdown(shutdownCtx); err != nil {
@@ -342,20 +367,20 @@ func runServe(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	// 4. NFS shutdown
+	// 5. NFS shutdown
 	if nfsSrv != nil {
 		slog.Info("nfs: shutting down")
 		nfsSrv.Shutdown(shutdownCtx)
 	}
 
-	// 5. SSH shutdown — stop accepting new connections and drain active sessions
+	// 6. SSH shutdown — stop accepting new connections and drain active sessions
 	if sshSrv != nil {
 		slog.Info("ssh: shutting down")
 		sshSrv.Shutdown(shutdownCtx)
 		slog.Info("ssh: stopped")
 	}
 
-	// 6. HTTP shutdown — stop accepting new connections, drain in-flight requests
+	// 7. HTTP shutdown — stop accepting new connections, drain in-flight requests
 	slog.Info("http: shutting down")
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		slog.Error("http: shutdown error", "error", err)
@@ -363,7 +388,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 		slog.Info("http: stopped")
 	}
 
-	// 7. App shutdown — stop workers, agents, event bus, close DB (with deadline)
+	// 8. App shutdown — stop workers, agents, event bus, close DB (with deadline)
 	slog.Info("stopping application services")
 	if err := app.Close(shutdownCtx); err != nil {
 		slog.Error("app close error", "error", err)

--- a/docs/feature-ingestion.md
+++ b/docs/feature-ingestion.md
@@ -24,14 +24,14 @@ Documents enter through the CLI (`know import`) or WebDAV file saves. Both paths
                          |  publish event   |                   |
                          |  enqueue job     |          +--------v-----------+
                          +------------------+          |    Job Handlers    |
-                                                       | parse | pdf       |
-                                                       | transcribe        |
-                                                       | summarize | embed |
+                                                       | parse | pdf        |
+                                                       | transcribe         |
+                                                       | summarize | embed  |
                                                        +--------------------+
                                                                 |
                                                        +--------v-----------+
                                                        |  Search Indexes    |
-                                                       |  BM25 + HNSW      |
+                                                       |  BM25 + HNSW       |
                                                        +--------------------+
 ```
 
@@ -209,7 +209,7 @@ Applies a vault template to an audio transcript using an LLM:
 
 1. **Check vault settings** — look up `transcript_template` path; skip if not configured
 2. **Fetch template** document from the vault
-3. **Apply template variables** — substitute `{{date}}`, `{{datetime}}`, `{{title}}`, `{{vault}}` placeholders
+3. **Apply template variables** — substitute `{{date}}`, `{{path}}`, `{{vault}}` placeholders
 4. **LLM FillTemplate()** — generate structured summary from template + raw transcript
 5. **Overwrite transcript** with the LLM-rendered summary
 6. **Enqueue `parse` job** — rechunk from the summary content (which then enqueues embed)
@@ -357,7 +357,7 @@ Frontmatter fields:
 
 ## Query Blocks
 
-Documents can embed queries using an inline DSL inside `know` code blocks. The parser extracts and validates these blocks, but **execution is not yet implemented** — currently only parsing and validation occur during ingestion.
+Documents can embed live queries using an inline DSL inside `know` code blocks:
 
 ````markdown
 ```know
@@ -369,7 +369,7 @@ LIMIT 10
 ```
 ````
 
-Planned output format: 1-2 `SHOW` fields render as a list, 3+ fields render as a table.
+Output format depends on the number of `SHOW` fields: 1-2 fields render as a list, 3+ fields render as a table.
 
 ## Graceful Degradation
 

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -16,7 +16,6 @@ const maxAttachments = 20
 
 type chatRequestBody struct {
 	ConversationID string                  `json:"conversationId"`
-	VaultID        string                  `json:"vaultId"`
 	Content        string                  `json:"content"`
 	DocRefs        []string                `json:"docRefs"`
 	Attachments    []models.ChatAttachment `json:"attachments,omitempty"`
@@ -55,10 +54,8 @@ func (rn *Runner) HandleChat() http.HandlerFunc {
 			return
 		}
 
-		if body.VaultID == "" {
-			http.Error(w, "vaultId is required", http.StatusBadRequest)
-			return
-		}
+		vaultID := auth.MustVaultIDFromCtx(r.Context())
+
 		if body.Content == "" {
 			http.Error(w, "content is required", http.StatusBadRequest)
 			return
@@ -87,14 +84,14 @@ func (rn *Runner) HandleChat() http.HandlerFunc {
 			}
 		}
 
-		if err := auth.RequireVaultRole(r.Context(), body.VaultID, models.RoleWrite); err != nil {
+		if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleWrite); err != nil {
 			http.Error(w, "forbidden", http.StatusForbidden)
 			return
 		}
 
 		req := ChatRequest{
 			ConversationID: body.ConversationID,
-			VaultID:        body.VaultID,
+			VaultID:        vaultID,
 			UserID:         ac.UserID,
 			Content:        body.Content,
 			DocRefs:        body.DocRefs,

--- a/internal/api/assets.go
+++ b/internal/api/assets.go
@@ -21,10 +21,10 @@ func (s *Server) uploadAsset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	vaultID := r.FormValue("vault")
+	vaultID := auth.MustVaultIDFromCtx(r.Context())
 	path := r.FormValue("path")
-	if vaultID == "" || path == "" {
-		writeError(w, http.StatusBadRequest, "vault and path fields are required")
+	if path == "" {
+		writeError(w, http.StatusBadRequest, "path field is required")
 		return
 	}
 
@@ -76,16 +76,11 @@ func (s *Server) uploadAsset(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getAsset(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.URL.Query().Get("vault")
+	vaultID := auth.MustVaultIDFromCtx(r.Context())
 	path := r.URL.Query().Get("path")
 
-	if vaultID == "" || path == "" {
-		writeError(w, http.StatusBadRequest, "vault and path query parameters required")
-		return
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+	if path == "" {
+		writeError(w, http.StatusBadRequest, "path query parameter required")
 		return
 	}
 
@@ -125,16 +120,11 @@ func (s *Server) getAsset(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getAssetMeta(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.URL.Query().Get("vault")
+	vaultID := auth.MustVaultIDFromCtx(r.Context())
 	path := r.URL.Query().Get("path")
 
-	if vaultID == "" || path == "" {
-		writeError(w, http.StatusBadRequest, "vault and path query parameters required")
-		return
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+	if path == "" {
+		writeError(w, http.StatusBadRequest, "path query parameter required")
 		return
 	}
 
@@ -161,11 +151,11 @@ func (s *Server) getAssetMeta(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) deleteAsset(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.URL.Query().Get("vault")
+	vaultID := auth.MustVaultIDFromCtx(r.Context())
 	path := r.URL.Query().Get("path")
 
-	if vaultID == "" || path == "" {
-		writeError(w, http.StatusBadRequest, "vault and path query parameters required")
+	if path == "" {
+		writeError(w, http.StatusBadRequest, "path query parameter required")
 		return
 	}
 

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -13,17 +13,7 @@ import (
 
 func (s *Server) exportBackup(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-
-	vaultID := r.URL.Query().Get("vault")
-	if vaultID == "" {
-		writeError(w, http.StatusBadRequest, "vault query parameter is required")
-		return
-	}
-
-	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, err.Error())
-		return
-	}
+	vaultID := auth.MustVaultIDFromCtx(ctx)
 
 	bareVault := models.BareID("vault", vaultID)
 	w.Header().Set("Content-Type", "application/gzip")

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -14,9 +14,8 @@ import (
 
 // bulkMeta is the JSON metadata sent as the first multipart part ("meta").
 type bulkMeta struct {
-	VaultID string `json:"vaultId"`
-	Force   bool   `json:"force"`
-	DryRun  bool   `json:"dryRun"`
+	Force  bool `json:"force"`
+	DryRun bool `json:"dryRun"`
 }
 
 // bulkFileResult is the per-file result in the response.
@@ -58,12 +57,9 @@ func (s *Server) bulkUpload(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid meta JSON: %v", err))
 		return
 	}
-	if meta.VaultID == "" {
-		writeError(w, http.StatusBadRequest, "vaultId is required in meta")
-		return
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), meta.VaultID, models.RoleWrite); err != nil {
+	ctx := r.Context()
+	vaultID := auth.MustVaultIDFromCtx(ctx)
+	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
 		writeError(w, http.StatusForbidden, "forbidden")
 		return
 	}
@@ -78,12 +74,12 @@ func (s *Server) bulkUpload(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 		if err != nil {
-			logutil.FromCtx(r.Context()).Error("bulk upload: read part", "vault", meta.VaultID, "error", err)
+			logutil.FromCtx(r.Context()).Error("bulk upload: read part", "vault", vaultID, "error", err)
 			loopErr = err
 			break
 		}
 
-		result := s.processBulkPart(r, part, meta)
+		result := s.processBulkPart(r, part, vaultID, meta)
 		results = append(results, result)
 	}
 
@@ -98,7 +94,7 @@ func (s *Server) bulkUpload(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func (s *Server) processBulkPart(r *http.Request, part *multipart.Part, meta bulkMeta) bulkFileResult {
+func (s *Server) processBulkPart(r *http.Request, part *multipart.Part, vaultID string, meta bulkMeta) bulkFileResult {
 	path := part.FormName()
 	if path == "" {
 		return bulkFileResult{Path: "(unknown)", Status: "error", Error: "missing path in form name"}
@@ -110,18 +106,18 @@ func (s *Server) processBulkPart(r *http.Request, part *multipart.Part, meta bul
 	}
 
 	if models.IsImageFile(path) || models.IsAudioFile(path) {
-		return s.processBulkAsset(r, path, data, meta)
+		return s.processBulkAsset(r, path, data, vaultID, meta)
 	}
-	return s.processBulkDocument(r, path, string(data), meta)
+	return s.processBulkDocument(r, path, string(data), vaultID, meta)
 }
 
-func (s *Server) processBulkDocument(r *http.Request, path, content string, meta bulkMeta) bulkFileResult {
+func (s *Server) processBulkDocument(r *http.Request, path, content, vaultID string, meta bulkMeta) bulkFileResult {
 	logger := logutil.FromCtx(r.Context())
 	hash := models.ContentHash(content)
 
-	existing, err := s.app.DBClient().GetFileByPath(r.Context(), meta.VaultID, path)
+	existing, err := s.app.DBClient().GetFileByPath(r.Context(), vaultID, path)
 	if err != nil {
-		logger.Error("bulk: check existing document", "vault", meta.VaultID, "path", path, "error", err)
+		logger.Error("bulk: check existing document", "vault", vaultID, "path", path, "error", err)
 		return bulkFileResult{Path: path, Status: "error", Error: fmt.Sprintf("check existing document: %v", err)}
 	}
 
@@ -142,12 +138,12 @@ func (s *Server) processBulkDocument(r *http.Request, path, content string, meta
 	}
 
 	_, err = s.app.FileService().Create(r.Context(), models.FileInput{
-		VaultID: meta.VaultID,
+		VaultID: vaultID,
 		Path:    path,
 		Content: content,
 	})
 	if err != nil {
-		logger.Error("bulk: upsert document", "vault", meta.VaultID, "path", path, "error", err)
+		logger.Error("bulk: upsert document", "vault", vaultID, "path", path, "error", err)
 		return bulkFileResult{Path: path, Status: "error", Error: fmt.Sprintf("create/update document: %v", err)}
 	}
 
@@ -157,13 +153,13 @@ func (s *Server) processBulkDocument(r *http.Request, path, content string, meta
 	return bulkFileResult{Path: path, Status: "created"}
 }
 
-func (s *Server) processBulkAsset(r *http.Request, path string, data []byte, meta bulkMeta) bulkFileResult {
+func (s *Server) processBulkAsset(r *http.Request, path string, data []byte, vaultID string, meta bulkMeta) bulkFileResult {
 	logger := logutil.FromCtx(r.Context())
 	hash := models.ContentHash(string(data))
 
-	existing, err := s.app.DBClient().GetFileMetaByPath(r.Context(), meta.VaultID, path)
+	existing, err := s.app.DBClient().GetFileMetaByPath(r.Context(), vaultID, path)
 	if err != nil {
-		logger.Error("bulk: check existing asset", "vault", meta.VaultID, "path", path, "error", err)
+		logger.Error("bulk: check existing asset", "vault", vaultID, "path", path, "error", err)
 		return bulkFileResult{Path: path, Status: "error", Error: fmt.Sprintf("check existing asset: %v", err)}
 	}
 
@@ -184,12 +180,12 @@ func (s *Server) processBulkAsset(r *http.Request, path string, data []byte, met
 	}
 
 	_, err = s.app.FileService().Create(r.Context(), models.FileInput{
-		VaultID: meta.VaultID,
+		VaultID: vaultID,
 		Path:    path,
 		Data:    data,
 	})
 	if err != nil {
-		logger.Error("bulk: upload asset", "vault", meta.VaultID, "path", path, "error", err)
+		logger.Error("bulk: upload asset", "vault", vaultID, "path", path, "error", err)
 		return bulkFileResult{Path: path, Status: "error", Error: fmt.Sprintf("upload asset: %v", err)}
 	}
 

--- a/internal/api/export.go
+++ b/internal/api/export.go
@@ -18,17 +18,7 @@ import (
 
 func (s *Server) export(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-
-	vaultID := r.URL.Query().Get("vault")
-	if vaultID == "" {
-		writeError(w, http.StatusBadRequest, "vault query parameter is required")
-		return
-	}
-
-	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, err.Error())
-		return
-	}
+	vaultID := auth.MustVaultIDFromCtx(ctx)
 
 	logger := logutil.FromCtx(ctx)
 	dbClient := s.app.DBClient()

--- a/internal/api/export_epub.go
+++ b/internal/api/export_epub.go
@@ -14,26 +14,16 @@ import (
 	"github.com/raphi011/know/internal/db"
 	"github.com/raphi011/know/internal/epub"
 	"github.com/raphi011/know/internal/logutil"
-	"github.com/raphi011/know/internal/models"
 )
 
 func (s *Server) exportEPUB(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := logutil.FromCtx(ctx)
 
-	vaultID := r.URL.Query().Get("vault")
-	if vaultID == "" {
-		writeError(w, http.StatusBadRequest, "vault query parameter is required")
-		return
-	}
+	vaultID := auth.MustVaultIDFromCtx(ctx)
 	filePath := r.URL.Query().Get("path")
 	if filePath == "" {
 		writeError(w, http.StatusBadRequest, "path query parameter is required")
-		return
-	}
-
-	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, err.Error())
 		return
 	}
 

--- a/internal/api/external_links.go
+++ b/internal/api/external_links.go
@@ -11,16 +11,7 @@ import (
 )
 
 func (s *Server) externalLinkStats(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.URL.Query().Get("vault")
-	if vaultID == "" {
-		writeError(w, http.StatusBadRequest, "vault query parameter required")
-		return
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
-		return
-	}
+	vaultID := auth.MustVaultIDFromCtx(r.Context())
 
 	stats, err := s.app.DBClient().GetExternalLinkStats(r.Context(), vaultID)
 	if err != nil {
@@ -37,16 +28,7 @@ func (s *Server) externalLinkStats(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listExternalLinks(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.URL.Query().Get("vault")
-	if vaultID == "" {
-		writeError(w, http.StatusBadRequest, "vault query parameter required")
-		return
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
-		return
-	}
+	vaultID := auth.MustVaultIDFromCtx(r.Context())
 
 	filter := db.ExternalLinkFilter{
 		VaultID: vaultID,

--- a/internal/api/fetch.go
+++ b/internal/api/fetch.go
@@ -6,19 +6,18 @@ import (
 
 	"github.com/raphi011/know/internal/auth"
 	"github.com/raphi011/know/internal/logutil"
+	"github.com/raphi011/know/internal/models"
 	"github.com/raphi011/know/internal/webclip"
 )
 
 type fetchRequest struct {
-	URL     string  `json:"url"`
-	VaultID string  `json:"vault_id"`
-	Path    *string `json:"path,omitempty"`
+	URL  string  `json:"url"`
+	Path *string `json:"path,omitempty"`
 }
 
 type fetchResponse struct {
-	Path    string `json:"path"`
-	Title   string `json:"title"`
-	VaultID string `json:"vault_id"`
+	Path  string `json:"path"`
+	Title string `json:"title"`
 }
 
 func (s *Server) fetchWebpage(w http.ResponseWriter, r *http.Request) {
@@ -34,21 +33,10 @@ func (s *Server) fetchWebpage(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	logger := logutil.FromCtx(ctx)
+	vaultID := auth.MustVaultIDFromCtx(ctx)
 
-	// Resolve vault.
-	vaultID := req.VaultID
-	if vaultID == "" {
-		ac, err := auth.FromContext(ctx)
-		if err != nil {
-			writeError(w, http.StatusUnauthorized, "unauthorized")
-			return
-		}
-		if len(ac.Vaults) > 0 {
-			vaultID = ac.Vaults[0].VaultID
-		}
-	}
-	if vaultID == "" {
-		writeError(w, http.StatusBadRequest, "vault_id is required")
+	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
@@ -75,8 +63,7 @@ func (s *Server) fetchWebpage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, fetchResponse{
-		Path:    result.Path,
-		Title:   result.Title,
-		VaultID: vaultID,
+		Path:  result.Path,
+		Title: result.Title,
 	})
 }

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -12,16 +12,11 @@ import (
 )
 
 func (s *Server) getDocument(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.URL.Query().Get("vault")
+	vaultID := auth.MustVaultIDFromCtx(r.Context())
 	path := r.URL.Query().Get("path")
 
-	if vaultID == "" || path == "" {
-		writeError(w, http.StatusBadRequest, "vault and path query parameters required")
-		return
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+	if path == "" {
+		writeError(w, http.StatusBadRequest, "path query parameter required")
 		return
 	}
 
@@ -80,7 +75,6 @@ func (s *Server) getDocument(w http.ResponseWriter, r *http.Request) {
 }
 
 type upsertDocumentRequest struct {
-	VaultID string `json:"vaultId"`
 	Path    string `json:"path"`
 	Content string `json:"content"`
 }
@@ -90,20 +84,22 @@ func (s *Server) upsertDocument(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if body.VaultID == "" || body.Path == "" {
-		writeError(w, http.StatusBadRequest, "vaultId and path are required")
+	if body.Path == "" {
+		writeError(w, http.StatusBadRequest, "path is required")
 		return
 	}
 
-	if err := auth.RequireVaultRole(r.Context(), body.VaultID, models.RoleWrite); err != nil {
+	ctx := r.Context()
+	vaultID := auth.MustVaultIDFromCtx(ctx)
+	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
 		writeError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
-	logger := logutil.FromCtx(r.Context())
+	logger := logutil.FromCtx(ctx)
 
-	doc, err := s.app.FileService().Create(r.Context(), models.FileInput{
-		VaultID: body.VaultID,
+	doc, err := s.app.FileService().Create(ctx, models.FileInput{
+		VaultID: vaultID,
 		Path:    body.Path,
 		Content: body.Content,
 	})
@@ -123,15 +119,16 @@ type deleteDocumentsResponse struct {
 }
 
 func (s *Server) deleteDocuments(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.URL.Query().Get("vault")
+	ctx := r.Context()
+	vaultID := auth.MustVaultIDFromCtx(ctx)
 	path := r.URL.Query().Get("path")
 
-	if vaultID == "" || path == "" {
-		writeError(w, http.StatusBadRequest, "vault and path query parameters required")
+	if path == "" {
+		writeError(w, http.StatusBadRequest, "path query parameter required")
 		return
 	}
 
-	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleWrite); err != nil {
+	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
 		writeError(w, http.StatusForbidden, "forbidden")
 		return
 	}
@@ -140,7 +137,6 @@ func (s *Server) deleteDocuments(w http.ResponseWriter, r *http.Request) {
 	recursive := r.URL.Query().Get("recursive") == "true"
 	dryRun := r.URL.Query().Get("dry-run") == "true"
 
-	ctx := r.Context()
 	logger := logutil.FromCtx(ctx)
 
 	// Check if path exists (documents and folders are in the same table)
@@ -213,7 +209,6 @@ func (s *Server) deleteDocuments(w http.ResponseWriter, r *http.Request) {
 }
 
 type moveRequest struct {
-	VaultID     string `json:"vaultId"`
 	Source      string `json:"source"`
 	Destination string `json:"destination"`
 	DryRun      bool   `json:"dryRun"`
@@ -231,12 +226,14 @@ func (s *Server) move(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if body.VaultID == "" || body.Source == "" || body.Destination == "" {
-		writeError(w, http.StatusBadRequest, "vaultId, source, and destination are required")
+	if body.Source == "" || body.Destination == "" {
+		writeError(w, http.StatusBadRequest, "source and destination are required")
 		return
 	}
 
-	if err := auth.RequireVaultRole(r.Context(), body.VaultID, models.RoleWrite); err != nil {
+	ctx := r.Context()
+	vaultID := auth.MustVaultIDFromCtx(ctx)
+	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
 		writeError(w, http.StatusForbidden, "forbidden")
 		return
 	}
@@ -249,11 +246,10 @@ func (s *Server) move(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := r.Context()
 	logger := logutil.FromCtx(ctx)
 
 	// Single lookup — documents and folders are in the same table
-	sourceFile, err := s.app.DBClient().GetFileByPath(ctx, body.VaultID, source)
+	sourceFile, err := s.app.DBClient().GetFileByPath(ctx, vaultID, source)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to check source: %s", source))
 		logger.Error("move: get source", "source", source, "error", err)
@@ -265,7 +261,7 @@ func (s *Server) move(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check for destination conflict (same table — covers both docs and folders)
-	existing, err := s.app.DBClient().GetFileByPath(ctx, body.VaultID, destination)
+	existing, err := s.app.DBClient().GetFileByPath(ctx, vaultID, destination)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to check destination: %s", destination))
 		logger.Error("move: check destination", "destination", destination, "error", err)
@@ -287,7 +283,7 @@ func (s *Server) move(w http.ResponseWriter, r *http.Request) {
 	// Document move
 	if !sourceFile.IsFolder {
 		if !body.DryRun {
-			if _, err := s.app.FileService().Move(ctx, body.VaultID, source, destination); err != nil {
+			if _, err := s.app.FileService().Move(ctx, vaultID, source, destination); err != nil {
 				writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to move document: %s", source))
 				logger.Error("move document", "source", source, "destination", destination, "error", err)
 				return
@@ -306,7 +302,7 @@ func (s *Server) move(w http.ResponseWriter, r *http.Request) {
 	prefix := source + "/"
 	isNotFolder := false
 	metas, err := s.app.DBClient().ListFileMetas(ctx, db.ListFilesFilter{
-		VaultID:  body.VaultID,
+		VaultID:  vaultID,
 		Folder:   &prefix,
 		IsFolder: &isNotFolder,
 		Limit:    10000,
@@ -323,7 +319,7 @@ func (s *Server) move(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !body.DryRun {
-		if err := s.app.VaultService().MoveFolder(ctx, body.VaultID, source, destination); err != nil {
+		if err := s.app.VaultService().MoveFolder(ctx, vaultID, source, destination); err != nil {
 			writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to move folder: %s", source))
 			logger.Error("move folder", "source", source, "destination", destination, "error", err)
 			return

--- a/internal/api/folders.go
+++ b/internal/api/folders.go
@@ -11,7 +11,6 @@ import (
 )
 
 type updateFolderRequest struct {
-	Vault   string `json:"vault"`
 	Path    string `json:"path"`
 	NoEmbed *bool  `json:"no_embed"`
 }
@@ -21,18 +20,8 @@ type updateFolderResponse struct {
 }
 
 func (s *Server) listFolders(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.URL.Query().Get("vault")
-	if vaultID == "" {
-		writeError(w, http.StatusBadRequest, "vault query parameter required")
-		return
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
-		return
-	}
-
 	ctx := r.Context()
+	vaultID := auth.MustVaultIDFromCtx(ctx)
 	logger := logutil.FromCtx(ctx)
 
 	folders, err := s.app.DBClient().ListFolders(ctx, vaultID)
@@ -72,26 +61,27 @@ func (s *Server) updateFolder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Vault == "" || req.Path == "" {
-		writeError(w, http.StatusBadRequest, "vault and path are required")
-		return
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), req.Vault, models.RoleWrite); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+	if req.Path == "" {
+		writeError(w, http.StatusBadRequest, "path is required")
 		return
 	}
 
 	ctx := r.Context()
+	vaultID := auth.MustVaultIDFromCtx(ctx)
+	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+
 	logger := logutil.FromCtx(ctx)
 	db := s.app.DBClient()
 
 	req.Path = models.NormalizePath(req.Path)
 
-	folder, err := db.GetFolderByPath(ctx, req.Vault, req.Path)
+	folder, err := db.GetFolderByPath(ctx, vaultID, req.Path)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to get folder")
-		logger.Error("update folder: get folder", "vault_id", req.Vault, "path", req.Path, "error", err)
+		logger.Error("update folder: get folder", "vault_id", vaultID, "path", req.Path, "error", err)
 		return
 	}
 	if folder == nil {
@@ -102,16 +92,16 @@ func (s *Server) updateFolder(w http.ResponseWriter, r *http.Request) {
 	var stripped int
 
 	if req.NoEmbed != nil {
-		if err := db.SetFolderNoEmbed(ctx, req.Vault, req.Path, *req.NoEmbed); err != nil {
+		if err := db.SetFolderNoEmbed(ctx, vaultID, req.Path, *req.NoEmbed); err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to update folder")
-			logger.Error("update folder: set no_embed", "vault_id", req.Vault, "path", req.Path, "error", err)
+			logger.Error("update folder: set no_embed", "vault_id", vaultID, "path", req.Path, "error", err)
 			return
 		}
 		if *req.NoEmbed {
-			n, err := db.StripEmbeddingsByFolder(ctx, req.Vault, req.Path)
+			n, err := db.StripEmbeddingsByFolder(ctx, vaultID, req.Path)
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, "failed to strip embeddings")
-				logger.Error("update folder: strip embeddings", "vault_id", req.Vault, "path", req.Path, "error", err)
+				logger.Error("update folder: strip embeddings", "vault_id", vaultID, "path", req.Path, "error", err)
 				return
 			}
 			stripped = n

--- a/internal/api/import.go
+++ b/internal/api/import.go
@@ -57,10 +57,9 @@ type importManifestFile struct {
 
 // importManifestRequest is the request body for POST /api/import/manifest.
 type importManifestRequest struct {
-	VaultID string               `json:"vaultId"`
-	Force   bool                 `json:"force"`
-	DryRun  bool                 `json:"dryRun"`
-	Files   []importManifestFile `json:"files"`
+	Force  bool                 `json:"force"`
+	DryRun bool                 `json:"dryRun"`
+	Files  []importManifestFile `json:"files"`
 }
 
 // importManifestResponse is the response body for POST /api/import/manifest.
@@ -86,26 +85,23 @@ func (s *Server) importManifest(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if req.VaultID == "" {
-		writeError(w, http.StatusBadRequest, "vaultId is required")
-		return
-	}
-	if err := auth.RequireVaultRole(r.Context(), req.VaultID, models.RoleWrite); err != nil {
+	ctx := r.Context()
+	vaultID := auth.MustVaultIDFromCtx(ctx)
+	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
 		writeError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
-	logger := logutil.FromCtx(r.Context())
-	ctx := r.Context()
+	logger := logutil.FromCtx(ctx)
 
 	// Batch-query existing file metadata for all paths in one DB round-trip.
 	paths := make([]string, len(req.Files))
 	for i, f := range req.Files {
 		paths[i] = f.Path
 	}
-	existingMap, err := s.app.DBClient().GetFileMetaByPaths(ctx, req.VaultID, paths)
+	existingMap, err := s.app.DBClient().GetFileMetaByPaths(ctx, vaultID, paths)
 	if err != nil {
-		logger.Error("import manifest: batch query", "vault", req.VaultID, "error", err)
+		logger.Error("import manifest: batch query", "vault", vaultID, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to check existing files")
 		return
 	}
@@ -153,8 +149,7 @@ func (s *Server) importManifest(w http.ResponseWriter, r *http.Request) {
 
 // importUploadMeta is the JSON metadata in the first multipart part of an upload.
 type importUploadMeta struct {
-	VaultID string            `json:"vaultId"`
-	Hashes  map[string]string `json:"hashes"` // path → expected SHA256 hash
+	Hashes map[string]string `json:"hashes"` // path → expected SHA256 hash
 }
 
 // importUpload handles POST /api/import/upload.
@@ -185,18 +180,14 @@ func (s *Server) importUpload(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid meta JSON: %v", err))
 		return
 	}
-	if meta.VaultID == "" {
-		writeError(w, http.StatusBadRequest, "vaultId is required in meta")
-		return
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), meta.VaultID, models.RoleWrite); err != nil {
+	ctx := r.Context()
+	vaultID := auth.MustVaultIDFromCtx(ctx)
+	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
 		writeError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
-	logger := logutil.FromCtx(r.Context())
-	ctx := r.Context()
+	logger := logutil.FromCtx(ctx)
 	var results []importFileResult
 
 	// Process remaining parts — each is a file identified by form name (vault path).
@@ -207,7 +198,7 @@ func (s *Server) importUpload(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 		if err != nil {
-			logger.Error("import upload: read part", "vault", meta.VaultID, "error", err)
+			logger.Error("import upload: read part", "vault", vaultID, "error", err)
 			streamErr = err
 			break
 		}
@@ -226,7 +217,7 @@ func (s *Server) importUpload(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		result := s.processImportPart(ctx, part, path, expectedHash, meta.VaultID)
+		result := s.processImportPart(ctx, part, path, expectedHash, vaultID)
 
 		// Hash mismatch = abort entire import. The client is faulty or malicious.
 		if result.Status == statusError && result.Reason == reasonHashMismatch {

--- a/internal/api/labels.go
+++ b/internal/api/labels.go
@@ -5,20 +5,10 @@ import (
 
 	"github.com/raphi011/know/internal/auth"
 	"github.com/raphi011/know/internal/logutil"
-	"github.com/raphi011/know/internal/models"
 )
 
 func (s *Server) listLabels(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.URL.Query().Get("vault")
-	if vaultID == "" {
-		writeError(w, http.StatusBadRequest, "vault query parameter required")
-		return
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
-		return
-	}
+	vaultID := auth.MustVaultIDFromCtx(r.Context())
 
 	logger := logutil.FromCtx(r.Context())
 

--- a/internal/api/ls.go
+++ b/internal/api/ls.go
@@ -12,16 +12,7 @@ import (
 )
 
 func (s *Server) ls(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.URL.Query().Get("vault")
-	if vaultID == "" {
-		writeError(w, http.StatusBadRequest, "vault query parameter required")
-		return
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
-		return
-	}
+	vaultID := auth.MustVaultIDFromCtx(r.Context())
 
 	folder := r.URL.Query().Get("path")
 	if folder == "" {

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -7,21 +7,15 @@ import (
 
 	"github.com/raphi011/know/internal/auth"
 	"github.com/raphi011/know/internal/logutil"
-	"github.com/raphi011/know/internal/models"
 	"github.com/raphi011/know/internal/search"
 )
 
 func (s *Server) searchDocuments(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.URL.Query().Get("vault")
+	vaultID := auth.MustVaultIDFromCtx(r.Context())
 	query := r.URL.Query().Get("query")
 
-	if vaultID == "" || query == "" {
-		writeError(w, http.StatusBadRequest, "vault and query parameters required")
-		return
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+	if query == "" {
+		writeError(w, http.StatusBadRequest, "query parameter required")
 		return
 	}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/raphi011/know/internal/agent"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/server"
 )
@@ -20,85 +21,102 @@ func NewServer(app *server.App) *Server {
 	return &Server{app: app}
 }
 
-// Register wires all /api/ routes onto the given mux.
-func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Handler) {
-	// Conversations
-	mux.Handle("GET /api/conversations", authMw(http.HandlerFunc(s.listConversations)))
-	mux.Handle("GET /api/conversations/{id}", authMw(http.HandlerFunc(s.getConversation)))
-	mux.Handle("POST /api/conversations", authMw(http.HandlerFunc(s.createConversation)))
-	mux.Handle("DELETE /api/conversations/{id}", authMw(http.HandlerFunc(s.deleteConversation)))
-	mux.Handle("PATCH /api/conversations/{id}", authMw(http.HandlerFunc(s.renameConversation)))
+// Register wires all /api/v1/ routes onto the given mux.
+// authMw validates the Bearer token and injects AuthContext.
+// agentRunner is optional — if nil, agent routes are not registered.
+func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Handler, agentRunner *agent.Runner) {
+	// v aliases for vault-scoped and global routes.
+	// vs wraps handler with auth + vault scope (resolves {vault} name → ID in context).
+	// g wraps handler with auth only (no vault scope).
+	vs := func(handler http.HandlerFunc) http.Handler {
+		return authMw(s.vaultScope(handler))
+	}
+	g := func(handler http.HandlerFunc) http.Handler {
+		return authMw(handler)
+	}
 
-	// Vaults
-	mux.Handle("GET /api/vaults", authMw(http.HandlerFunc(s.listVaults)))
-	mux.Handle("GET /api/vaults/{name}/info", authMw(http.HandlerFunc(s.getVaultInfo)))
-	mux.Handle("GET /api/vaults/{name}/settings", authMw(http.HandlerFunc(s.getVaultSettings)))
-	mux.Handle("PATCH /api/vaults/{name}/settings", authMw(http.HandlerFunc(s.updateVaultSettings)))
+	// --- Vaults (list is global, rest is vault-scoped) ---
+	mux.Handle("GET /api/v1/vaults", g(s.listVaults))
+	mux.Handle("GET /api/v1/vaults/{vault}", vs(s.getVaultInfo))
+	mux.Handle("GET /api/v1/vaults/{vault}/settings", vs(s.getVaultSettings))
+	mux.Handle("PATCH /api/v1/vaults/{vault}/settings", vs(s.updateVaultSettings))
 
-	// Documents
-	mux.Handle("GET /api/ls", authMw(http.HandlerFunc(s.ls)))
-	mux.Handle("GET /api/documents", authMw(http.HandlerFunc(s.getDocument)))
-	mux.Handle("POST /api/documents", authMw(http.HandlerFunc(s.upsertDocument)))
-	mux.Handle("DELETE /api/documents", authMw(http.HandlerFunc(s.deleteDocuments)))
+	// --- Documents ---
+	mux.Handle("GET /api/v1/vaults/{vault}/documents", vs(s.getDocument))
+	mux.Handle("POST /api/v1/vaults/{vault}/documents", vs(s.upsertDocument))
+	mux.Handle("DELETE /api/v1/vaults/{vault}/documents", vs(s.deleteDocuments))
+	mux.Handle("GET /api/v1/vaults/{vault}/documents/ls", vs(s.ls))
+	mux.Handle("POST /api/v1/vaults/{vault}/documents/move", vs(s.move))
+	mux.Handle("POST /api/v1/vaults/{vault}/documents/bulk", vs(s.bulkUpload))
+	mux.Handle("POST /api/v1/vaults/{vault}/documents/clip", vs(s.fetchWebpage))
 
-	// Move (document or folder)
-	mux.Handle("POST /api/move", authMw(http.HandlerFunc(s.move)))
+	// --- Import (two-phase) ---
+	mux.Handle("POST /api/v1/vaults/{vault}/import/manifest", vs(s.importManifest))
+	mux.Handle("POST /api/v1/vaults/{vault}/import/upload", vs(s.importUpload))
 
-	// Assets
-	mux.Handle("POST /api/assets", authMw(http.HandlerFunc(s.uploadAsset)))
-	mux.Handle("GET /api/assets", authMw(http.HandlerFunc(s.getAsset)))
-	mux.Handle("GET /api/assets/meta", authMw(http.HandlerFunc(s.getAssetMeta)))
-	mux.Handle("DELETE /api/assets", authMw(http.HandlerFunc(s.deleteAsset)))
+	// --- Export ---
+	mux.Handle("GET /api/v1/vaults/{vault}/export", vs(s.export))
+	mux.Handle("GET /api/v1/vaults/{vault}/export/epub", vs(s.exportEPUB))
 
-	// Import (two-phase: manifest + upload)
-	mux.Handle("POST /api/import/manifest", authMw(http.HandlerFunc(s.importManifest)))
-	mux.Handle("POST /api/import/upload", authMw(http.HandlerFunc(s.importUpload)))
+	// --- Backup / Restore ---
+	mux.Handle("GET /api/v1/vaults/{vault}/backup", vs(s.exportBackup))
+	mux.Handle("POST /api/v1/backup/restore", g(s.restoreBackup)) // global: creates vault from archive
 
-	// Bulk upload (used by integration tests; CLI uses import/* endpoints)
-	mux.Handle("POST /api/bulk", authMw(http.HandlerFunc(s.bulkUpload)))
+	// --- Search ---
+	mux.Handle("GET /api/v1/vaults/{vault}/search", vs(s.searchDocuments))
 
-	// Search
-	mux.Handle("GET /api/search", authMw(http.HandlerFunc(s.searchDocuments)))
+	// --- Folders ---
+	mux.Handle("GET /api/v1/vaults/{vault}/folders", vs(s.listFolders))
+	mux.Handle("PATCH /api/v1/vaults/{vault}/folders", vs(s.updateFolder))
 
-	// Folders
-	mux.Handle("GET /api/folders", authMw(http.HandlerFunc(s.listFolders)))
-	mux.Handle("PATCH /api/folders", authMw(http.HandlerFunc(s.updateFolder)))
+	// --- Versions ---
+	mux.Handle("GET /api/v1/vaults/{vault}/versions", vs(s.listVersions))
 
-	// Versions
-	mux.Handle("GET /api/versions", authMw(http.HandlerFunc(s.listVersions)))
+	// --- Labels ---
+	mux.Handle("GET /api/v1/vaults/{vault}/labels", vs(s.listLabels))
 
-	// Labels
-	mux.Handle("GET /api/labels", authMw(http.HandlerFunc(s.listLabels)))
+	// --- Tasks ---
+	mux.Handle("GET /api/v1/vaults/{vault}/tasks", vs(s.listTasks))
+	mux.Handle("POST /api/v1/vaults/{vault}/tasks/{id}/toggle", vs(s.toggleTask))
 
-	// Tasks
-	mux.Handle("GET /api/tasks", authMw(http.HandlerFunc(s.listTasks)))
-	mux.Handle("POST /api/tasks/{id}/toggle", authMw(http.HandlerFunc(s.toggleTask)))
+	// --- Assets ---
+	mux.Handle("POST /api/v1/vaults/{vault}/assets", vs(s.uploadAsset))
+	mux.Handle("GET /api/v1/vaults/{vault}/assets", vs(s.getAsset))
+	mux.Handle("GET /api/v1/vaults/{vault}/assets/meta", vs(s.getAssetMeta))
+	mux.Handle("DELETE /api/v1/vaults/{vault}/assets", vs(s.deleteAsset))
 
-	// Remotes (federation)
-	mux.Handle("GET /api/remotes", authMw(http.HandlerFunc(s.listRemotes)))
-	mux.Handle("POST /api/remotes", authMw(http.HandlerFunc(s.addRemote)))
-	mux.Handle("DELETE /api/remotes/{name}", authMw(http.HandlerFunc(s.removeRemote)))
+	// --- External Links ---
+	mux.Handle("GET /api/v1/vaults/{vault}/external-links", vs(s.listExternalLinks))
+	mux.Handle("GET /api/v1/vaults/{vault}/external-links/stats", vs(s.externalLinkStats))
 
-	// External links
-	mux.Handle("GET /api/external-links/stats", authMw(http.HandlerFunc(s.externalLinkStats)))
-	mux.Handle("GET /api/external-links", authMw(http.HandlerFunc(s.listExternalLinks)))
+	// --- SSE (document change stream, vault-scoped) ---
+	// Registered in cmd_serve.go since it depends on the event bus.
 
-	// Export
-	mux.Handle("GET /api/export", authMw(http.HandlerFunc(s.export)))
-	mux.Handle("GET /api/export/epub", authMw(http.HandlerFunc(s.exportEPUB)))
+	// --- Conversations (global, identified by ID) ---
+	mux.Handle("GET /api/v1/conversations", g(s.listConversations))
+	mux.Handle("POST /api/v1/conversations", g(s.createConversation))
+	mux.Handle("GET /api/v1/conversations/{id}", g(s.getConversation))
+	mux.Handle("PATCH /api/v1/conversations/{id}", g(s.renameConversation))
+	mux.Handle("DELETE /api/v1/conversations/{id}", g(s.deleteConversation))
 
-	// Backup / Restore
-	mux.Handle("GET /api/backup", authMw(http.HandlerFunc(s.exportBackup)))
-	mux.Handle("POST /api/backup/restore", authMw(http.HandlerFunc(s.restoreBackup)))
+	// --- Agent ---
+	if agentRunner != nil {
+		mux.Handle("POST /api/v1/vaults/{vault}/agent/chat", vs(agentRunner.HandleChat()))
+		mux.Handle("GET /api/v1/agent/events/{id}", g(agentRunner.HandleEvents()))
+		mux.Handle("POST /api/v1/agent/cancel/{id}", g(agentRunner.HandleCancel()))
+		mux.Handle("POST /api/v1/agent/approval", g(agentRunner.HandleApproval()))
+	}
 
-	// Jobs (pipeline status)
-	mux.Handle("GET /api/jobs", authMw(http.HandlerFunc(s.getJobStatus)))
+	// --- Remotes (federation, system admin only) ---
+	mux.Handle("GET /api/v1/remotes", g(s.listRemotes))
+	mux.Handle("POST /api/v1/remotes", g(s.addRemote))
+	mux.Handle("DELETE /api/v1/remotes/{name}", g(s.removeRemote))
 
-	// Web clipping
-	mux.Handle("POST /api/fetch", authMw(http.HandlerFunc(s.fetchWebpage)))
+	// --- Jobs (pipeline status) ---
+	mux.Handle("GET /api/v1/jobs", g(s.getJobStatus))
 
-	// Config
-	mux.Handle("GET /api/config", authMw(http.HandlerFunc(s.getConfig)))
+	// --- Config ---
+	mux.Handle("GET /api/v1/config", g(s.getConfig))
 }
 
 // writeJSON writes a JSON response with the given status code.

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -13,18 +13,9 @@ import (
 )
 
 func (s *Server) listTasks(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.URL.Query().Get("vault")
-	if vaultID == "" {
-		writeError(w, http.StatusBadRequest, "vault query parameter required")
-		return
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
-		return
-	}
-
-	logger := logutil.FromCtx(r.Context())
+	ctx := r.Context()
+	vaultID := auth.MustVaultIDFromCtx(ctx)
+	logger := logutil.FromCtx(ctx)
 
 	filter := db.TaskFilter{
 		VaultID: vaultID,
@@ -78,14 +69,14 @@ func (s *Server) listTasks(w http.ResponseWriter, r *http.Request) {
 		filter.Offset = n
 	}
 
-	tasks, err := s.app.DBClient().ListTasks(r.Context(), filter)
+	tasks, err := s.app.DBClient().ListTasks(ctx, filter)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list tasks")
 		logger.Error("list tasks", "vault_id", vaultID, "error", err)
 		return
 	}
 
-	total, err := s.app.DBClient().CountTasks(r.Context(), filter)
+	total, err := s.app.DBClient().CountTasks(ctx, filter)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to count tasks")
 		logger.Error("count tasks", "vault_id", vaultID, "error", err)
@@ -123,33 +114,16 @@ func (s *Server) toggleTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logger := logutil.FromCtx(r.Context())
-
-	// Fetch task to get vault ID for auth check.
-	task, err := s.app.DBClient().GetTaskByID(r.Context(), taskID)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get task")
-		logger.Error("get task for toggle", "task_id", taskID, "error", err)
-		return
-	}
-	if task == nil {
-		writeError(w, http.StatusNotFound, "task not found")
-		return
-	}
-
-	vaultID, err := models.RecordIDString(task.Vault)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "invalid vault id")
-		logger.Error("extract vault id", "error", err)
-		return
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleWrite); err != nil {
+	ctx := r.Context()
+	vaultID := auth.MustVaultIDFromCtx(ctx)
+	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
 		writeError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
-	updated, err := s.app.FileService().ToggleTask(r.Context(), taskID)
+	logger := logutil.FromCtx(ctx)
+
+	updated, err := s.app.FileService().ToggleTask(ctx, vaultID, taskID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to toggle task")
 		logger.Error("toggle task", "task_id", taskID, "error", err)

--- a/internal/api/vault_scope.go
+++ b/internal/api/vault_scope.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/logutil"
+	"github.com/raphi011/know/internal/models"
+)
+
+// VaultScopeHandler wraps an http.Handler with vault scope resolution.
+// Exported for use by cmd_serve.go for protocol handlers (SSE events) that need
+// vault scoping but aren't registered through Server.Register.
+func (s *Server) VaultScopeHandler(next http.Handler) http.Handler {
+	return s.vaultScope(next.ServeHTTP)
+}
+
+// vaultScope is a middleware that extracts the {vault} path parameter (vault name),
+// resolves it to a bare vault ID via VaultService, checks at least RoleRead access,
+// and injects the vault ID into the request context via auth.WithVaultID.
+//
+// Handlers retrieve the vault ID with auth.MustVaultIDFromCtx(ctx).
+// Write/admin handlers should additionally call auth.RequireVaultRole for higher roles.
+func (s *Server) vaultScope(next http.HandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("vault")
+		if name == "" {
+			writeError(w, http.StatusBadRequest, "vault name required")
+			return
+		}
+
+		ctx := r.Context()
+
+		ac, err := auth.FromContext(ctx)
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+
+		v, err := s.app.VaultService().GetByName(ctx, name)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to resolve vault")
+			logutil.FromCtx(ctx).Error("vault scope: get by name", "name", name, "error", err)
+			return
+		}
+		if v == nil {
+			writeError(w, http.StatusNotFound, "vault not found")
+			return
+		}
+
+		vaultID, err := models.RecordIDString(v.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "invalid vault ID")
+			logutil.FromCtx(ctx).Error("vault scope: extract ID", "name", name, "error", err)
+			return
+		}
+
+		if err := auth.CheckVaultRole(ac, vaultID, models.RoleRead); err != nil {
+			writeError(w, http.StatusForbidden, "forbidden")
+			return
+		}
+
+		ctx = auth.WithVaultID(ctx, vaultID)
+		logger := logutil.FromCtx(ctx).With("vault_id", vaultID)
+		ctx = logutil.WithLogger(ctx, logger)
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/internal/api/vaults.go
+++ b/internal/api/vaults.go
@@ -87,54 +87,26 @@ func (s *Server) listVaults(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, result)
 }
 
-// resolveVault looks up a vault by the "name" path parameter, extracts its ID,
-// and checks that the caller has at least minRole. Returns the vault, its bare ID,
-// and true on success. On failure it writes the HTTP error and returns false.
-func (s *Server) resolveVault(w http.ResponseWriter, r *http.Request, minRole models.VaultRole) (*models.Vault, string, bool) {
-	name := r.PathValue("name")
-	if name == "" {
-		writeError(w, http.StatusBadRequest, "vault name required")
-		return nil, "", false
-	}
+func (s *Server) getVaultInfo(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	vaultID := auth.MustVaultIDFromCtx(ctx)
+	logger := logutil.FromCtx(ctx)
 
-	logger := logutil.FromCtx(r.Context())
-
-	v, err := s.app.VaultService().GetByName(r.Context(), name)
+	v, err := s.app.DBClient().GetVault(ctx, vaultID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to resolve vault")
-		logger.Error("get vault by name", "name", name, "error", err)
-		return nil, "", false
+		writeError(w, http.StatusInternalServerError, "failed to get vault")
+		logger.Error("get vault", "vault_id", vaultID, "error", err)
+		return
 	}
 	if v == nil {
 		writeError(w, http.StatusNotFound, "vault not found")
-		return nil, "", false
-	}
-
-	vaultID, err := models.RecordIDString(v.ID)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "invalid vault ID")
-		logger.Error("extract vault ID", "name", name, "error", err)
-		return nil, "", false
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), vaultID, minRole); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
-		return nil, "", false
-	}
-
-	return v, vaultID, true
-}
-
-func (s *Server) getVaultInfo(w http.ResponseWriter, r *http.Request) {
-	v, vaultID, ok := s.resolveVault(w, r, models.RoleRead)
-	if !ok {
 		return
 	}
 
-	stats, err := s.app.DBClient().GetVaultInfo(r.Context(), vaultID)
+	stats, err := s.app.DBClient().GetVaultInfo(ctx, vaultID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to get vault info")
-		logutil.FromCtx(r.Context()).Error("get vault info", "vault_id", vaultID, "error", err)
+		logger.Error("get vault info", "vault_id", vaultID, "error", err)
 		return
 	}
 
@@ -165,8 +137,17 @@ func (s *Server) getVaultInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getVaultSettings(w http.ResponseWriter, r *http.Request) {
-	v, _, ok := s.resolveVault(w, r, models.RoleRead)
-	if !ok {
+	ctx := r.Context()
+	vaultID := auth.MustVaultIDFromCtx(ctx)
+
+	v, err := s.app.DBClient().GetVault(ctx, vaultID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get vault")
+		logutil.FromCtx(ctx).Error("get vault", "vault_id", vaultID, "error", err)
+		return
+	}
+	if v == nil {
+		writeError(w, http.StatusNotFound, "vault not found")
 		return
 	}
 
@@ -184,8 +165,21 @@ func (s *Server) updateVaultSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	v, vaultID, ok := s.resolveVault(w, r, models.RoleAdmin)
-	if !ok {
+	ctx := r.Context()
+	vaultID := auth.MustVaultIDFromCtx(ctx)
+	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleAdmin); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	v, err := s.app.DBClient().GetVault(ctx, vaultID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get vault")
+		logutil.FromCtx(ctx).Error("get vault", "vault_id", vaultID, "error", err)
+		return
+	}
+	if v == nil {
+		writeError(w, http.StatusNotFound, "vault not found")
 		return
 	}
 
@@ -193,10 +187,10 @@ func (s *Server) updateVaultSettings(w http.ResponseWriter, r *http.Request) {
 
 	// Validate transcript_template points to an existing file
 	if path := patch.TranscriptTemplate; path != "" && path != "-" {
-		f, err := s.app.DBClient().GetFileByPath(r.Context(), vaultID, path)
+		f, err := s.app.DBClient().GetFileByPath(ctx, vaultID, path)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to validate transcript_template")
-			logutil.FromCtx(r.Context()).Error("validate transcript_template", "path", path, "error", err)
+			logutil.FromCtx(ctx).Error("validate transcript_template", "path", path, "error", err)
 			return
 		}
 		if f == nil {
@@ -205,10 +199,10 @@ func (s *Server) updateVaultSettings(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	updated, err := s.app.DBClient().UpdateVaultSettings(r.Context(), vaultID, merged)
+	updated, err := s.app.DBClient().UpdateVaultSettings(ctx, vaultID, merged)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update settings")
-		logutil.FromCtx(r.Context()).Error("update vault settings", "vault_id", vaultID, "error", err)
+		logutil.FromCtx(ctx).Error("update vault settings", "vault_id", vaultID, "error", err)
 		return
 	}
 

--- a/internal/api/versions.go
+++ b/internal/api/versions.go
@@ -10,16 +10,11 @@ import (
 )
 
 func (s *Server) listVersions(w http.ResponseWriter, r *http.Request) {
-	vaultID := r.URL.Query().Get("vault")
+	vaultID := auth.MustVaultIDFromCtx(r.Context())
 	path := r.URL.Query().Get("path")
 
-	if vaultID == "" || path == "" {
-		writeError(w, http.StatusBadRequest, "vault and path parameters required")
-		return
-	}
-
-	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+	if path == "" {
+		writeError(w, http.StatusBadRequest, "path parameter required")
 		return
 	}
 

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -45,6 +45,11 @@ func New(baseURL, token string) *Client {
 	}
 }
 
+// vaultPath constructs a vault-scoped API path: /api/v1/vaults/{name}{resource}.
+func vaultPath(vaultName, resource string) string {
+	return "/api/v1/vaults/" + url.PathEscape(vaultName) + resource
+}
+
 // Get performs a GET request and decodes the JSON response into target.
 func (c *Client) Get(ctx context.Context, path string, target any) error {
 	return c.do(ctx, http.MethodGet, path, nil, target)
@@ -108,9 +113,8 @@ type BulkFile struct {
 
 // BulkMeta holds shared metadata for a bulk upload request.
 type BulkMeta struct {
-	VaultID string `json:"vaultId"`
-	Force   bool   `json:"force"`
-	DryRun  bool   `json:"dryRun"`
+	Force  bool `json:"force"`
+	DryRun bool `json:"dryRun"`
 }
 
 // BulkResult is a per-file result from the bulk upload endpoint.
@@ -127,7 +131,7 @@ type BulkResult struct {
 //
 // A nil error means the HTTP request succeeded, but individual files may still have
 // failed — callers must check each BulkResult.Status for "error" entries.
-func (c *Client) BulkUpload(ctx context.Context, meta BulkMeta, files []BulkFile) ([]BulkResult, error) {
+func (c *Client) BulkUpload(ctx context.Context, vaultName string, meta BulkMeta, files []BulkFile) ([]BulkResult, error) {
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
 
@@ -155,7 +159,7 @@ func (c *Client) BulkUpload(ctx context.Context, meta BulkMeta, files []BulkFile
 		return nil, fmt.Errorf("close multipart writer: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/bulk", &buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+vaultPath(vaultName, "/documents/bulk"), &buf)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
@@ -194,12 +198,11 @@ type ImportManifestFile struct {
 	Hash string `json:"hash"`
 }
 
-// ImportManifestRequest is the request body for POST /api/import/manifest.
+// ImportManifestRequest is the request body for POST /api/v1/vaults/{name}/import/manifest.
 type ImportManifestRequest struct {
-	VaultID string               `json:"vaultId"`
-	Force   bool                 `json:"force"`
-	DryRun  bool                 `json:"dryRun"`
-	Files   []ImportManifestFile `json:"files"`
+	Force  bool                 `json:"force"`
+	DryRun bool                 `json:"dryRun"`
+	Files  []ImportManifestFile `json:"files"`
 }
 
 // ImportManifestResponse is the response from POST /api/import/manifest.
@@ -223,9 +226,9 @@ type ImportUploadResponse struct {
 }
 
 // ImportManifest sends a file manifest to the server and returns which files need uploading.
-func (c *Client) ImportManifest(ctx context.Context, req ImportManifestRequest) (*ImportManifestResponse, error) {
+func (c *Client) ImportManifest(ctx context.Context, vaultName string, req ImportManifestRequest) (*ImportManifestResponse, error) {
 	var resp ImportManifestResponse
-	if err := c.Post(ctx, "/api/import/manifest", req, &resp); err != nil {
+	if err := c.Post(ctx, vaultPath(vaultName, "/import/manifest"), req, &resp); err != nil {
 		return nil, fmt.Errorf("import manifest: %w", err)
 	}
 	return &resp, nil
@@ -240,7 +243,7 @@ type ImportFile struct {
 
 // ImportUpload sends only the needed files to the server's import upload endpoint.
 // The meta part includes per-file hashes for server-side verification.
-func (c *Client) ImportUpload(ctx context.Context, vaultID string, files []ImportFile) (*ImportUploadResponse, error) {
+func (c *Client) ImportUpload(ctx context.Context, vaultName string, files []ImportFile) (*ImportUploadResponse, error) {
 	// Build the multipart request with pipe to avoid buffering all files in memory.
 	pr, pw := io.Pipe()
 	writer := multipart.NewWriter(pw)
@@ -267,9 +270,8 @@ func (c *Client) ImportUpload(ctx context.Context, vaultID string, files []Impor
 			hashes[f.Path] = f.Hash
 		}
 		meta := struct {
-			VaultID string            `json:"vaultId"`
-			Hashes  map[string]string `json:"hashes"`
-		}{VaultID: vaultID, Hashes: hashes}
+			Hashes map[string]string `json:"hashes"`
+		}{Hashes: hashes}
 		if err := json.NewEncoder(metaPart).Encode(meta); err != nil {
 			writeErr = fmt.Errorf("encode meta: %w", err)
 			errCh <- writeErr
@@ -299,7 +301,7 @@ func (c *Client) ImportUpload(ctx context.Context, vaultID string, files []Impor
 		errCh <- nil
 	}()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/import/upload", pr)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+vaultPath(vaultName, "/import/upload"), pr)
 	if err != nil {
 		pr.Close()
 		<-errCh // drain goroutine to prevent leak
@@ -388,15 +390,14 @@ type MoveResult struct {
 }
 
 // Move moves a document or folder to a new path within the same vault.
-func (c *Client) Move(ctx context.Context, vaultID, source, destination string, dryRun bool) (*MoveResult, error) {
+func (c *Client) Move(ctx context.Context, vaultName, source, destination string, dryRun bool) (*MoveResult, error) {
 	body := map[string]any{
-		"vaultId":     vaultID,
 		"source":      source,
 		"destination": destination,
 		"dryRun":      dryRun,
 	}
 	var result MoveResult
-	if err := c.Post(ctx, "/api/move", body, &result); err != nil {
+	if err := c.Post(ctx, vaultPath(vaultName, "/documents/move"), body, &result); err != nil {
 		return nil, fmt.Errorf("move: %w", err)
 	}
 	return &result, nil
@@ -413,7 +414,7 @@ type Vault struct {
 // ListVaults returns all accessible vaults.
 func (c *Client) ListVaults(ctx context.Context) ([]Vault, error) {
 	var vaults []Vault
-	if err := c.Get(ctx, "/api/vaults", &vaults); err != nil {
+	if err := c.Get(ctx, "/api/v1/vaults", &vaults); err != nil {
 		return nil, fmt.Errorf("list vaults: %w", err)
 	}
 	return vaults, nil
@@ -436,13 +437,13 @@ type ChunkMatch struct {
 }
 
 // SearchDocuments searches documents on the remote server.
-func (c *Client) SearchDocuments(ctx context.Context, vaultID, query string, limit int) ([]SearchResult, error) {
-	q := url.Values{"vault": {vaultID}, "query": {query}}
+func (c *Client) SearchDocuments(ctx context.Context, vaultName, query string, limit int) ([]SearchResult, error) {
+	q := url.Values{"query": {query}}
 	if limit > 0 {
 		q.Set("limit", fmt.Sprintf("%d", limit))
 	}
 	var results []SearchResult
-	if err := c.Get(ctx, "/api/search?"+q.Encode(), &results); err != nil {
+	if err := c.Get(ctx, vaultPath(vaultName, "/search")+"?"+q.Encode(), &results); err != nil {
 		return nil, fmt.Errorf("search documents: %w", err)
 	}
 	return results, nil
@@ -455,13 +456,17 @@ type Folder struct {
 }
 
 // ListFolders lists folders in a vault, optionally under a parent path.
-func (c *Client) ListFolders(ctx context.Context, vaultID string, parent *string) ([]Folder, error) {
-	q := url.Values{"vault": {vaultID}}
+func (c *Client) ListFolders(ctx context.Context, vaultName string, parent *string) ([]Folder, error) {
+	q := url.Values{}
 	if parent != nil {
 		q.Set("parent", *parent)
 	}
+	path := vaultPath(vaultName, "/folders")
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
 	var folders []Folder
-	if err := c.Get(ctx, "/api/folders?"+q.Encode(), &folders); err != nil {
+	if err := c.Get(ctx, path, &folders); err != nil {
 		return nil, fmt.Errorf("list folders: %w", err)
 	}
 	return folders, nil
@@ -469,15 +474,15 @@ func (c *Client) ListFolders(ctx context.Context, vaultID string, parent *string
 
 // CreateDocumentRequest is the body for creating a document via REST API.
 type CreateDocumentRequest struct {
-	VaultID string `json:"vaultId"`
-	Path    string `json:"path"`
-	Content string `json:"content"`
+	VaultName string `json:"-"`
+	Path      string `json:"path"`
+	Content   string `json:"content"`
 }
 
 // CreateDocument creates a new document on the remote server.
 func (c *Client) CreateDocument(ctx context.Context, req CreateDocumentRequest) (*Document, error) {
 	var doc Document
-	if err := c.Post(ctx, "/api/documents", req, &doc); err != nil {
+	if err := c.Post(ctx, vaultPath(req.VaultName, "/documents"), req, &doc); err != nil {
 		return nil, fmt.Errorf("create document: %w", err)
 	}
 	return &doc, nil
@@ -490,7 +495,7 @@ type EditDocumentRequest = CreateDocumentRequest
 // EditDocument updates an existing document on the remote server.
 func (c *Client) EditDocument(ctx context.Context, req EditDocumentRequest) (*Document, error) {
 	var doc Document
-	if err := c.Post(ctx, "/api/documents", req, &doc); err != nil {
+	if err := c.Post(ctx, vaultPath(req.VaultName, "/documents"), req, &doc); err != nil {
 		return nil, fmt.Errorf("edit document: %w", err)
 	}
 	return &doc, nil
@@ -505,13 +510,13 @@ type Version struct {
 }
 
 // ListVersions returns version history for a document.
-func (c *Client) ListVersions(ctx context.Context, vaultID, path string, limit int) ([]Version, error) {
-	q := url.Values{"vault": {vaultID}, "path": {path}}
+func (c *Client) ListVersions(ctx context.Context, vaultName, path string, limit int) ([]Version, error) {
+	q := url.Values{"path": {path}}
 	if limit > 0 {
 		q.Set("limit", fmt.Sprintf("%d", limit))
 	}
 	var versions []Version
-	if err := c.Get(ctx, "/api/versions?"+q.Encode(), &versions); err != nil {
+	if err := c.Get(ctx, vaultPath(vaultName, "/versions")+"?"+q.Encode(), &versions); err != nil {
 		return nil, fmt.Errorf("list versions: %w", err)
 	}
 	return versions, nil
@@ -528,10 +533,10 @@ type Document struct {
 }
 
 // GetDocument fetches a document by vault and path.
-func (c *Client) GetDocument(ctx context.Context, vaultID, path string) (*Document, error) {
-	q := url.Values{"vault": {vaultID}, "path": {path}}
+func (c *Client) GetDocument(ctx context.Context, vaultName, path string) (*Document, error) {
+	q := url.Values{"path": {path}}
 	var doc Document
-	if err := c.Get(ctx, "/api/documents?"+q.Encode(), &doc); err != nil {
+	if err := c.Get(ctx, vaultPath(vaultName, "/documents")+"?"+q.Encode(), &doc); err != nil {
 		return nil, fmt.Errorf("get document: %w", err)
 	}
 	return &doc, nil
@@ -545,8 +550,8 @@ type DeleteResult struct {
 }
 
 // DeleteDocuments deletes a document or folder (with recursive flag) from a vault.
-func (c *Client) DeleteDocuments(ctx context.Context, vaultID, path string, recursive, dryRun bool) (*DeleteResult, error) {
-	q := url.Values{"vault": {vaultID}, "path": {path}}
+func (c *Client) DeleteDocuments(ctx context.Context, vaultName, path string, recursive, dryRun bool) (*DeleteResult, error) {
+	q := url.Values{"path": {path}}
 	if recursive {
 		q.Set("recursive", "true")
 	}
@@ -554,38 +559,38 @@ func (c *Client) DeleteDocuments(ctx context.Context, vaultID, path string, recu
 		q.Set("dry-run", "true")
 	}
 	var result DeleteResult
-	if err := c.do(ctx, http.MethodDelete, "/api/documents?"+q.Encode(), nil, &result); err != nil {
+	if err := c.do(ctx, http.MethodDelete, vaultPath(vaultName, "/documents")+"?"+q.Encode(), nil, &result); err != nil {
 		return nil, fmt.Errorf("delete documents: %w", err)
 	}
 	return &result, nil
 }
 
 // ListFiles lists files and folders at the given path in a vault.
-func (c *Client) ListFiles(ctx context.Context, vaultID, path string, recursive bool) ([]models.FileEntry, error) {
-	q := url.Values{"vault": {vaultID}, "path": {path}}
+func (c *Client) ListFiles(ctx context.Context, vaultName, path string, recursive bool) ([]models.FileEntry, error) {
+	q := url.Values{"path": {path}}
 	if recursive {
 		q.Set("recursive", "true")
 	}
 	var entries []models.FileEntry
-	if err := c.Get(ctx, "/api/ls?"+q.Encode(), &entries); err != nil {
+	if err := c.Get(ctx, vaultPath(vaultName, "/documents/ls")+"?"+q.Encode(), &entries); err != nil {
 		return nil, fmt.Errorf("list files: %w", err)
 	}
 	return entries, nil
 }
 
 // ListLabels returns all distinct labels in the given vault.
-func (c *Client) ListLabels(ctx context.Context, vaultID string) ([]string, error) {
+func (c *Client) ListLabels(ctx context.Context, vaultName string) ([]string, error) {
 	var labels []string
-	if err := c.Get(ctx, "/api/labels?vault="+url.QueryEscape(vaultID), &labels); err != nil {
+	if err := c.Get(ctx, vaultPath(vaultName, "/labels"), &labels); err != nil {
 		return nil, fmt.Errorf("list labels: %w", err)
 	}
 	return labels, nil
 }
 
 // ListLabelsWithCounts returns labels with their document counts for the given vault.
-func (c *Client) ListLabelsWithCounts(ctx context.Context, vaultID string) ([]models.LabelCount, error) {
+func (c *Client) ListLabelsWithCounts(ctx context.Context, vaultName string) ([]models.LabelCount, error) {
 	var counts []models.LabelCount
-	if err := c.Get(ctx, "/api/labels?vault="+url.QueryEscape(vaultID)+"&counts=true", &counts); err != nil {
+	if err := c.Get(ctx, vaultPath(vaultName, "/labels")+"?counts=true", &counts); err != nil {
 		return nil, fmt.Errorf("list labels with counts: %w", err)
 	}
 	return counts, nil
@@ -605,7 +610,7 @@ func (c *Client) GetJobStatus(ctx context.Context, since string) (*JobStatusResp
 	if since != "" {
 		q.Set("since", since)
 	}
-	path := "/api/jobs"
+	path := "/api/v1/jobs"
 	if len(q) > 0 {
 		path += "?" + q.Encode()
 	}
@@ -649,7 +654,7 @@ type VaultInfo struct {
 // GetVaultInfo fetches comprehensive stats about a vault.
 func (c *Client) GetVaultInfo(ctx context.Context, vaultName string) (*VaultInfo, error) {
 	var info VaultInfo
-	if err := c.Get(ctx, "/api/vaults/"+url.PathEscape(vaultName)+"/info", &info); err != nil {
+	if err := c.Get(ctx, vaultPath(vaultName, ""), &info); err != nil {
 		return nil, fmt.Errorf("get vault info: %w", err)
 	}
 	return &info, nil
@@ -658,7 +663,7 @@ func (c *Client) GetVaultInfo(ctx context.Context, vaultName string) (*VaultInfo
 // GetVaultSettings fetches vault settings with defaults applied.
 func (c *Client) GetVaultSettings(ctx context.Context, vaultName string) (*models.VaultSettings, error) {
 	var settings models.VaultSettings
-	if err := c.Get(ctx, "/api/vaults/"+url.PathEscape(vaultName)+"/settings", &settings); err != nil {
+	if err := c.Get(ctx, vaultPath(vaultName, "/settings"), &settings); err != nil {
 		return nil, fmt.Errorf("get vault settings: %w", err)
 	}
 	return &settings, nil
@@ -667,7 +672,7 @@ func (c *Client) GetVaultSettings(ctx context.Context, vaultName string) (*model
 // UpdateVaultSettings updates vault settings (partial: only non-zero fields are applied).
 func (c *Client) UpdateVaultSettings(ctx context.Context, vaultName string, patch models.VaultSettings) (*models.VaultSettings, error) {
 	var settings models.VaultSettings
-	if err := c.Patch(ctx, "/api/vaults/"+url.PathEscape(vaultName)+"/settings", patch, &settings); err != nil {
+	if err := c.Patch(ctx, vaultPath(vaultName, "/settings"), patch, &settings); err != nil {
 		return nil, fmt.Errorf("update vault settings: %w", err)
 	}
 	return &settings, nil
@@ -675,22 +680,21 @@ func (c *Client) UpdateVaultSettings(ctx context.Context, vaultName string, patc
 
 // FetchWebpageRequest is the body for the fetch webpage endpoint.
 type FetchWebpageRequest struct {
-	URL     string  `json:"url"`
-	VaultID string  `json:"vault_id"`
-	Path    *string `json:"path,omitempty"`
+	URL       string  `json:"url"`
+	VaultName string  `json:"-"`
+	Path      *string `json:"path,omitempty"`
 }
 
 // FetchWebpageResponse is the response from the fetch webpage endpoint.
 type FetchWebpageResponse struct {
-	Path    string `json:"path"`
-	Title   string `json:"title"`
-	VaultID string `json:"vault_id"`
+	Path  string `json:"path"`
+	Title string `json:"title"`
 }
 
 // FetchWebpage fetches a web page via the server and saves it to the vault.
 func (c *Client) FetchWebpage(ctx context.Context, req FetchWebpageRequest) (*FetchWebpageResponse, error) {
 	var resp FetchWebpageResponse
-	if err := c.Post(ctx, "/api/fetch", req, &resp); err != nil {
+	if err := c.Post(ctx, vaultPath(req.VaultName, "/documents/clip"), req, &resp); err != nil {
 		return nil, fmt.Errorf("fetch webpage: %w", err)
 	}
 	return &resp, nil
@@ -698,14 +702,14 @@ func (c *Client) FetchWebpage(ctx context.Context, req FetchWebpageRequest) (*Fe
 
 // DownloadExport downloads a vault export archive to the given output path.
 // Returns the number of bytes written.
-func (c *Client) DownloadExport(ctx context.Context, vaultID, outputPath string) (int64, error) {
-	return c.downloadToFile(ctx, "/api/export?vault="+url.QueryEscape(vaultID), outputPath)
+func (c *Client) DownloadExport(ctx context.Context, vaultName, outputPath string) (int64, error) {
+	return c.downloadToFile(ctx, vaultPath(vaultName, "/export"), outputPath)
 }
 
 // DownloadBackup downloads a manifest-based backup archive to the given output path.
 // Returns the number of bytes written.
-func (c *Client) DownloadBackup(ctx context.Context, vaultID, outputPath string) (int64, error) {
-	return c.downloadToFile(ctx, "/api/backup?vault="+url.QueryEscape(vaultID), outputPath)
+func (c *Client) DownloadBackup(ctx context.Context, vaultName, outputPath string) (int64, error) {
+	return c.downloadToFile(ctx, vaultPath(vaultName, "/backup"), outputPath)
 }
 
 // RestoreBackup uploads a backup archive to the server for restoration.
@@ -716,7 +720,7 @@ func (c *Client) RestoreBackup(ctx context.Context, archivePath string) error {
 	}
 	defer f.Close()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/backup/restore", f)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v1/backup/restore", f)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -743,15 +747,15 @@ func (c *Client) RestoreBackup(ctx context.Context, archivePath string) error {
 
 // DownloadExportEPUB downloads an EPUB export to the given output path.
 // Returns the number of bytes written.
-func (c *Client) DownloadExportEPUB(ctx context.Context, vaultID, path, title, author, outputPath string) (int64, error) {
-	params := url.Values{"vault": {vaultID}, "path": {path}}
+func (c *Client) DownloadExportEPUB(ctx context.Context, vaultName, path, title, author, outputPath string) (int64, error) {
+	params := url.Values{"path": {path}}
 	if title != "" {
 		params.Set("title", title)
 	}
 	if author != "" {
 		params.Set("author", author)
 	}
-	return c.downloadToFile(ctx, "/api/export/epub?"+params.Encode(), outputPath)
+	return c.downloadToFile(ctx, vaultPath(vaultName, "/export/epub")+"?"+params.Encode(), outputPath)
 }
 
 // downloadToFile performs a GET request and streams the response body to a file.

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -44,8 +44,8 @@ type ToggleTaskResponse struct {
 }
 
 // ListTasks fetches tasks matching the given filter.
-func (c *Client) ListTasks(ctx context.Context, vaultID string, filter TaskFilter) (*TaskListResponse, error) {
-	q := url.Values{"vault": {vaultID}, "limit": {"1000"}}
+func (c *Client) ListTasks(ctx context.Context, vaultName string, filter TaskFilter) (*TaskListResponse, error) {
+	q := url.Values{"limit": {"1000"}}
 
 	if filter.Status != "" && filter.Status != "all" {
 		q.Set("status", filter.Status)
@@ -68,16 +68,16 @@ func (c *Client) ListTasks(ctx context.Context, vaultID string, filter TaskFilte
 	}
 
 	var resp TaskListResponse
-	if err := c.Get(ctx, "/api/tasks?"+q.Encode(), &resp); err != nil {
+	if err := c.Get(ctx, vaultPath(vaultName, "/tasks")+"?"+q.Encode(), &resp); err != nil {
 		return nil, fmt.Errorf("list tasks: %w", err)
 	}
 	return &resp, nil
 }
 
 // ToggleTask toggles a task's status (open↔done).
-func (c *Client) ToggleTask(ctx context.Context, taskID string) (*ToggleTaskResponse, error) {
+func (c *Client) ToggleTask(ctx context.Context, vaultName, taskID string) (*ToggleTaskResponse, error) {
 	var resp ToggleTaskResponse
-	if err := c.Post(ctx, "/api/tasks/"+url.PathEscape(taskID)+"/toggle", nil, &resp); err != nil {
+	if err := c.Post(ctx, vaultPath(vaultName, "/tasks/"+url.PathEscape(taskID)+"/toggle"), nil, &resp); err != nil {
 		return nil, fmt.Errorf("toggle task: %w", err)
 	}
 	return &resp, nil

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -22,6 +22,7 @@ type VaultResolver interface {
 }
 
 type contextKey struct{}
+type vaultIDKey struct{}
 
 // WildcardVaultAccess grants admin access to all vaults (used in no-auth mode).
 const WildcardVaultAccess = "*"
@@ -44,6 +45,29 @@ type AuthContext struct {
 // WithAuth stores auth context in the request context.
 func WithAuth(ctx context.Context, ac AuthContext) context.Context {
 	return context.WithValue(ctx, contextKey{}, ac)
+}
+
+// WithVaultID stores a resolved vault ID in the request context.
+// Used by the vault-scoping middleware so handlers can retrieve it via VaultIDFromCtx.
+func WithVaultID(ctx context.Context, vaultID string) context.Context {
+	return context.WithValue(ctx, vaultIDKey{}, vaultID)
+}
+
+// VaultIDFromCtx retrieves the vault ID injected by the vault-scoping middleware.
+// Returns an empty string if no vault ID is present.
+func VaultIDFromCtx(ctx context.Context) string {
+	v, _ := ctx.Value(vaultIDKey{}).(string)
+	return v
+}
+
+// MustVaultIDFromCtx retrieves the vault ID injected by the vault-scoping middleware.
+// Panics if no vault ID is present — use only in handlers guaranteed to run behind vaultScope.
+func MustVaultIDFromCtx(ctx context.Context) string {
+	v, ok := ctx.Value(vaultIDKey{}).(string)
+	if !ok || v == "" {
+		panic("bug: MustVaultIDFromCtx called without vault scope middleware")
+	}
+	return v
 }
 
 // DetachContext creates a new context.Background() with the auth context copied

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,7 @@ type Config struct {
 	IngestConcurrency int
 	NoAuth            bool   // bypass token auth (for local/Docker use)
 	MCPEnabled        bool   // serve MCP endpoint at /mcp (default: true)
+	ProtocolPort      string // KNOW_PROTOCOL_PORT — separate port for WebDAV + MCP (default: "4002")
 	MetricsPort       string // KNOW_METRICS_PORT — separate port for /metrics (default: "" = disabled)
 
 	// SSH/SFTP server
@@ -237,6 +238,7 @@ func Load() Config {
 		IngestConcurrency: getEnvInt("KNOW_INGEST_CONCURRENCY", 4),
 		NoAuth:            getEnvBool("KNOW_NO_AUTH", false),
 		MCPEnabled:        getEnvBool("KNOW_MCP_ENABLED", true),
+		ProtocolPort:      getEnv("KNOW_PROTOCOL_PORT", "4002"),
 		SSHEnabled:        getEnvBool("KNOW_SSH_ENABLED", false),
 		SSHPort:           getEnv("KNOW_SSH_PORT", "2222"),
 		SSHHostKeyPath:    getEnv("KNOW_SSH_HOST_KEY", ""),

--- a/internal/file/task_toggle.go
+++ b/internal/file/task_toggle.go
@@ -14,8 +14,10 @@ import (
 var toggleCheckboxRegex = regexp.MustCompile(`^(\s*- \[)([ xX])(\]\s+)`)
 
 // ToggleTask flips a task's checkbox in the source file and re-ingests it.
+// The vaultID parameter ensures the task belongs to the expected vault,
+// preventing cross-vault task manipulation.
 // Returns the updated task after re-ingestion.
-func (s *Service) ToggleTask(ctx context.Context, taskID string) (*models.Task, error) {
+func (s *Service) ToggleTask(ctx context.Context, vaultID, taskID string) (*models.Task, error) {
 	logger := logutil.FromCtx(ctx)
 
 	task, err := s.db.GetTaskByID(ctx, taskID)
@@ -38,9 +40,12 @@ func (s *Service) ToggleTask(ctx context.Context, taskID string) (*models.Task, 
 		return nil, fmt.Errorf("source file not found for task %s", taskID)
 	}
 
-	vaultID, err := models.RecordIDString(doc.Vault)
+	docVaultID, err := models.RecordIDString(doc.Vault)
 	if err != nil {
 		return nil, fmt.Errorf("extract vault id: %w", err)
+	}
+	if docVaultID != vaultID {
+		return nil, fmt.Errorf("task %s does not belong to vault %s", taskID, vaultID)
 	}
 
 	// Load content from blob store.
@@ -101,7 +106,7 @@ func (s *Service) ToggleTask(ctx context.Context, taskID string) (*models.Task, 
 	prefix := rawContent[:len(rawContent)-len(contentBody)]
 	newContent := prefix + newBody
 	_, err = s.Create(ctx, models.FileInput{
-		VaultID: vaultID,
+		VaultID: docVaultID,
 		Path:    doc.Path,
 		Content: newContent,
 	})
@@ -110,7 +115,7 @@ func (s *Service) ToggleTask(ctx context.Context, taskID string) (*models.Task, 
 	}
 
 	// Process immediately so the caller gets fresh data.
-	if err := s.ProcessAllPending(ctx, vaultID); err != nil {
+	if err := s.ProcessAllPending(ctx, docVaultID); err != nil {
 		return nil, fmt.Errorf("process after toggle: %w", err)
 	}
 

--- a/internal/integration/bulk_test.go
+++ b/internal/integration/bulk_test.go
@@ -34,11 +34,12 @@ type bulkResult struct {
 }
 
 // setupBulkServer creates a vault and httptest.Server with the bulk upload endpoint.
-func setupBulkServer(t *testing.T, suffix string) (*httptest.Server, string) {
+// Returns the server, the bare vault ID, and the vault name (for URL paths).
+func setupBulkServer(t *testing.T, suffix string) (*httptest.Server, string, string) {
 	t.Helper()
 	ctx := context.Background()
 
-	vaultID, vaultSvc := setupVault(t, ctx, "bulk-"+suffix+"-"+fmt.Sprint(time.Now().UnixNano()))
+	vaultID, vaultName, vaultSvc := setupVault(t, ctx, "bulk-"+suffix+"-"+fmt.Sprint(time.Now().UnixNano()))
 	blobStore := blob.NewFS(t.TempDir())
 	fileSvc := file.NewService(testDB, blobStore, nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
 
@@ -46,15 +47,15 @@ func setupBulkServer(t *testing.T, suffix string) (*httptest.Server, string) {
 	apiSrv := api.NewServer(app)
 
 	mux := http.NewServeMux()
-	apiSrv.Register(mux, auth.NoAuthMiddleware)
+	apiSrv.Register(mux, auth.NoAuthMiddleware, nil)
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	return srv, vaultID
+	return srv, vaultID, vaultName
 }
 
 // bulkUploadRequest builds and sends a multipart bulk upload request.
-func bulkUploadRequest(t *testing.T, srv *httptest.Server, meta map[string]any, files map[string][]byte) bulkResponse {
+func bulkUploadRequest(t *testing.T, srv *httptest.Server, vaultName string, meta map[string]any, files map[string][]byte) bulkResponse {
 	t.Helper()
 
 	var buf bytes.Buffer
@@ -84,7 +85,7 @@ func bulkUploadRequest(t *testing.T, srv *httptest.Server, meta map[string]any, 
 		t.Fatalf("close multipart writer: %v", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/bulk", &buf)
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/vaults/"+vaultName+"/documents/bulk", &buf)
 	if err != nil {
 		t.Fatalf("create request: %v", err)
 	}
@@ -118,11 +119,10 @@ func findResult(results []bulkResult, path string) *bulkResult {
 }
 
 func TestBulkUpload_CreateDocuments(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "create")
+	srv, vaultID, vaultName := setupBulkServer(t, "create")
 
-	resp := bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	resp := bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/a.md": []byte("# Doc A\n\nContent A"),
 		"/docs/b.md": []byte("# Doc B\n\nContent B"),
@@ -152,13 +152,12 @@ func TestBulkUpload_CreateDocuments(t *testing.T) {
 }
 
 func TestBulkUpload_HashSkip(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "hash-skip")
+	srv, _, vaultName := setupBulkServer(t, "hash-skip")
 	content := []byte("# Same Content\n\nThis won't change.")
 
 	// First upload — creates the document
-	resp := bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	resp := bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/stable.md": content,
 	})
@@ -168,9 +167,8 @@ func TestBulkUpload_HashSkip(t *testing.T) {
 	}
 
 	// Second upload with same content — should skip with hash_match
-	resp = bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	resp = bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/stable.md": content,
 	})
@@ -182,20 +180,18 @@ func TestBulkUpload_HashSkip(t *testing.T) {
 }
 
 func TestBulkUpload_ForceUpdate(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "force-update")
+	srv, _, vaultName := setupBulkServer(t, "force-update")
 
 	// Create initial document
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/changing.md": []byte("# Version 1"),
 	})
 
 	// Upload with different content and force=true — should update
-	resp := bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	resp := bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/changing.md": []byte("# Version 2"),
 	})
@@ -207,20 +203,18 @@ func TestBulkUpload_ForceUpdate(t *testing.T) {
 }
 
 func TestBulkUpload_NoForceSkipsExisting(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "no-force")
+	srv, _, vaultName := setupBulkServer(t, "no-force")
 
 	// Create initial document
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/existing.md": []byte("# Original"),
 	})
 
 	// Upload with different content but force=false — should skip with "exists"
-	resp := bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   false,
+	resp := bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": false,
 	}, map[string][]byte{
 		"/docs/existing.md": []byte("# Changed"),
 	})
@@ -231,9 +225,8 @@ func TestBulkUpload_NoForceSkipsExisting(t *testing.T) {
 	}
 
 	// But hash_match should still work with force=false
-	resp = bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   false,
+	resp = bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": false,
 	}, map[string][]byte{
 		"/docs/existing.md": []byte("# Original"),
 	})
@@ -245,13 +238,12 @@ func TestBulkUpload_NoForceSkipsExisting(t *testing.T) {
 }
 
 func TestBulkUpload_DryRun(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "dryrun")
+	srv, vaultID, vaultName := setupBulkServer(t, "dryrun")
 
 	// Dry run on new documents — should report "created" without writing
-	resp := bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
-		"dryRun":  true,
+	resp := bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force":  true,
+		"dryRun": true,
 	}, map[string][]byte{
 		"/docs/new.md": []byte("# New Doc"),
 	})
@@ -271,17 +263,15 @@ func TestBulkUpload_DryRun(t *testing.T) {
 	}
 
 	// Create a real document, then dry run with different content and force=true
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/exists.md": []byte("# Existing"),
 	})
 
-	resp = bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
-		"dryRun":  true,
+	resp = bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force":  true,
+		"dryRun": true,
 	}, map[string][]byte{
 		"/docs/exists.md": []byte("# Changed"),
 	})
@@ -292,13 +282,12 @@ func TestBulkUpload_DryRun(t *testing.T) {
 }
 
 func TestBulkUpload_MixedDocumentsAndAssets(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "mixed")
+	srv, vaultID, vaultName := setupBulkServer(t, "mixed")
 
 	// Upload a markdown document and a PNG asset in the same request
 	pngData := []byte{0x89, 0x50, 0x4E, 0x47} // minimal PNG magic bytes
-	resp := bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	resp := bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/readme.md":  []byte("# Readme"),
 		"/images/logo.png": pngData,
@@ -345,19 +334,17 @@ func TestBulkUpload_MixedDocumentsAndAssets(t *testing.T) {
 }
 
 func TestBulkUpload_EmptyRequest(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "empty")
+	srv, _, vaultName := setupBulkServer(t, "empty")
 
-	resp := bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-	}, map[string][]byte{})
+	resp := bulkUploadRequest(t, srv, vaultName, map[string]any{}, map[string][]byte{})
 
 	if len(resp.Results) != 0 {
 		t.Errorf("expected 0 results, got %d", len(resp.Results))
 	}
 }
 
-func TestBulkUpload_MissingVaultID(t *testing.T) {
-	srv, _ := setupBulkServer(t, "no-vault")
+func TestBulkUpload_NonexistentVault(t *testing.T) {
+	srv, _, _ := setupBulkServer(t, "no-vault")
 
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
@@ -373,7 +360,7 @@ func TestBulkUpload_MissingVaultID(t *testing.T) {
 		t.Fatalf("close writer: %v", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/bulk", &buf)
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/vaults/nonexistent/documents/bulk", &buf)
 	if err != nil {
 		t.Fatalf("create request: %v", err)
 	}
@@ -385,19 +372,18 @@ func TestBulkUpload_MissingVaultID(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
 	}
 }
 
 func TestBulkUpload_AssetHashSkip(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "asset-hash")
+	srv, _, vaultName := setupBulkServer(t, "asset-hash")
 	pngData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
 
 	// First upload — creates
-	resp := bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	resp := bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/images/icon.png": pngData,
 	})
@@ -407,9 +393,8 @@ func TestBulkUpload_AssetHashSkip(t *testing.T) {
 	}
 
 	// Same content — should skip with hash_match
-	resp = bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	resp = bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/images/icon.png": pngData,
 	})
@@ -420,9 +405,8 @@ func TestBulkUpload_AssetHashSkip(t *testing.T) {
 	}
 
 	// Different content with force — should update
-	resp = bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	resp = bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/images/icon.png": []byte{0x89, 0x50, 0x4E, 0x47, 0xFF, 0xFF},
 	})

--- a/internal/integration/delete_test.go
+++ b/internal/integration/delete_test.go
@@ -17,11 +17,11 @@ type deleteResponse struct {
 	DryRun  bool     `json:"dryRun"`
 }
 
-// deleteRequest performs a DELETE /api/documents request and returns the parsed response.
-func deleteRequest(t *testing.T, srv *httptest.Server, vaultID, path string, recursive, dryRun bool) (*http.Response, deleteResponse) {
+// deleteRequest performs a DELETE /api/v1/vaults/{vault}/documents request and returns the parsed response.
+func deleteRequest(t *testing.T, srv *httptest.Server, vaultName, path string, recursive, dryRun bool) (*http.Response, deleteResponse) {
 	t.Helper()
 
-	u := srv.URL + "/api/documents?vault=" + vaultID + "&path=" + path
+	u := srv.URL + "/api/v1/vaults/" + vaultName + "/documents?path=" + path
 	if recursive {
 		u += "&recursive=true"
 	}
@@ -53,16 +53,15 @@ func deleteRequest(t *testing.T, srv *httptest.Server, vaultID, path string, rec
 }
 
 func TestDelete_SingleDocument(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "del-single")
+	srv, vaultID, vaultName := setupBulkServer(t, "del-single")
 
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/readme.md": []byte("# Readme"),
 	})
 
-	resp, result := deleteRequest(t, srv, vaultID, "/docs/readme.md", false, false)
+	resp, result := deleteRequest(t, srv, vaultName, "/docs/readme.md", false, false)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -88,18 +87,17 @@ func TestDelete_SingleDocument(t *testing.T) {
 }
 
 func TestDelete_RecursiveFolder(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "del-recursive")
+	srv, vaultID, vaultName := setupBulkServer(t, "del-recursive")
 
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/a.md":     []byte("# A"),
 		"/docs/sub/b.md": []byte("# B"),
 		"/other/c.md":    []byte("# C"),
 	})
 
-	resp, result := deleteRequest(t, srv, vaultID, "/docs", true, false)
+	resp, result := deleteRequest(t, srv, vaultName, "/docs", true, false)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -143,16 +141,15 @@ func TestDelete_RecursiveFolder(t *testing.T) {
 }
 
 func TestDelete_DryRunSingleDocument(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "del-dryrun-single")
+	srv, vaultID, vaultName := setupBulkServer(t, "del-dryrun-single")
 
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/readme.md": []byte("# Readme"),
 	})
 
-	resp, result := deleteRequest(t, srv, vaultID, "/docs/readme.md", false, true)
+	resp, result := deleteRequest(t, srv, vaultName, "/docs/readme.md", false, true)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -175,17 +172,16 @@ func TestDelete_DryRunSingleDocument(t *testing.T) {
 }
 
 func TestDelete_DryRunRecursiveFolder(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "del-dryrun-recursive")
+	srv, vaultID, vaultName := setupBulkServer(t, "del-dryrun-recursive")
 
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/a.md":     []byte("# A"),
 		"/docs/sub/b.md": []byte("# B"),
 	})
 
-	resp, result := deleteRequest(t, srv, vaultID, "/docs", true, true)
+	resp, result := deleteRequest(t, srv, vaultName, "/docs", true, true)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -210,46 +206,45 @@ func TestDelete_DryRunRecursiveFolder(t *testing.T) {
 }
 
 func TestDelete_NonRecursiveOnFolder(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "del-nonrecursive-folder")
+	srv, _, vaultName := setupBulkServer(t, "del-nonrecursive-folder")
 
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/a.md": []byte("# A"),
 	})
 
-	resp, _ := deleteRequest(t, srv, vaultID, "/docs", false, false)
+	resp, _ := deleteRequest(t, srv, vaultName, "/docs", false, false)
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", resp.StatusCode)
 	}
 }
 
 func TestDelete_NotFound(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "del-notfound")
+	srv, _, vaultName := setupBulkServer(t, "del-notfound")
 
-	resp, _ := deleteRequest(t, srv, vaultID, "/nonexistent.md", false, false)
+	resp, _ := deleteRequest(t, srv, vaultName, "/nonexistent.md", false, false)
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("expected 404, got %d", resp.StatusCode)
 	}
 }
 
 func TestDelete_MissingParams(t *testing.T) {
-	srv, _ := setupBulkServer(t, "del-missing-params")
+	srv, _, vaultName := setupBulkServer(t, "del-missing-params")
 
-	// Missing vault
-	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/documents?path=/docs/a.md", nil)
+	// Nonexistent vault
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/vaults/nonexistent/documents?path=/docs/a.md", nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("send request: %v", err)
 	}
 	resp.Body.Close()
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("missing vault: expected 400, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("nonexistent vault: expected 404, got %d", resp.StatusCode)
 	}
 
 	// Missing path
-	req, _ = http.NewRequest(http.MethodDelete, srv.URL+"/api/documents?vault=somevault", nil)
+	req, _ = http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/vaults/"+vaultName+"/documents", nil)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("send request: %v", err)

--- a/internal/integration/export_epub_test.go
+++ b/internal/integration/export_epub_test.go
@@ -12,16 +12,15 @@ import (
 )
 
 func TestExportEPUB_SingleDocument(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "epub-single")
+	srv, _, vaultName := setupBulkServer(t, "epub-single")
 
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/hello.md": []byte("# Hello World\n\nSome content here."),
 	})
 
-	resp, err := http.Get(srv.URL + "/api/export/epub?vault=" + vaultID + "&path=/docs/hello.md")
+	resp, err := http.Get(srv.URL + "/api/v1/vaults/" + vaultName + "/export/epub?path=/docs/hello.md")
 	if err != nil {
 		t.Fatalf("GET export/epub: %v", err)
 	}
@@ -45,18 +44,17 @@ func TestExportEPUB_SingleDocument(t *testing.T) {
 }
 
 func TestExportEPUB_FolderMultiChapter(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "epub-folder")
+	srv, _, vaultName := setupBulkServer(t, "epub-folder")
 
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/book/01-intro.md":      []byte("# Introduction\n\nWelcome."),
 		"/book/02-chapter.md":    []byte("# Chapter 1\n\nContent."),
 		"/book/03-conclusion.md": []byte("# Conclusion\n\nThe end."),
 	})
 
-	resp, err := http.Get(srv.URL + "/api/export/epub?vault=" + vaultID + "&path=/book/")
+	resp, err := http.Get(srv.URL + "/api/v1/vaults/" + vaultName + "/export/epub?path=/book/")
 	if err != nil {
 		t.Fatalf("GET export/epub: %v", err)
 	}
@@ -92,7 +90,7 @@ func TestExportEPUB_FolderMultiChapter(t *testing.T) {
 }
 
 func TestExportEPUB_WithImages(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "epub-images")
+	srv, _, vaultName := setupBulkServer(t, "epub-images")
 
 	// Minimal valid PNG (1x1 red pixel).
 	pngData := []byte{
@@ -104,15 +102,14 @@ func TestExportEPUB_WithImages(t *testing.T) {
 		0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
 	}
 
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/with-image.md": []byte("# Doc\n\n![logo](/images/logo.png)\n"),
 		"/images/logo.png":    pngData,
 	})
 
-	resp, err := http.Get(srv.URL + "/api/export/epub?vault=" + vaultID + "&path=/docs/with-image.md")
+	resp, err := http.Get(srv.URL + "/api/v1/vaults/" + vaultName + "/export/epub?path=/docs/with-image.md")
 	if err != nil {
 		t.Fatalf("GET export/epub: %v", err)
 	}
@@ -148,22 +145,20 @@ func TestExportEPUB_WithImages(t *testing.T) {
 }
 
 func TestExportEPUB_TitleAuthorOverride(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "epub-meta")
+	srv, _, vaultName := setupBulkServer(t, "epub-meta")
 
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/doc.md": []byte("# Original Title\n\nContent."),
 	})
 
 	params := url.Values{
-		"vault":  {vaultID},
 		"path":   {"/doc.md"},
 		"title":  {"Custom Title"},
 		"author": {"Custom Author"},
 	}
-	resp, err := http.Get(srv.URL + "/api/export/epub?" + params.Encode())
+	resp, err := http.Get(srv.URL + "/api/v1/vaults/" + vaultName + "/export/epub?" + params.Encode())
 	if err != nil {
 		t.Fatalf("GET export/epub: %v", err)
 	}
@@ -188,9 +183,9 @@ func TestExportEPUB_TitleAuthorOverride(t *testing.T) {
 }
 
 func TestExportEPUB_MissingPath(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "epub-no-path")
+	srv, _, vaultName := setupBulkServer(t, "epub-no-path")
 
-	resp, err := http.Get(srv.URL + "/api/export/epub?vault=" + vaultID)
+	resp, err := http.Get(srv.URL + "/api/v1/vaults/" + vaultName + "/export/epub")
 	if err != nil {
 		t.Fatalf("GET export/epub: %v", err)
 	}
@@ -212,9 +207,9 @@ func TestExportEPUB_MissingPath(t *testing.T) {
 }
 
 func TestExportEPUB_NonexistentPath(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "epub-404")
+	srv, _, vaultName := setupBulkServer(t, "epub-404")
 
-	resp, err := http.Get(srv.URL + "/api/export/epub?vault=" + vaultID + "&path=/nonexistent/")
+	resp, err := http.Get(srv.URL + "/api/v1/vaults/" + vaultName + "/export/epub?path=/nonexistent/")
 	if err != nil {
 		t.Fatalf("GET export/epub: %v", err)
 	}

--- a/internal/integration/export_test.go
+++ b/internal/integration/export_test.go
@@ -3,26 +3,24 @@ package integration
 import (
 	"archive/tar"
 	"compress/gzip"
-	"encoding/json"
 	"io"
 	"net/http"
 	"testing"
 )
 
 func TestExport_DocumentsAndAssets(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "export")
+	srv, _, vaultName := setupBulkServer(t, "export")
 
 	// Seed documents and an asset via bulk upload.
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/readme.md":   []byte("# Hello\n\nWorld"),
 		"/docs/nested/a.md": []byte("# Nested"),
 		"/images/logo.png":  {0x89, 0x50, 0x4E, 0x47},
 	})
 
-	resp, err := http.Get(srv.URL + "/api/export?vault=" + vaultID)
+	resp, err := http.Get(srv.URL + "/api/v1/vaults/" + vaultName + "/export")
 	if err != nil {
 		t.Fatalf("GET export: %v", err)
 	}
@@ -93,9 +91,9 @@ func TestExport_DocumentsAndAssets(t *testing.T) {
 }
 
 func TestExport_EmptyVault(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "export-empty")
+	srv, _, vaultName := setupBulkServer(t, "export-empty")
 
-	resp, err := http.Get(srv.URL + "/api/export?vault=" + vaultID)
+	resp, err := http.Get(srv.URL + "/api/v1/vaults/" + vaultName + "/export")
 	if err != nil {
 		t.Fatalf("GET export: %v", err)
 	}
@@ -129,27 +127,17 @@ func TestExport_EmptyVault(t *testing.T) {
 	}
 }
 
-func TestExport_MissingVaultParam(t *testing.T) {
-	srv, _ := setupBulkServer(t, "export-no-vault")
+func TestExport_NonexistentVault(t *testing.T) {
+	srv, _, _ := setupBulkServer(t, "export-no-vault")
 
-	resp, err := http.Get(srv.URL + "/api/export")
+	resp, err := http.Get(srv.URL + "/api/v1/vaults/nonexistent/export")
 	if err != nil {
 		t.Fatalf("GET export: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", resp.StatusCode)
-	}
-
-	var errResp struct {
-		Error string `json:"error"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
-		t.Fatalf("decode error: %v", err)
-	}
-	if errResp.Error == "" {
-		t.Error("expected non-empty error message")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
 	}
 }
 

--- a/internal/integration/folder_test.go
+++ b/internal/integration/folder_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/raphi011/know/internal/vault"
 )
 
-func setupVault(t *testing.T, ctx context.Context, suffix string) (string, *vault.Service) {
+func setupVault(t *testing.T, ctx context.Context, suffix string) (string, string, *vault.Service) {
 	t.Helper()
 	user, err := testDB.CreateUser(ctx, models.UserInput{Name: "folder-test-user-" + suffix})
 	if err != nil {
@@ -21,18 +21,19 @@ func setupVault(t *testing.T, ctx context.Context, suffix string) (string, *vaul
 	}
 	userID := models.MustRecordIDString(user.ID)
 
+	vaultName := "folder-test-" + suffix
 	vaultSvc := vault.NewService(testDB)
-	v, err := vaultSvc.Create(ctx, userID, models.VaultInput{Name: "folder-test-" + suffix})
+	v, err := vaultSvc.Create(ctx, userID, models.VaultInput{Name: vaultName})
 	if err != nil {
 		t.Fatalf("create vault: %v", err)
 	}
 	vaultID := models.MustRecordIDString(v.ID)
-	return vaultID, vaultSvc
+	return vaultID, vaultName, vaultSvc
 }
 
 func TestFolderAutoCreate(t *testing.T) {
 	ctx := context.Background()
-	vaultID, vaultSvc := setupVault(t, ctx, "autocreate-"+fmt.Sprint(time.Now().UnixNano()))
+	vaultID, _, vaultSvc := setupVault(t, ctx, "autocreate-"+fmt.Sprint(time.Now().UnixNano()))
 
 	fileSvc := file.NewService(testDB, blob.NewFS(t.TempDir()), nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
 
@@ -69,7 +70,7 @@ func TestFolderAutoCreate(t *testing.T) {
 
 func TestFolderRootDocNoFolders(t *testing.T) {
 	ctx := context.Background()
-	vaultID, vaultSvc := setupVault(t, ctx, "rootdoc-"+fmt.Sprint(time.Now().UnixNano()))
+	vaultID, _, vaultSvc := setupVault(t, ctx, "rootdoc-"+fmt.Sprint(time.Now().UnixNano()))
 
 	fileSvc := file.NewService(testDB, blob.NewFS(t.TempDir()), nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
 
@@ -97,7 +98,7 @@ func TestFolderRootDocNoFolders(t *testing.T) {
 
 func TestFolderEnsureIdempotency(t *testing.T) {
 	ctx := context.Background()
-	vaultID, vaultSvc := setupVault(t, ctx, "idempotent-"+fmt.Sprint(time.Now().UnixNano()))
+	vaultID, _, vaultSvc := setupVault(t, ctx, "idempotent-"+fmt.Sprint(time.Now().UnixNano()))
 
 	if err := testDB.EnsureFolders(ctx, vaultID, "/guides/sub/file.md"); err != nil {
 		t.Fatalf("first EnsureFolders: %v", err)
@@ -122,7 +123,7 @@ func TestFolderEnsureIdempotency(t *testing.T) {
 
 func TestFolderEmptyPersistence(t *testing.T) {
 	ctx := context.Background()
-	vaultID, vaultSvc := setupVault(t, ctx, "empty-"+fmt.Sprint(time.Now().UnixNano()))
+	vaultID, _, vaultSvc := setupVault(t, ctx, "empty-"+fmt.Sprint(time.Now().UnixNano()))
 
 	fileSvc := file.NewService(testDB, blob.NewFS(t.TempDir()), nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
 
@@ -154,7 +155,7 @@ func TestFolderEmptyPersistence(t *testing.T) {
 
 func TestFolderExplicitCreate(t *testing.T) {
 	ctx := context.Background()
-	vaultID, vaultSvc := setupVault(t, ctx, "explicit-"+fmt.Sprint(time.Now().UnixNano()))
+	vaultID, _, vaultSvc := setupVault(t, ctx, "explicit-"+fmt.Sprint(time.Now().UnixNano()))
 
 	folder, err := vaultSvc.CreateFolder(ctx, vaultID, "/projects/new-idea")
 	if err != nil {
@@ -189,7 +190,7 @@ func TestFolderExplicitCreate(t *testing.T) {
 
 func TestFolderDeleteCascade(t *testing.T) {
 	ctx := context.Background()
-	vaultID, vaultSvc := setupVault(t, ctx, "cascade-"+fmt.Sprint(time.Now().UnixNano()))
+	vaultID, _, vaultSvc := setupVault(t, ctx, "cascade-"+fmt.Sprint(time.Now().UnixNano()))
 
 	fileSvc := file.NewService(testDB, blob.NewFS(t.TempDir()), nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
 
@@ -252,7 +253,7 @@ func TestFolderDeleteCascade(t *testing.T) {
 
 func TestFolderMoveBasic(t *testing.T) {
 	ctx := context.Background()
-	vaultID, vaultSvc := setupVault(t, ctx, "move-"+fmt.Sprint(time.Now().UnixNano()))
+	vaultID, _, vaultSvc := setupVault(t, ctx, "move-"+fmt.Sprint(time.Now().UnixNano()))
 
 	fileSvc := file.NewService(testDB, blob.NewFS(t.TempDir()), nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
 
@@ -333,7 +334,7 @@ func TestFolderMoveBasic(t *testing.T) {
 
 func TestFolderMoveCreatesAncestors(t *testing.T) {
 	ctx := context.Background()
-	vaultID, vaultSvc := setupVault(t, ctx, "move-ancestors-"+fmt.Sprint(time.Now().UnixNano()))
+	vaultID, _, vaultSvc := setupVault(t, ctx, "move-ancestors-"+fmt.Sprint(time.Now().UnixNano()))
 
 	fileSvc := file.NewService(testDB, blob.NewFS(t.TempDir()), nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
 
@@ -372,7 +373,7 @@ func TestFolderMoveCreatesAncestors(t *testing.T) {
 
 func TestFolderListByParent(t *testing.T) {
 	ctx := context.Background()
-	vaultID, vaultSvc := setupVault(t, ctx, "listparent-"+fmt.Sprint(time.Now().UnixNano()))
+	vaultID, _, vaultSvc := setupVault(t, ctx, "listparent-"+fmt.Sprint(time.Now().UnixNano()))
 
 	fileSvc := file.NewService(testDB, blob.NewFS(t.TempDir()), nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
 
@@ -425,7 +426,7 @@ func TestFolderListByParent(t *testing.T) {
 
 func TestFolderListAll(t *testing.T) {
 	ctx := context.Background()
-	vaultID, vaultSvc := setupVault(t, ctx, "listall-"+fmt.Sprint(time.Now().UnixNano()))
+	vaultID, _, vaultSvc := setupVault(t, ctx, "listall-"+fmt.Sprint(time.Now().UnixNano()))
 
 	fileSvc := file.NewService(testDB, blob.NewFS(t.TempDir()), nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
 

--- a/internal/integration/ls_test.go
+++ b/internal/integration/ls_test.go
@@ -12,11 +12,10 @@ import (
 )
 
 func TestLs_NonRecursiveRoot(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "ls-root")
+	srv, _, vaultName := setupBulkServer(t, "ls-root")
 
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/readme.md":        []byte("# Readme"),
 		"/docs/guide.md":    []byte("# Guide"),
@@ -24,7 +23,7 @@ func TestLs_NonRecursiveRoot(t *testing.T) {
 		"/notes/todo.md":    []byte("# Todo"),
 	})
 
-	entries := lsRequest(t, srv, vaultID, "/", false)
+	entries := lsRequest(t, srv, vaultName, "/", false)
 
 	// Should list direct children only: readme.md + folders docs/ and notes/
 	names := entryNames(entries)
@@ -57,18 +56,17 @@ func TestLs_NonRecursiveRoot(t *testing.T) {
 }
 
 func TestLs_NonRecursiveSubfolder(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "ls-subfolder")
+	srv, _, vaultName := setupBulkServer(t, "ls-subfolder")
 
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/guide.md":    []byte("# Guide"),
 		"/docs/setup.md":    []byte("# Setup"),
 		"/docs/sub/deep.md": []byte("# Deep"),
 	})
 
-	entries := lsRequest(t, srv, vaultID, "/docs", false)
+	entries := lsRequest(t, srv, vaultName, "/docs", false)
 
 	names := entryNames(entries)
 	sort.Strings(names)
@@ -86,17 +84,16 @@ func TestLs_NonRecursiveSubfolder(t *testing.T) {
 }
 
 func TestLs_Recursive(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "ls-recursive")
+	srv, _, vaultName := setupBulkServer(t, "ls-recursive")
 
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/guide.md":    []byte("# Guide"),
 		"/docs/sub/deep.md": []byte("# Deep"),
 	})
 
-	entries := lsRequest(t, srv, vaultID, "/docs", true)
+	entries := lsRequest(t, srv, vaultName, "/docs", true)
 
 	paths := entryPaths(entries)
 	sort.Strings(paths)
@@ -114,19 +111,18 @@ func TestLs_Recursive(t *testing.T) {
 }
 
 func TestLs_PrefixIsolation(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "ls-prefix")
+	srv, _, vaultName := setupBulkServer(t, "ls-prefix")
 
 	// Create docs under /docs and /docs-other — they share the "/docs" prefix
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		"/docs/a.md":       []byte("# A"),
 		"/docs-other/b.md": []byte("# B"),
 	})
 
 	// Non-recursive ls of /docs should NOT include /docs-other/b.md
-	entries := lsRequest(t, srv, vaultID, "/docs", false)
+	entries := lsRequest(t, srv, vaultName, "/docs", false)
 	for _, e := range entries {
 		if e.Name == "b.md" || e.Path == "/docs-other/b.md" {
 			t.Errorf("ls /docs should not include /docs-other entries: got %+v", e)
@@ -137,7 +133,7 @@ func TestLs_PrefixIsolation(t *testing.T) {
 	}
 
 	// Recursive ls of /docs should also not include /docs-other
-	entries = lsRequest(t, srv, vaultID, "/docs", true)
+	entries = lsRequest(t, srv, vaultName, "/docs", true)
 	for _, e := range entries {
 		if e.Name == "b.md" || e.Path == "/docs-other/b.md" {
 			t.Errorf("recursive ls /docs should not include /docs-other entries: got %+v", e)
@@ -146,33 +142,33 @@ func TestLs_PrefixIsolation(t *testing.T) {
 }
 
 func TestLs_EmptyVault(t *testing.T) {
-	srv, vaultID := setupBulkServer(t, "ls-empty")
+	srv, _, vaultName := setupBulkServer(t, "ls-empty")
 
-	entries := lsRequest(t, srv, vaultID, "/", false)
+	entries := lsRequest(t, srv, vaultName, "/", false)
 	if len(entries) != 0 {
 		t.Errorf("expected 0 entries for empty vault, got %d", len(entries))
 	}
 }
 
-func TestLs_MissingVaultParam(t *testing.T) {
-	srv, _ := setupBulkServer(t, "ls-no-vault")
+func TestLs_NonexistentVault(t *testing.T) {
+	srv, _, _ := setupBulkServer(t, "ls-no-vault")
 
-	resp, err := http.Get(srv.URL + "/api/ls")
+	resp, err := http.Get(srv.URL + "/api/v1/vaults/nonexistent/documents/ls?path=/")
 	if err != nil {
 		t.Fatalf("GET ls: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
 	}
 }
 
-// lsRequest performs a GET /api/ls and returns the parsed entries.
-func lsRequest(t *testing.T, srv *httptest.Server, vaultID, path string, recursive bool) []models.FileEntry {
+// lsRequest performs a GET /api/v1/vaults/{vault}/documents/ls and returns the parsed entries.
+func lsRequest(t *testing.T, srv *httptest.Server, vaultName, path string, recursive bool) []models.FileEntry {
 	t.Helper()
 
-	u := srv.URL + "/api/ls?vault=" + vaultID + "&path=" + path
+	u := srv.URL + "/api/v1/vaults/" + vaultName + "/documents/ls?path=" + path
 	if recursive {
 		u += "&recursive=true"
 	}

--- a/internal/integration/mcp_http_test.go
+++ b/internal/integration/mcp_http_test.go
@@ -27,7 +27,7 @@ import (
 func setupMCPServer(t *testing.T, suffix string) (*httptest.Server, string, *file.Service) {
 	t.Helper()
 	ctx := context.Background()
-	vaultID, _ := setupVault(t, ctx, "mcp-"+suffix+"-"+fmt.Sprint(time.Now().UnixNano()))
+	vaultID, _, _ := setupVault(t, ctx, "mcp-"+suffix+"-"+fmt.Sprint(time.Now().UnixNano()))
 
 	searchSvc := search.NewService(testDB, nil)
 	docSvc := file.NewService(testDB, blob.NewFS(t.TempDir()), nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)

--- a/internal/integration/mcp_tools_test.go
+++ b/internal/integration/mcp_tools_test.go
@@ -19,7 +19,7 @@ import (
 func setupExecutor(t *testing.T, suffix string) (*tools.Executor, string) {
 	t.Helper()
 	ctx := context.Background()
-	vaultID, _ := setupVault(t, ctx, "exec-"+suffix+"-"+fmt.Sprint(time.Now().UnixNano()))
+	vaultID, _, _ := setupVault(t, ctx, "exec-"+suffix+"-"+fmt.Sprint(time.Now().UnixNano()))
 
 	searchSvc := search.NewService(testDB, nil)
 	docSvc := file.NewService(testDB, blob.NewFS(t.TempDir()), nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)

--- a/internal/integration/move_test.go
+++ b/internal/integration/move_test.go
@@ -33,11 +33,12 @@ type errorResponse struct {
 }
 
 // setupMoveServer creates a vault and httptest.Server with the move endpoint.
-func setupMoveServer(t *testing.T, suffix string) (*httptest.Server, string) {
+// Returns the server, the bare vault ID, and the vault name (for URL paths).
+func setupMoveServer(t *testing.T, suffix string) (*httptest.Server, string, string) {
 	t.Helper()
 	ctx := context.Background()
 
-	vaultID, vaultSvc := setupVault(t, ctx, "move-"+suffix+"-"+fmt.Sprint(time.Now().UnixNano()))
+	vaultID, vaultName, vaultSvc := setupVault(t, ctx, "move-"+suffix+"-"+fmt.Sprint(time.Now().UnixNano()))
 	blobStore := blob.NewFS(t.TempDir())
 	fileSvc := file.NewService(testDB, blobStore, nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
 
@@ -45,19 +46,18 @@ func setupMoveServer(t *testing.T, suffix string) (*httptest.Server, string) {
 	apiSrv := api.NewServer(app)
 
 	mux := http.NewServeMux()
-	apiSrv.Register(mux, auth.NoAuthMiddleware)
+	apiSrv.Register(mux, auth.NoAuthMiddleware, nil)
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	return srv, vaultID
+	return srv, vaultID, vaultName
 }
 
-// moveRequest sends a POST /api/move request and returns the HTTP response.
-func moveRequest(t *testing.T, srv *httptest.Server, vaultID, source, destination string, dryRun bool) (*http.Response, []byte) {
+// moveRequest sends a POST /api/v1/vaults/{vault}/documents/move request and returns the HTTP response.
+func moveRequest(t *testing.T, srv *httptest.Server, vaultName, source, destination string, dryRun bool) (*http.Response, []byte) {
 	t.Helper()
 
 	body, err := json.Marshal(map[string]any{
-		"vaultId":     vaultID,
 		"source":      source,
 		"destination": destination,
 		"dryRun":      dryRun,
@@ -66,7 +66,7 @@ func moveRequest(t *testing.T, srv *httptest.Server, vaultID, source, destinatio
 		t.Fatalf("marshal move request: %v", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/move", bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/vaults/"+vaultName+"/documents/move", bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("create request: %v", err)
 	}
@@ -87,26 +87,25 @@ func moveRequest(t *testing.T, srv *httptest.Server, vaultID, source, destinatio
 }
 
 // createDoc creates a document via the bulk upload endpoint.
-func createDoc(t *testing.T, srv *httptest.Server, vaultID, path, content string) {
+func createDoc(t *testing.T, srv *httptest.Server, vaultName, path, content string) {
 	t.Helper()
 
-	bulkUploadRequest(t, srv, map[string]any{
-		"vaultId": vaultID,
-		"force":   true,
+	bulkUploadRequest(t, srv, vaultName, map[string]any{
+		"force": true,
 	}, map[string][]byte{
 		path: []byte(content),
 	})
 }
 
 func TestMove_DocumentToExistingDocument_Conflict(t *testing.T) {
-	srv, vaultID := setupMoveServer(t, "doc-to-doc")
+	srv, _, vaultName := setupMoveServer(t, "doc-to-doc")
 
 	// Create two documents
-	createDoc(t, srv, vaultID, "/doc-a.md", "# Doc A")
-	createDoc(t, srv, vaultID, "/doc-b.md", "# Doc B")
+	createDoc(t, srv, vaultName, "/doc-a.md", "# Doc A")
+	createDoc(t, srv, vaultName, "/doc-b.md", "# Doc B")
 
 	// Try to move doc-a to doc-b's path — should 409
-	resp, body := moveRequest(t, srv, vaultID, "/doc-a.md", "/doc-b.md", false)
+	resp, body := moveRequest(t, srv, vaultName, "/doc-a.md", "/doc-b.md", false)
 	if resp.StatusCode != http.StatusConflict {
 		t.Fatalf("expected 409, got %d: %s", resp.StatusCode, string(body))
 	}
@@ -121,14 +120,14 @@ func TestMove_DocumentToExistingDocument_Conflict(t *testing.T) {
 }
 
 func TestMove_DocumentToExistingFolder_Conflict(t *testing.T) {
-	srv, vaultID := setupMoveServer(t, "doc-to-folder")
+	srv, _, vaultName := setupMoveServer(t, "doc-to-folder")
 
 	// Create a document and a folder (by creating a doc inside a folder)
-	createDoc(t, srv, vaultID, "/doc.md", "# Document")
-	createDoc(t, srv, vaultID, "/myfolder/nested.md", "# Nested")
+	createDoc(t, srv, vaultName, "/doc.md", "# Document")
+	createDoc(t, srv, vaultName, "/myfolder/nested.md", "# Nested")
 
 	// Try to move /doc.md to /myfolder — should 409 (cross-type: document → folder)
-	resp, body := moveRequest(t, srv, vaultID, "/doc.md", "/myfolder", false)
+	resp, body := moveRequest(t, srv, vaultName, "/doc.md", "/myfolder", false)
 	if resp.StatusCode != http.StatusConflict {
 		t.Fatalf("expected 409, got %d: %s", resp.StatusCode, string(body))
 	}
@@ -143,14 +142,14 @@ func TestMove_DocumentToExistingFolder_Conflict(t *testing.T) {
 }
 
 func TestMove_FolderToExistingDocument_Conflict(t *testing.T) {
-	srv, vaultID := setupMoveServer(t, "folder-to-doc")
+	srv, _, vaultName := setupMoveServer(t, "folder-to-doc")
 
 	// Create a folder (by creating a doc inside it) and a standalone document
-	createDoc(t, srv, vaultID, "/myfolder/nested.md", "# Nested")
-	createDoc(t, srv, vaultID, "/target.md", "# Target")
+	createDoc(t, srv, vaultName, "/myfolder/nested.md", "# Nested")
+	createDoc(t, srv, vaultName, "/target.md", "# Target")
 
 	// Try to move /myfolder to /target.md — should 409 (cross-type: folder → document)
-	resp, body := moveRequest(t, srv, vaultID, "/myfolder", "/target.md", false)
+	resp, body := moveRequest(t, srv, vaultName, "/myfolder", "/target.md", false)
 	if resp.StatusCode != http.StatusConflict {
 		t.Fatalf("expected 409, got %d: %s", resp.StatusCode, string(body))
 	}
@@ -165,12 +164,12 @@ func TestMove_FolderToExistingDocument_Conflict(t *testing.T) {
 }
 
 func TestMove_FolderToNewPath_Success(t *testing.T) {
-	srv, vaultID := setupMoveServer(t, "folder-success")
+	srv, vaultID, vaultName := setupMoveServer(t, "folder-success")
 
-	createDoc(t, srv, vaultID, "/src/a.md", "# A")
-	createDoc(t, srv, vaultID, "/src/b.md", "# B")
+	createDoc(t, srv, vaultName, "/src/a.md", "# A")
+	createDoc(t, srv, vaultName, "/src/b.md", "# B")
 
-	resp, body := moveRequest(t, srv, vaultID, "/src", "/dst", false)
+	resp, body := moveRequest(t, srv, vaultName, "/src", "/dst", false)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
 	}
@@ -209,24 +208,24 @@ func TestMove_FolderToNewPath_Success(t *testing.T) {
 }
 
 func TestMove_DryRunReportsConflict(t *testing.T) {
-	srv, vaultID := setupMoveServer(t, "dryrun-conflict")
+	srv, _, vaultName := setupMoveServer(t, "dryrun-conflict")
 
-	createDoc(t, srv, vaultID, "/doc.md", "# Document")
-	createDoc(t, srv, vaultID, "/myfolder/nested.md", "# Nested")
+	createDoc(t, srv, vaultName, "/doc.md", "# Document")
+	createDoc(t, srv, vaultName, "/myfolder/nested.md", "# Nested")
 
 	// Dry-run move of doc to existing folder path — should still 409
-	resp, body := moveRequest(t, srv, vaultID, "/doc.md", "/myfolder", true)
+	resp, body := moveRequest(t, srv, vaultName, "/doc.md", "/myfolder", true)
 	if resp.StatusCode != http.StatusConflict {
 		t.Fatalf("expected 409 even with dry-run, got %d: %s", resp.StatusCode, string(body))
 	}
 }
 
 func TestMove_DocumentToNewPath_Success(t *testing.T) {
-	srv, vaultID := setupMoveServer(t, "doc-success")
+	srv, vaultID, vaultName := setupMoveServer(t, "doc-success")
 
-	createDoc(t, srv, vaultID, "/original.md", "# Original")
+	createDoc(t, srv, vaultName, "/original.md", "# Original")
 
-	resp, body := moveRequest(t, srv, vaultID, "/original.md", "/renamed.md", false)
+	resp, body := moveRequest(t, srv, vaultName, "/original.md", "/renamed.md", false)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
 	}

--- a/internal/integration/vault_scope_test.go
+++ b/internal/integration/vault_scope_test.go
@@ -1,0 +1,185 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/raphi011/know/internal/api"
+	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/blob"
+	"github.com/raphi011/know/internal/file"
+	"github.com/raphi011/know/internal/models"
+	"github.com/raphi011/know/internal/parser"
+	"github.com/raphi011/know/internal/server"
+	"github.com/raphi011/know/internal/vault"
+)
+
+func TestVaultScope_NonexistentVaultReturns404(t *testing.T) {
+	ctx := context.Background()
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	_, vaultName, vaultSvc := setupVault(t, ctx, "scope-404-"+suffix)
+
+	blobStore := blob.NewFS(t.TempDir())
+	fileSvc := file.NewService(testDB, blobStore, nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
+	app := server.NewForTest(testDB, blobStore, fileSvc, vaultSvc)
+	apiSrv := api.NewServer(app)
+	mux := http.NewServeMux()
+	apiSrv.Register(mux, auth.NoAuthMiddleware, nil)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	// Access a nonexistent vault
+	resp, err := http.Get(srv.URL + "/api/v1/vaults/nonexistent-vault-xyz/labels")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 404 for nonexistent vault, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Verify the existing vault works
+	resp2, err := http.Get(srv.URL + "/api/v1/vaults/" + vaultName + "/labels")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp2.Body)
+		t.Fatalf("expected 200 for existing vault, got %d: %s", resp2.StatusCode, string(body))
+	}
+}
+
+func TestVaultScope_ForbiddenReturns403(t *testing.T) {
+	ctx := context.Background()
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+
+	// Create a user with access to vault A only
+	user, err := testDB.CreateUser(ctx, models.UserInput{Name: "scope-403-user-" + suffix})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	userID := models.MustRecordIDString(user.ID)
+
+	vaultSvc := vault.NewService(testDB)
+
+	// Vault A — user has access
+	vA, err := vaultSvc.Create(ctx, userID, models.VaultInput{Name: "scope-403-a-" + suffix})
+	if err != nil {
+		t.Fatalf("create vault A: %v", err)
+	}
+	vaultAID := models.MustRecordIDString(vA.ID)
+	vaultAName := "scope-403-a-" + suffix
+
+	// Vault B — different user owns it
+	user2, err := testDB.CreateUser(ctx, models.UserInput{Name: "scope-403-user2-" + suffix})
+	if err != nil {
+		t.Fatalf("create user2: %v", err)
+	}
+	user2ID := models.MustRecordIDString(user2.ID)
+	_, err = vaultSvc.Create(ctx, user2ID, models.VaultInput{Name: "scope-403-b-" + suffix})
+	if err != nil {
+		t.Fatalf("create vault B: %v", err)
+	}
+	vaultBName := "scope-403-b-" + suffix
+
+	blobStore := blob.NewFS(t.TempDir())
+	fileSvc := file.NewService(testDB, blobStore, nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
+	app := server.NewForTest(testDB, blobStore, fileSvc, vaultSvc)
+	apiSrv := api.NewServer(app)
+	mux := http.NewServeMux()
+
+	// Use a middleware that grants access only to vault A
+	scopedAuthMw := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := auth.WithAuth(r.Context(), auth.AuthContext{
+				UserID: userID,
+				Vaults: []models.VaultPermission{
+					{VaultID: vaultAID, Role: models.RoleAdmin},
+				},
+			})
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+
+	apiSrv.Register(mux, scopedAuthMw, nil)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	// Vault A should be accessible
+	resp, err := http.Get(srv.URL + "/api/v1/vaults/" + vaultAName + "/labels")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for authorized vault, got %d", resp.StatusCode)
+	}
+
+	// Vault B should be forbidden
+	resp2, err := http.Get(srv.URL + "/api/v1/vaults/" + vaultBName + "/labels")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for unauthorized vault, got %d", resp2.StatusCode)
+	}
+}
+
+func TestVaultScope_InjectsVaultIDIntoContext(t *testing.T) {
+	ctx := context.Background()
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	vaultID, vaultName, vaultSvc := setupVault(t, ctx, "scope-inject-"+suffix)
+
+	blobStore := blob.NewFS(t.TempDir())
+	fileSvc := file.NewService(testDB, blobStore, nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
+	app := server.NewForTest(testDB, blobStore, fileSvc, vaultSvc)
+	apiSrv := api.NewServer(app)
+	mux := http.NewServeMux()
+	apiSrv.Register(mux, auth.NoAuthMiddleware, nil)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	// Create a document in the vault, then retrieve it — verifies the vault ID
+	// was correctly injected and used by the handler.
+	_, err := fileSvc.Create(ctx, models.FileInput{
+		VaultID: vaultID,
+		Path:    "/scope-test.md",
+		Content: "# Scope Test",
+	})
+	if err != nil {
+		t.Fatalf("create doc: %v", err)
+	}
+
+	resp, err := http.Get(srv.URL + "/api/v1/vaults/" + vaultName + "/documents?path=/scope-test.md")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	var doc map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if doc["path"] != "/scope-test.md" {
+		t.Errorf("expected path=/scope-test.md, got %v", doc["path"])
+	}
+}

--- a/internal/integration/webdav_test.go
+++ b/internal/integration/webdav_test.go
@@ -56,7 +56,7 @@ func setupWebDAV(t *testing.T, suffix string) (*httptest.Server, string) {
 	t.Helper()
 	ctx := context.Background()
 
-	vaultID, vaultSvc := setupVault(t, ctx, "webdav-"+suffix+"-"+fmt.Sprint(time.Now().UnixNano()))
+	vaultID, _, vaultSvc := setupVault(t, ctx, "webdav-"+suffix+"-"+fmt.Sprint(time.Now().UnixNano()))
 	blobStore := blob.NewFS(t.TempDir())
 	docSvc := file.NewService(testDB, blobStore, nil, parser.DefaultChunkConfig(), file.VersionConfig{CoalesceMinutes: 10, RetentionCount: 50}, nil, 0)
 

--- a/internal/remote/executor.go
+++ b/internal/remote/executor.go
@@ -242,9 +242,9 @@ func (e *Executor) execUpsertDocument(ctx context.Context, vaultID, arguments, v
 
 	start := time.Now()
 	doc, err := e.client.CreateDocument(ctx, apiclient.CreateDocumentRequest{
-		VaultID: vaultID,
-		Path:    input.Path,
-		Content: input.Content,
+		VaultName: vaultID,
+		Path:      input.Path,
+		Content:   input.Content,
 	})
 	durationMs := time.Since(start).Milliseconds()
 	if err != nil {
@@ -280,9 +280,9 @@ func (e *Executor) execCreateMemory(ctx context.Context, vaultID, arguments stri
 
 	start := time.Now()
 	doc, err := e.client.CreateDocument(ctx, apiclient.CreateDocumentRequest{
-		VaultID: vaultID,
-		Path:    path,
-		Content: fullContent,
+		VaultName: vaultID,
+		Path:      path,
+		Content:   fullContent,
 	})
 	durationMs := time.Since(start).Milliseconds()
 	if err != nil {

--- a/internal/tools/tool_toggle_task.go
+++ b/internal/tools/tool_toggle_task.go
@@ -41,8 +41,10 @@ func (t *ToggleTaskTool) InvokableRun(ctx context.Context, argumentsInJSON strin
 		return "", fmt.Errorf("task_id is required")
 	}
 
+	o := getToolOptions(opts...)
+
 	start := time.Now()
-	updated, err := t.docService.ToggleTask(ctx, input.TaskID)
+	updated, err := t.docService.ToggleTask(ctx, o.VaultID, input.TaskID)
 	durationMs := time.Since(start).Milliseconds()
 	if err != nil {
 		return "", fmt.Errorf("toggle task: %w", err)

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/raphi011/know/internal/api"
@@ -33,9 +34,9 @@ func NewClient(baseURL, token string) *Client {
 }
 
 // CreateConversation creates a new conversation in a vault.
-func (c *Client) CreateConversation(ctx context.Context, vaultID string) (*api.Conversation, error) {
+func (c *Client) CreateConversation(ctx context.Context, vaultName string) (*api.Conversation, error) {
 	var conv api.Conversation
-	err := c.rest.Post(ctx, "/api/conversations", map[string]string{"vaultId": vaultID}, &conv)
+	err := c.rest.Post(ctx, "/api/v1/conversations", map[string]string{"vaultId": vaultName}, &conv)
 	return &conv, err
 }
 
@@ -81,10 +82,9 @@ type chatStartResponse struct {
 
 // StartChat sends a chat request and returns the conversation ID.
 // The agent runs in the background on the server.
-func (c *Client) StartChat(ctx context.Context, conversationID, vaultID, content string, attachments []models.ChatAttachment, autoApprove bool) (string, error) {
+func (c *Client) StartChat(ctx context.Context, conversationID, vaultName, content string, attachments []models.ChatAttachment, autoApprove bool) (string, error) {
 	body := map[string]any{
 		"conversationId": conversationID,
-		"vaultId":        vaultID,
 		"content":        content,
 		"autoApprove":    autoApprove,
 	}
@@ -97,7 +97,7 @@ func (c *Client) StartChat(ctx context.Context, conversationID, vaultID, content
 		return "", fmt.Errorf("marshal chat request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/agent/chat", strings.NewReader(string(data)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v1/vaults/"+url.PathEscape(vaultName)+"/agent/chat", strings.NewReader(string(data)))
 	if err != nil {
 		return "", fmt.Errorf("create chat request: %w", err)
 	}
@@ -126,7 +126,7 @@ func (c *Client) StartChat(ctx context.Context, conversationID, vaultID, content
 
 // SubscribeEvents connects to the SSE event stream for a running agent.
 func (c *Client) SubscribeEvents(ctx context.Context, conversationID string) (<-chan StreamEvent, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/agent/events/"+conversationID, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/v1/agent/events/"+conversationID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create events request: %w", err)
 	}
@@ -202,7 +202,7 @@ func (c *Client) Chat(ctx context.Context, conversationID, vaultID, content stri
 
 // Approve sends a tool approval to the server using eino's interrupt/resume.
 func (c *Client) Approve(ctx context.Context, conversationID, interruptID, action string) error {
-	return c.rest.Post(ctx, "/agent/approval", map[string]string{
+	return c.rest.Post(ctx, "/api/v1/agent/approval", map[string]string{
 		"conversationId": conversationID,
 		"interruptId":    interruptID,
 		"action":         action,

--- a/internal/tui/tasks.go
+++ b/internal/tui/tasks.go
@@ -127,7 +127,7 @@ func (m TaskModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.toggling = true
 			idx := m.list.GlobalIndex()
-			return m, toggleTaskCmd(m.client, item.ID, idx)
+			return m, toggleTaskCmd(m.client, m.vaultID, item.ID, idx)
 		}
 
 	case toggleResultMsg:
@@ -168,9 +168,9 @@ func (m TaskModel) View() tea.View {
 }
 
 // toggleTaskCmd returns a command that toggles a task via the API.
-func toggleTaskCmd(client *apiclient.Client, taskID string, index int) tea.Cmd {
+func toggleTaskCmd(client *apiclient.Client, vaultName, taskID string, index int) tea.Cmd {
 	return func() tea.Msg {
-		resp, err := client.ToggleTask(context.Background(), taskID)
+		resp, err := client.ToggleTask(context.Background(), vaultName, taskID)
 		return toggleResultMsg{index: index, resp: resp, err: err}
 	}
 }


### PR DESCRIPTION
Restructure REST API from flat `/api/` routes to vault-scoped `/api/v1/vaults/{vault}/` with a centralized middleware. Eliminates per-handler vault resolution boilerplate and introduces API versioning.

## New Features
- **Vault-scoped routing**: All vault-specific endpoints now use `/api/v1/vaults/{vault}/...` paths with vault name in the URL instead of query params or request bodies
- **`vaultScope` middleware** (`vault_scope.go`): Resolves vault name → ID, checks `RoleRead` access, enriches context logger with `vault_id`, injects vault ID for handlers
- **`MustVaultIDFromCtx`**: Panicking variant that catches middleware misconfiguration during development (used by all vault-scoped handlers)
- **API versioning**: All routes now under `/api/v1/` prefix
- **Protocol server separation**: WebDAV + MCP moved to dedicated port
- **Cross-vault task toggle protection**: `ToggleTask` now requires `vaultID` parameter and verifies the task belongs to the expected vault

## Breaking Changes
- All REST API paths changed from `/api/...?vault=ID` to `/api/v1/vaults/{name}/...`
- `ToggleTask` service method signature changed: added `vaultID` parameter
- Vault identified by name in URL (not ID) — middleware resolves name → ID internally
- Protocol server (WebDAV + MCP) now runs on separate port from REST API

## Test plan
- [x] All existing integration tests updated and passing
- [x] New `TestVaultScope_NonexistentVaultReturns404` — verifies 404 for missing vaults
- [x] New `TestVaultScope_ForbiddenReturns403` — verifies 403 with scoped auth (not wildcard)
- [x] New `TestVaultScope_InjectsVaultIDIntoContext` — end-to-end doc creation + retrieval through vault scope
- [x] `just test` passes (all tests)
- [x] `go build` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)