### PR TITLE
perf: add composite indexes, fix N+1 query, transactional delete/move

### DIFF
--- a/internal/db/queries_file.go
+++ b/internal/db/queries_file.go
@@ -15,6 +15,12 @@ import (
 	surrealmodels "github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
+// idPath is used by stem-recomputation queries that only need the record ID and path.
+type idPath struct {
+	ID   surrealmodels.RecordID `json:"id"`
+	Path string                 `json:"path"`
+}
+
 // fileSize returns the appropriate size for a file input. It checks (in order):
 // an explicit Size override, len(Data) for binary files, and len(Content) for
 // text files. The Size override is used by streaming imports where the file data
@@ -305,6 +311,40 @@ func (c *Client) DeleteFile(ctx context.Context, id string) error {
 	return nil
 }
 
+// DeleteFileAtomic removes a file and all its associated data (wiki links, label edges, chunks)
+// in a single transaction. Cascade events remain as a safety net but the primary cleanup is
+// synchronous and atomic. Post-commit steps (stem collision resolution, blob deletion, events)
+// must be handled by the caller.
+func (c *Client) DeleteFileAtomic(ctx context.Context, fileID string) error {
+	defer c.logOp(ctx, "file.delete_atomic", time.Now())
+	tx, err := c.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("delete file atomic begin tx: %w", err)
+	}
+	defer tx.Cancel(ctx) //nolint:errcheck // no-op after Commit
+
+	vars := map[string]any{"file_id": bareID("file", fileID)}
+	for _, step := range []struct {
+		name string
+		sql  string
+	}{
+		{"delete wiki links", `DELETE FROM wiki_link WHERE from_file = type::record("file", $file_id)`},
+		{"unresolve incoming wiki links", `UPDATE wiki_link SET to_file = NONE WHERE to_file = type::record("file", $file_id)`},
+		{"delete label edges", `DELETE FROM has_label WHERE in = type::record("file", $file_id)`},
+		{"delete chunks", `DELETE FROM chunk WHERE file = type::record("file", $file_id)`},
+		{"delete file", `DELETE type::record("file", $file_id)`},
+	} {
+		if _, err := surrealdb.Query[any](ctx, tx, step.sql, vars); err != nil {
+			return fmt.Errorf("delete file atomic %s: %w", step.name, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("delete file atomic commit: %w", err)
+	}
+	return nil
+}
+
 // DeleteFilesByPrefix deletes all non-folder files in a vault whose path starts with the given prefix.
 // Returns the number of deleted files. Folder cleanup is handled separately by DeleteFoldersByPrefix.
 func (c *Client) DeleteFilesByPrefix(ctx context.Context, vaultID, pathPrefix string) (int, error) {
@@ -351,10 +391,6 @@ func (c *Client) RecomputeStems(ctx context.Context, vaultID, pathPrefix string)
 
 	// Fetch affected files
 	sql := `SELECT id, path FROM file WHERE vault = type::record("vault", $vault_id) AND is_folder = false AND string::starts_with(path, $prefix)`
-	type idPath struct {
-		ID   surrealmodels.RecordID `json:"id"`
-		Path string                 `json:"path"`
-	}
 	results, err := surrealdb.Query[[]idPath](ctx, c.DB(), sql, map[string]any{
 		"vault_id": bareID("vault", vaultID),
 		"prefix":   pathPrefix,
@@ -363,20 +399,29 @@ func (c *Client) RecomputeStems(ctx context.Context, vaultID, pathPrefix string)
 		return fmt.Errorf("recompute stems fetch: %w", err)
 	}
 	rows := allResults(results)
+	if len(rows) == 0 {
+		return nil
+	}
 
-	for _, row := range rows {
+	// Batch all stem updates into a single transaction (avoids N round-trips).
+	var b strings.Builder
+	vars := make(map[string]any, len(rows)*2)
+	b.WriteString("BEGIN TRANSACTION;\n")
+	for i, row := range rows {
 		idStr, err := models.RecordIDString(row.ID)
 		if err != nil {
 			return fmt.Errorf("recompute stems extract id: %w", err)
 		}
-		stem := models.FilenameStem(row.Path)
-		updateSQL := `UPDATE type::record("file", $id) SET stem = $stem`
-		if _, err := surrealdb.Query[any](ctx, c.DB(), updateSQL, map[string]any{
-			"id":   idStr,
-			"stem": stem,
-		}); err != nil {
-			return fmt.Errorf("recompute stems update: %w", err)
-		}
+		idKey := fmt.Sprintf("id_%d", i)
+		stemKey := fmt.Sprintf("stem_%d", i)
+		fmt.Fprintf(&b, "UPDATE type::record(\"file\", $%s) SET stem = $%s;\n", idKey, stemKey)
+		vars[idKey] = idStr
+		vars[stemKey] = models.FilenameStem(row.Path)
+	}
+	b.WriteString("COMMIT TRANSACTION;")
+
+	if _, err := surrealdb.Query[any](ctx, c.DB(), b.String(), vars); err != nil {
+		return fmt.Errorf("recompute stems batch update: %w", err)
 	}
 	return nil
 }
@@ -398,6 +443,184 @@ func (c *Client) MoveFile(ctx context.Context, id, newPath string) (*models.File
 		return nil, fmt.Errorf("move file: %w", err)
 	}
 	return firstResult(results, "move file")
+}
+
+// MoveFileAtomic updates a file's path and ensures destination folders exist in a single
+// transaction. Post-commit steps (wiki-link raw_target recomputation, stem collision
+// resolution) must be handled by the caller.
+func (c *Client) MoveFileAtomic(ctx context.Context, vaultID, fileID, newPath string) (*models.File, error) {
+	defer c.logOp(ctx, "file.move_atomic", time.Now())
+	tx, err := c.db.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("move file atomic begin tx: %w", err)
+	}
+	defer tx.Cancel(ctx) //nolint:errcheck // no-op after Commit
+
+	// 1. Update file path + stem
+	moveSQL := `
+		UPDATE type::record("file", $id) SET
+			path = $new_path,
+			stem = $stem
+		RETURN AFTER
+	`
+	results, err := surrealdb.Query[[]models.File](ctx, tx, moveSQL, map[string]any{
+		"id":       bareID("file", fileID),
+		"new_path": newPath,
+		"stem":     models.FilenameStem(newPath),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("move file atomic update: %w", err)
+	}
+	doc, err := firstResult(results, "move file atomic")
+	if err != nil {
+		return nil, fmt.Errorf("move file atomic: %w", err)
+	}
+
+	// 2. Ensure destination ancestor folders exist
+	dir := path.Dir(newPath)
+	if dir != "/" && dir != "." {
+		folders := buildFolderRows(vaultID, dir)
+		folderSQL := `INSERT INTO file $folders ON DUPLICATE KEY UPDATE id = id`
+		if _, err := surrealdb.Query[any](ctx, tx, folderSQL, map[string]any{
+			"folders": folders,
+		}); err != nil {
+			return nil, fmt.Errorf("move file atomic ensure folders: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("move file atomic commit: %w", err)
+	}
+
+	// Invalidate folder cache for the new directory
+	c.InvalidateFolderCache(vaultID, dir)
+
+	return doc, nil
+}
+
+// buildFolderRows returns folder row maps for a directory and all its ancestors,
+// suitable for batch INSERT into the file table.
+func buildFolderRows(vaultID, folderPath string) []map[string]any {
+	var folders []string
+	for cur := folderPath; cur != "/" && cur != "."; cur = path.Dir(cur) {
+		folders = append(folders, cur)
+	}
+	vid := bareID("vault", vaultID)
+	rows := make([]map[string]any, len(folders))
+	for i, fp := range folders {
+		rows[i] = map[string]any{
+			"vault":          newRecordID("vault", vid),
+			"path":           fp,
+			"title":          path.Base(fp),
+			"is_folder":      true,
+			"mime_type":      "inode/directory",
+			"content_length": 0,
+			"labels":         []string{},
+			"size":           0,
+		}
+	}
+	return rows
+}
+
+// MoveByPrefixAtomic renames files, recomputes stems, moves folders, and ensures ancestor
+// folders in a single transaction. Returns the count of moved non-folder files.
+// Post-commit steps (wiki-link raw_target recomputation) must be handled by the caller.
+func (c *Client) MoveByPrefixAtomic(ctx context.Context, vaultID, oldPrefix, newPrefix string) (int, error) {
+	defer c.logOp(ctx, "file.move_by_prefix_atomic", time.Now())
+	tx, err := c.db.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("move by prefix atomic begin tx: %w", err)
+	}
+	defer tx.Cancel(ctx) //nolint:errcheck // no-op after Commit
+
+	// 1. Move non-folder files
+	moveSQL := `
+		UPDATE file
+		SET path = string::concat($new_prefix, string::slice(path, string::len($old_prefix)))
+		WHERE vault = type::record("vault", $vault_id)
+		  AND is_folder = false
+		  AND string::starts_with(path, $old_prefix)
+		RETURN AFTER
+	`
+	moveVars := map[string]any{
+		"vault_id":   bareID("vault", vaultID),
+		"old_prefix": oldPrefix,
+		"new_prefix": newPrefix,
+	}
+	moveResults, err := surrealdb.Query[[]models.File](ctx, tx, moveSQL, moveVars)
+	if err != nil {
+		return 0, fmt.Errorf("move by prefix atomic move files: %w", err)
+	}
+	count := countResults(moveResults)
+
+	// 2. Recompute stems for all moved files using the results from step 1 (no re-query).
+	//    Batched into a single multi-statement query within the interactive transaction.
+	movedFiles := allResults(moveResults)
+	if len(movedFiles) > 0 {
+		var b strings.Builder
+		vars := make(map[string]any, len(movedFiles)*2)
+		for i, f := range movedFiles {
+			idStr, err := models.RecordIDString(f.ID)
+			if err != nil {
+				return 0, fmt.Errorf("move by prefix atomic extract id: %w", err)
+			}
+			idKey := fmt.Sprintf("id_%d", i)
+			stemKey := fmt.Sprintf("stem_%d", i)
+			fmt.Fprintf(&b, "UPDATE type::record(\"file\", $%s) SET stem = $%s;\n", idKey, stemKey)
+			vars[idKey] = idStr
+			vars[stemKey] = models.FilenameStem(f.Path)
+		}
+		if _, err := surrealdb.Query[any](ctx, tx, b.String(), vars); err != nil {
+			return 0, fmt.Errorf("move by prefix atomic recompute stems: %w", err)
+		}
+	}
+
+	// 3. Move folder records
+	oldFolderPath := strings.TrimSuffix(oldPrefix, "/")
+	newFolderPath := strings.TrimSuffix(newPrefix, "/")
+	oldFolderPrefix := oldFolderPath + "/"
+	newFolderPrefix := newFolderPath + "/"
+	folderVars := map[string]any{
+		"vault_id":   bareID("vault", vaultID),
+		"old_path":   oldFolderPath,
+		"new_path":   newFolderPath,
+		"new_title":  path.Base(newFolderPath),
+		"old_prefix": oldFolderPrefix,
+		"new_prefix": newFolderPrefix,
+	}
+	if _, err := surrealdb.Query[any](ctx, tx,
+		`UPDATE file SET path = $new_path, title = $new_title WHERE vault = type::record("vault", $vault_id) AND is_folder = true AND path = $old_path`, folderVars); err != nil {
+		return 0, fmt.Errorf("move by prefix atomic move folder root: %w", err)
+	}
+	if _, err := surrealdb.Query[any](ctx, tx,
+		`UPDATE file SET
+			path = string::concat($new_prefix, string::slice(path, string::len($old_prefix))),
+			title = array::last(string::split(string::concat($new_prefix, string::slice(path, string::len($old_prefix))), "/"))
+		WHERE vault = type::record("vault", $vault_id)
+		AND is_folder = true
+		AND string::starts_with(path, $old_prefix)`, folderVars); err != nil {
+		return 0, fmt.Errorf("move by prefix atomic move folder children: %w", err)
+	}
+
+	// 4. Ensure destination ancestor folders exist
+	if newFolderPath != "/" && newFolderPath != "." {
+		folders := buildFolderRows(vaultID, newFolderPath)
+		if _, err := surrealdb.Query[any](ctx, tx,
+			`INSERT INTO file $folders ON DUPLICATE KEY UPDATE id = id`,
+			map[string]any{"folders": folders}); err != nil {
+			return 0, fmt.Errorf("move by prefix atomic ensure folders: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("move by prefix atomic commit: %w", err)
+	}
+
+	// Invalidate folder cache for old and new paths
+	c.InvalidateFolderCache(vaultID, oldFolderPath)
+	c.InvalidateFolderCache(vaultID, newFolderPath)
+
+	return count, nil
 }
 
 // ListUnprocessedFiles returns non-folder files that have a pending parse pipeline job.
@@ -819,28 +1042,7 @@ func (c *Client) EnsureFolderPath(ctx context.Context, vaultID, folderPath strin
 		return nil
 	}
 
-	// Collect the target folder and all its ancestors
-	var folders []string
-	for cur := folderPath; cur != "/" && cur != "."; cur = path.Dir(cur) {
-		folders = append(folders, cur)
-	}
-
-	// Build batch of folder rows for a single INSERT
-	rows := make([]map[string]any, len(folders))
-	vid := bareID("vault", vaultID)
-	for i, fp := range folders {
-		rows[i] = map[string]any{
-			"vault":          newRecordID("vault", vid),
-			"path":           fp,
-			"title":          path.Base(fp),
-			"is_folder":      true,
-			"mime_type":      "inode/directory",
-			"content_length": 0,
-			"labels":         []string{},
-			"size":           0,
-		}
-	}
-
+	rows := buildFolderRows(vaultID, folderPath)
 	sql := `INSERT INTO file $folders ON DUPLICATE KEY UPDATE id = id`
 	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
 		"folders": rows,

--- a/internal/db/queries_file_test.go
+++ b/internal/db/queries_file_test.go
@@ -183,6 +183,260 @@ func TestDeleteFile(t *testing.T) {
 	}
 }
 
+func TestDeleteFileAtomic(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	// Create file with chunks, wiki links, and label edges
+	doc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID,
+		Path:    "/atomic-delete.md",
+		Title:   "Atomic Delete",
+		Content: "content",
+		Labels:  []string{"test"},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	if err := testDB.CreateChunks(ctx, []models.ChunkInput{
+		{FileID: docID, Text: "Chunk 1", Position: 0, Embedding: dummyEmbedding()},
+		{FileID: docID, Text: "Chunk 2", Position: 1, Embedding: dummyEmbedding()},
+	}); err != nil {
+		t.Fatalf("CreateChunks failed: %v", err)
+	}
+
+	// Outgoing wiki link from the file being deleted
+	if err := testDB.CreateWikiLinks(ctx, docID, vaultID, []WikiLinkInput{
+		{RawTarget: "other"},
+	}); err != nil {
+		t.Fatalf("CreateWikiLinks failed: %v", err)
+	}
+
+	// Create a second file with a wiki link pointing TO the file being deleted (incoming link)
+	otherDoc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID,
+		Path:    "/other.md",
+		Title:   "Other",
+		Content: "links to atomic-delete",
+		Labels:  []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile (other) failed: %v", err)
+	}
+	otherDocID := models.MustRecordIDString(otherDoc.ID)
+	if err := testDB.CreateWikiLinks(ctx, otherDocID, vaultID, []WikiLinkInput{
+		{RawTarget: "atomic-delete", ToFileID: &docID},
+	}); err != nil {
+		t.Fatalf("CreateWikiLinks (incoming) failed: %v", err)
+	}
+
+	if err := testDB.SyncFileLabels(ctx, docID, vaultID, []string{"test"}); err != nil {
+		t.Fatalf("SyncFileLabels failed: %v", err)
+	}
+
+	// Delete atomically
+	if err := testDB.DeleteFileAtomic(ctx, docID); err != nil {
+		t.Fatalf("DeleteFileAtomic failed: %v", err)
+	}
+
+	// Verify file is gone
+	gone, err := testDB.GetFileByID(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetFileByID after atomic delete error: %v", err)
+	}
+	if gone != nil {
+		t.Error("File should be nil after atomic delete")
+	}
+
+	// Verify chunks are gone
+	chunks, err := testDB.GetChunks(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetChunks after atomic delete error: %v", err)
+	}
+	if len(chunks) != 0 {
+		t.Errorf("Expected 0 chunks after atomic delete, got %d", len(chunks))
+	}
+
+	// Verify outgoing wiki links are gone
+	links, err := testDB.GetWikiLinks(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetWikiLinks after atomic delete error: %v", err)
+	}
+	if len(links) != 0 {
+		t.Errorf("Expected 0 outgoing wiki links after atomic delete, got %d", len(links))
+	}
+
+	// Verify incoming wiki links were unresolved (to_file set to NONE)
+	incomingLinks, err := testDB.GetWikiLinksToFile(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetWikiLinksToFile after atomic delete error: %v", err)
+	}
+	if len(incomingLinks) != 0 {
+		t.Errorf("Expected 0 incoming wiki links after atomic delete, got %d", len(incomingLinks))
+	}
+	// The link itself should still exist on the other file, just unresolved
+	otherLinks, err := testDB.GetWikiLinks(ctx, otherDocID)
+	if err != nil {
+		t.Fatalf("GetWikiLinks for other doc error: %v", err)
+	}
+	if len(otherLinks) != 1 {
+		t.Errorf("Expected 1 wiki link on other doc, got %d", len(otherLinks))
+	}
+
+	// Verify label edges are gone
+	labels, err := testDB.GetLabelsForFile(ctx, docID)
+	if err != nil {
+		t.Fatalf("GetLabelsForFile after atomic delete error: %v", err)
+	}
+	if len(labels) != 0 {
+		t.Errorf("Expected 0 labels after atomic delete, got %d", len(labels))
+	}
+}
+
+func TestMoveFileAtomic(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	doc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID,
+		Path:    "/old/move-test.md",
+		Title:   "Move Test",
+		Content: "content",
+		Labels:  []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	moved, err := testDB.MoveFileAtomic(ctx, vaultID, docID, "/new/subdir/move-test.md")
+	if err != nil {
+		t.Fatalf("MoveFileAtomic failed: %v", err)
+	}
+	if moved.Path != "/new/subdir/move-test.md" {
+		t.Errorf("Expected path '/new/subdir/move-test.md', got %q", moved.Path)
+	}
+	expectedStem := models.FilenameStem("/new/subdir/move-test.md")
+	if moved.Stem != expectedStem {
+		t.Errorf("Expected stem %q, got %q", expectedStem, moved.Stem)
+	}
+
+	// Verify ancestor folders were created atomically
+	folder, err := testDB.GetFolderByPath(ctx, vaultID, "/new/subdir")
+	if err != nil {
+		t.Fatalf("GetFolderByPath /new/subdir error: %v", err)
+	}
+	if folder == nil {
+		t.Error("Expected folder /new/subdir to exist after atomic move")
+	}
+
+	folder, err = testDB.GetFolderByPath(ctx, vaultID, "/new")
+	if err != nil {
+		t.Fatalf("GetFolderByPath /new error: %v", err)
+	}
+	if folder == nil {
+		t.Error("Expected folder /new to exist after atomic move")
+	}
+}
+
+func TestMoveByPrefixAtomic(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	// Create folder + files under /src/
+	ts := fmt.Sprintf("%d", time.Now().UnixNano())
+	srcPath := "/src-" + ts + "/"
+	dstPath := "/dst-" + ts + "/"
+
+	if _, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID:  vaultID,
+		Path:     strings.TrimSuffix(srcPath, "/"),
+		Title:    "src",
+		IsFolder: true,
+		Labels:   []string{},
+	}); err != nil {
+		t.Fatalf("CreateFolder failed: %v", err)
+	}
+
+	for _, name := range []string{"a.md", "b.md"} {
+		if _, err := testDB.CreateFile(ctx, models.FileInput{
+			VaultID: vaultID,
+			Path:    srcPath + name,
+			Title:   name,
+			Content: "content",
+			Labels:  []string{},
+		}); err != nil {
+			t.Fatalf("CreateFile %s failed: %v", name, err)
+		}
+	}
+
+	count, err := testDB.MoveByPrefixAtomic(ctx, vaultID, srcPath, dstPath)
+	if err != nil {
+		t.Fatalf("MoveByPrefixAtomic failed: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("Expected 2 moved files, got %d", count)
+	}
+
+	// Verify files are at new paths
+	for _, name := range []string{"a.md", "b.md"} {
+		f, err := testDB.GetFileByPath(ctx, vaultID, dstPath+name)
+		if err != nil {
+			t.Fatalf("GetFileByPath %s error: %v", dstPath+name, err)
+		}
+		if f == nil {
+			t.Errorf("Expected file at %s after prefix move", dstPath+name)
+		}
+		// Verify stem was recomputed
+		expectedStem := models.FilenameStem(dstPath + name)
+		if f != nil && f.Stem != expectedStem {
+			t.Errorf("Expected stem %q for %s, got %q", expectedStem, name, f.Stem)
+		}
+	}
+
+	// Verify old files are gone
+	for _, name := range []string{"a.md", "b.md"} {
+		f, err := testDB.GetFileByPath(ctx, vaultID, srcPath+name)
+		if err != nil {
+			t.Fatalf("GetFileByPath %s error: %v", srcPath+name, err)
+		}
+		if f != nil {
+			t.Errorf("Expected no file at old path %s", srcPath+name)
+		}
+	}
+
+	// Verify destination folder was created
+	dstFolderPath := strings.TrimSuffix(dstPath, "/")
+	folder, err := testDB.GetFolderByPath(ctx, vaultID, dstFolderPath)
+	if err != nil {
+		t.Fatalf("GetFolderByPath %s error: %v", dstFolderPath, err)
+	}
+	if folder == nil {
+		t.Errorf("Expected folder %s to exist after prefix move", dstFolderPath)
+	}
+
+	// Verify source folder was moved (not left behind as a ghost)
+	srcFolderPath := strings.TrimSuffix(srcPath, "/")
+	srcFolder, err := testDB.GetFolderByPath(ctx, vaultID, srcFolderPath)
+	if err != nil {
+		t.Fatalf("GetFolderByPath %s error: %v", srcFolderPath, err)
+	}
+	if srcFolder != nil {
+		t.Errorf("Expected source folder %s to be gone after prefix move", srcFolderPath)
+	}
+}
+
 func TestMoveFile(t *testing.T) {
 	ctx := context.Background()
 	user := createTestUser(t, ctx)

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -148,7 +148,7 @@ func SchemaSQL(dimension int) string {
     DEFINE FIELD IF NOT EXISTS embedding  ON chunk TYPE option<array<float>>;
     DEFINE FIELD IF NOT EXISTS created_at ON chunk TYPE datetime DEFAULT time::now();
 
-    DEFINE INDEX IF NOT EXISTS idx_chunk_file      ON chunk FIELDS file;
+    DEFINE INDEX IF NOT EXISTS idx_chunk_file_position ON chunk FIELDS file, position;
     DEFINE INDEX IF NOT EXISTS idx_chunk_text_ft    ON chunk FIELDS text FULLTEXT ANALYZER know_analyzer BM25;
     DEFINE INDEX IF NOT EXISTS idx_chunk_embedding  ON chunk FIELDS embedding
         HNSW DIMENSION %d DIST COSINE TYPE F32 EFC 150 M 12 HASHED_VECTOR;
@@ -297,8 +297,9 @@ func SchemaSQL(dimension int) string {
     DEFINE FIELD IF NOT EXISTS bg_started_at   ON conversation TYPE option<datetime>;
     DEFINE FIELD IF NOT EXISTS bg_completed_at ON conversation TYPE option<datetime>;
 
-    DEFINE INDEX IF NOT EXISTS idx_conversation_vault ON conversation FIELDS vault;
-    DEFINE INDEX IF NOT EXISTS idx_conversation_user  ON conversation FIELDS user;
+    DEFINE INDEX IF NOT EXISTS idx_conversation_vault      ON conversation FIELDS vault;
+    DEFINE INDEX IF NOT EXISTS idx_conversation_user       ON conversation FIELDS user;
+    DEFINE INDEX IF NOT EXISTS idx_conversation_vault_user ON conversation FIELDS vault, user;
 
     -- ==========================================================================
     -- MESSAGE TABLE
@@ -316,7 +317,7 @@ func SchemaSQL(dimension int) string {
     DEFINE FIELD IF NOT EXISTS tool_calls   ON message TYPE option<string>;
     DEFINE FIELD IF NOT EXISTS created_at   ON message TYPE datetime DEFAULT time::now();
 
-    DEFINE INDEX IF NOT EXISTS idx_message_conversation ON message FIELDS conversation;
+    DEFINE INDEX IF NOT EXISTS idx_message_conversation_created ON message FIELDS conversation, created_at;
 
     -- Cascade: delete messages when conversation deleted
     DEFINE EVENT IF NOT EXISTS cascade_delete_conversation_messages ON conversation
@@ -414,5 +415,12 @@ func SchemaSQL(dimension int) string {
 
     DEFINE INDEX IF NOT EXISTS idx_job_pending ON pipeline_job
         FIELDS status, run_after, priority, created_at;
+    DEFINE INDEX IF NOT EXISTS idx_job_file ON pipeline_job FIELDS file;
+
+    -- ==========================================================================
+    -- CLEANUP: remove superseded single-field indexes
+    -- ==========================================================================
+    REMOVE INDEX IF EXISTS idx_chunk_file ON chunk;
+    REMOVE INDEX IF EXISTS idx_message_conversation ON message;
 `, dimension)
 }

--- a/internal/file/service.go
+++ b/internal/file/service.go
@@ -984,27 +984,14 @@ func (s *Service) Delete(ctx context.Context, vaultID, path string) error {
 		contentHash = *doc.ContentHash
 	}
 
-	// Synchronous cleanup — async cascade events are a safety net, not primary.
-	if err := s.db.DeleteWikiLinks(ctx, fileID); err != nil {
-		return fmt.Errorf("delete wiki links: %w", err)
-	}
-	if _, err := s.db.UnresolveWikiLinksToFile(ctx, fileID); err != nil {
-		return fmt.Errorf("unresolve incoming wiki links: %w", err)
-	}
-
-	if err := s.db.SyncFileLabels(ctx, fileID, vaultID, nil); err != nil {
-		return fmt.Errorf("delete label edges: %w", err)
-	}
-	if err := s.db.DeleteChunks(ctx, fileID); err != nil {
-		return fmt.Errorf("delete chunks: %w", err)
-	}
-
-	if err := s.db.DeleteFile(ctx, fileID); err != nil {
-		return fmt.Errorf("delete file: %w", err)
+	// Atomic cleanup: wiki links, label edges, chunks, and file record in one transaction.
+	// Async cascade events remain as a safety net.
+	if err := s.db.DeleteFileAtomic(ctx, fileID); err != nil {
+		return fmt.Errorf("delete file atomic: %w", err)
 	}
 
 	// After deletion, check if this file's stem is now unique (collision removed).
-	// This must happen after DeleteFile so CountFilesByStem returns the correct count.
+	// This must happen after DeleteFileAtomic so CountFilesByStem returns the correct count.
 	stem := models.FilenameStem(doc.Path)
 	if err := s.resolveAfterStemCollisionRemoval(ctx, vaultID, stem); err != nil {
 		logutil.FromCtx(ctx).Warn("resolve after stem collision removal", "stem", stem, "error", err)
@@ -1072,18 +1059,13 @@ func (s *Service) MoveByPrefix(ctx context.Context, vaultID, oldPrefix, newPrefi
 	if oldNorm == newNorm {
 		return 0, nil
 	}
-	count, err := s.db.MoveFilesByPrefix(ctx, vaultID, oldNorm, newNorm)
+	// Atomic: move files, recompute stems, move folders, ensure ancestors in one transaction
+	count, err := s.db.MoveByPrefixAtomic(ctx, vaultID, oldNorm, newNorm)
 	if err != nil {
 		return 0, fmt.Errorf("move by prefix: %w", err)
 	}
 
-	// Recompute stems for all moved files
-	if err := s.db.RecomputeStems(ctx, vaultID, newNorm); err != nil {
-		return count, fmt.Errorf("recompute stems after prefix move: %w", err)
-	}
-
-	// Best-effort: raw_target recomputation is cosmetic (affects display only);
-	// stem recomputation above is required for resolution correctness.
+	// Post-commit best-effort: raw_target recomputation is cosmetic (affects display only)
 	movedFiles, err := s.db.ListFilesByPrefix(ctx, vaultID, newNorm)
 	if err != nil {
 		logutil.FromCtx(ctx).Warn("list moved files for raw target recompute", "error", err)
@@ -1098,15 +1080,6 @@ func (s *Service) MoveByPrefix(ctx context.Context, vaultID, oldPrefix, newPrefi
 				logutil.FromCtx(ctx).Warn("recompute incoming raw targets after prefix move", "path", f.Path, "error", err)
 			}
 		}
-	}
-
-	// Move folder records to match
-	if _, err := s.db.MoveFoldersByPrefix(ctx, vaultID, oldNorm, newNorm); err != nil {
-		return count, fmt.Errorf("move folder records: %w", err)
-	}
-	// Ensure destination ancestor folders exist
-	if err := s.db.EnsureFolderPath(ctx, vaultID, strings.TrimSuffix(newNorm, "/")); err != nil {
-		return count, fmt.Errorf("ensure destination folders: %w", err)
 	}
 
 	return count, nil
@@ -1132,12 +1105,13 @@ func (s *Service) Move(ctx context.Context, vaultID, oldPath, newPath string) (*
 	normalizedNew := models.NormalizePath(newPath)
 	newStem := models.FilenameStem(normalizedNew)
 
-	doc, err = s.db.MoveFile(ctx, fileID, normalizedNew)
+	// Atomic: update file path + ensure destination folders in one transaction
+	doc, err = s.db.MoveFileAtomic(ctx, vaultID, fileID, normalizedNew)
 	if err != nil {
 		return nil, fmt.Errorf("move file: %w", err)
 	}
 
-	// Best-effort: raw_target recomputation is cosmetic (affects display only)
+	// Post-commit best-effort: raw_target recomputation is cosmetic (affects display only)
 	if err := s.recomputeIncomingRawTargets(ctx, vaultID, fileID, normalizedNew); err != nil {
 		logutil.FromCtx(ctx).Warn("recompute incoming raw targets", "error", err)
 	}
@@ -1152,11 +1126,6 @@ func (s *Service) Move(ctx context.Context, vaultID, oldPath, newPath string) (*
 		if err := s.resolveAfterStemCollisionRemoval(ctx, vaultID, oldStem); err != nil {
 			logutil.FromCtx(ctx).Warn("resolve after stem collision removal", "stem", oldStem, "error", err)
 		}
-	}
-
-	// Ensure destination folders exist
-	if err := s.db.EnsureFolders(ctx, vaultID, normalizedNew); err != nil {
-		return nil, fmt.Errorf("ensure destination folders: %w", err)
 	}
 
 	s.publishFileMoveEvent(vaultID, doc, oldPath)


### PR DESCRIPTION
## Summary

- **4 composite indexes** added for hot query paths (`ListConversations`, `ListMessages`, `GetChunks`, `CancelJobsForFile`); 2 redundant single-field indexes removed
- **RecomputeStems N+1 fix**: batches all stem UPDATEs into a single transaction instead of one round-trip per file
- **Transactional Delete/Move/MoveByPrefix**: wraps multi-step DB operations in interactive transactions for atomicity — previously 5-7 sequential calls could leave inconsistent state on partial failure

## Details

### Indexes (`internal/db/schema.go`)

| New Index | Table | Fields | Purpose |
|-----------|-------|--------|---------|
| `idx_conversation_vault_user` | conversation | `vault, user` | `ListConversations` filters on both |
| `idx_message_conversation_created` | message | `conversation, created_at` | `ListMessages` filter + ORDER BY |
| `idx_chunk_file_position` | chunk | `file, position` | `GetChunks` filter + ORDER BY |
| `idx_job_file` | pipeline_job | `file` | `CancelJobsForFile` |

Removed: `idx_chunk_file` (superseded by composite), `idx_message_conversation` (superseded by composite).

### N+1 Fix (`internal/db/queries_file.go`)

`RecomputeStems` previously did 1 SELECT + N individual UPDATEs. Now does 1 SELECT + 1 batched `BEGIN TRANSACTION; UPDATE ...; COMMIT TRANSACTION;`.

### Transactions (`internal/db/queries_file.go`, `internal/file/service.go`)

| Method | What's Atomic | Post-commit (best-effort) |
|--------|--------------|--------------------------|
| `DeleteFileAtomic` | wiki links, label edges, chunks, file record | stem collision resolution, blob delete, events |
| `MoveFileAtomic` | file path+stem update, folder creation | wiki-link recomputation, stem ambiguity |
| `MoveByPrefixAtomic` | file moves, stem recomputation, folder moves, ancestor creation | wiki-link raw_target recomputation |

## Test plan

- [x] `just build` passes
- [x] `just test` — all 31 packages pass (0 failures)
- [x] New integration tests: `TestDeleteFileAtomic`, `TestMoveFileAtomic`, `TestMoveByPrefixAtomic`
- [x] Existing `TestRecomputeStems` still passes with batched implementation
- [ ] Manual: import docs, delete/move files via API, verify no partial state

🤖 Generated with [Claude Code](https://claude.com/claude-code)