### PR TITLE
fix: mount emptyDir at /tmp for export and PDF processing

### DIFF
--- a/helm/know/Chart.yaml
+++ b/helm/know/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: know
 description: Know - Personal Knowledge RAG Database with REST API and WebDAV
 type: application
-version: 0.10.0
+version: 0.10.1
 appVersion: "0.10.0"
 keywords:
   - know

--- a/helm/know/templates/deployment.yaml
+++ b/helm/know/templates/deployment.yaml
@@ -353,6 +353,8 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+            - name: tmp
+              mountPath: /tmp
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
@@ -368,6 +370,8 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Mount an emptyDir volume at `/tmp` so `os.CreateTemp`/`os.MkdirTemp` work with `readOnlyRootFilesystem: true`.

## New Features
- None

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)