### PR TITLE
fix: browse TUI escape key, piping support, and picker improvements

### DIFF
--- a/cmd/know/cmd_browse.go
+++ b/cmd/know/cmd_browse.go
@@ -51,6 +51,8 @@ Examples:
   know browse                              # fuzzy search → TUI viewer
   know browse /docs/readme.md              # TUI viewer for specific file
   know browse /docs/readme.md | head       # print raw content (piped)
+  know browse | head                       # fuzzy pick → pipe content
+  know browse | wc -l                      # fuzzy pick → count lines
   know browse --viewer bat /docs/readme.md # view with bat
   know browse -e /docs/readme.md           # edit in $EDITOR
   know browse -e                           # fuzzy pick → edit`,
@@ -153,6 +155,15 @@ func browseWithPicker(ctx context.Context, client *apiclient.Client) error {
 		})
 	}
 
+	// When stdout is piped, pick on stderr and pipe content to stdout.
+	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
+	if !isTTY {
+		return pickAndDo(ctx, client, docs, func(_ string, doc *apiclient.Document) error {
+			fmt.Print(doc.Content)
+			return nil
+		}, tea.WithOutput(os.Stderr))
+	}
+
 	// Standard browse TUI.
 	isDark := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
 	model := browse.NewModel(client, *browseVaultID, docs, isDark)
@@ -164,8 +175,8 @@ func browseWithPicker(ctx context.Context, client *apiclient.Client) error {
 }
 
 // pickAndDo launches the fuzzy picker then runs action on the selected document.
-func pickAndDo(ctx context.Context, client *apiclient.Client, docs []models.FileEntry, action func(string, *apiclient.Document) error) error {
-	selected, err := pick.Run(docs)
+func pickAndDo(ctx context.Context, client *apiclient.Client, docs []models.FileEntry, action func(string, *apiclient.Document) error, opts ...tea.ProgramOption) error {
+	selected, err := pick.Run(docs, opts...)
 	if err != nil {
 		return fmt.Errorf("browse: %w", err)
 	}

--- a/internal/tui/browse/browser.go
+++ b/internal/tui/browse/browser.go
@@ -108,8 +108,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		m.finder.picker.Width = msg.Width
-		m.finder.picker.Height = msg.Height
+		m.finder.picker.SetSize(msg.Width, msg.Height)
 		m.updateRenderer()
 		if m.state == stateViewing {
 			m.viewer.width = msg.Width

--- a/internal/tui/browse/finder.go
+++ b/internal/tui/browse/finder.go
@@ -41,7 +41,7 @@ func (f finderModel) Update(msg tea.Msg) (finderModel, tea.Cmd) {
 				}
 			}
 			return f, nil
-		case "esc", "escape":
+		case "esc":
 			return f, tea.Quit
 		}
 	}

--- a/internal/tui/browse/viewer.go
+++ b/internal/tui/browse/viewer.go
@@ -32,7 +32,7 @@ func (v viewerModel) Update(msg tea.Msg) (viewerModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
 		switch msg.String() {
-		case "escape":
+		case "esc":
 			return v, func() tea.Msg { return backToFinderMsg{} }
 		case "q":
 			return v, tea.Quit

--- a/internal/tui/pick/picker.go
+++ b/internal/tui/pick/picker.go
@@ -40,29 +40,31 @@ func NewModel(files []models.FileEntry) Model {
 	ti := textinput.New()
 	ti.Placeholder = "Search files..."
 	ti.CharLimit = 256
-	ti.Prompt = PromptStyle.Render("/ ")
+	ti.Prompt = "/ "
 
 	styles := ti.Styles()
 	styles.Cursor.Blink = false
+	styles.Focused.Prompt = PromptStyle
 	ti.SetStyles(styles)
 
 	m := Model{
 		Input:    ti,
 		AllFiles: files,
 	}
+	m.Input.Focus()
 	m.Refilter()
 	return m
 }
 
 func (m Model) Init() tea.Cmd {
+	// Input is already focused from NewModel; re-call to get the focus cmd.
 	return m.Input.Focus()
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.Width = msg.Width
-		m.Height = msg.Height
+		m.SetSize(msg.Width, msg.Height)
 		return m, nil
 
 	case tea.KeyPressMsg:
@@ -73,7 +75,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.Selected = m.AllFiles[idx].Path
 			}
 			return m, tea.Quit
-		case "esc", "escape", "ctrl+c":
+		case "esc", "ctrl+c":
 			return m, tea.Quit
 		case "up":
 			if m.Cursor > 0 {
@@ -86,6 +88,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.Cursor++
 				m.EnsureCursorVisible()
 			}
+			return m, nil
+		case "pgup":
+			m.Cursor = max(m.Cursor-m.VisibleRows(), 0)
+			m.EnsureCursorVisible()
+			return m, nil
+		case "pgdown":
+			m.Cursor = min(m.Cursor+m.VisibleRows(), max(len(m.Matches)-1, 0))
+			m.EnsureCursorVisible()
 			return m, nil
 		}
 	}
@@ -144,6 +154,13 @@ func (m Model) View() tea.View {
 	return v
 }
 
+// SetSize updates the picker dimensions and propagates width to the text input.
+func (m *Model) SetSize(width, height int) {
+	m.Width = width
+	m.Height = height
+	m.Input.SetWidth(width - len(m.Input.Prompt))
+}
+
 func (m Model) VisibleRows() int {
 	return max(m.Height-4, 1)
 }
@@ -200,9 +217,9 @@ func RenderHighlighted(s string, matchedIndexes []int, baseStyle lipgloss.Style)
 
 // Run launches the fuzzy picker TUI and returns the selected file path.
 // Returns an empty string if the user cancelled (Escape/Ctrl+C).
-func Run(files []models.FileEntry) (string, error) {
+func Run(files []models.FileEntry, opts ...tea.ProgramOption) (string, error) {
 	m := NewModel(files)
-	p := tea.NewProgram(m)
+	p := tea.NewProgram(m, opts...)
 	final, err := p.Run()
 	if err != nil {
 		return "", fmt.Errorf("pick: %w", err)

--- a/internal/tui/pick/picker_test.go
+++ b/internal/tui/pick/picker_test.go
@@ -250,6 +250,76 @@ func TestRefilter_NoFiles(t *testing.T) {
 	}
 }
 
+func TestNewModel_InputFocused(t *testing.T) {
+	m := NewModel(testFiles)
+	if !m.Input.Focused() {
+		t.Error("expected input to be focused after NewModel")
+	}
+}
+
+func TestSetSize_PropagatesWidthToInput(t *testing.T) {
+	m := NewModel(testFiles)
+	m.SetSize(120, 40)
+
+	if m.Width != 120 || m.Height != 40 {
+		t.Errorf("size = %dx%d, want 120x40", m.Width, m.Height)
+	}
+
+	wantInputWidth := 120 - len(m.Input.Prompt)
+	if got := m.Input.Width(); got != wantInputWidth {
+		t.Errorf("Input.Width() = %d, want %d", got, wantInputWidth)
+	}
+}
+
+func TestUpdate_PageDown_MovesFullPage(t *testing.T) {
+	m := NewModel(testFiles) // 4 files
+	m.Height = 6             // visibleRows = max(6-4, 1) = 2
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
+	m = result.(Model)
+
+	if m.Cursor != 2 {
+		t.Errorf("after pgdown: cursor = %d, want 2", m.Cursor)
+	}
+}
+
+func TestUpdate_PageDown_ClampsAtEnd(t *testing.T) {
+	m := NewModel(testFiles) // 4 files
+	m.Cursor = 3
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
+	m = result.(Model)
+
+	if m.Cursor != 3 {
+		t.Errorf("pgdown at end: cursor = %d, want 3", m.Cursor)
+	}
+}
+
+func TestUpdate_PageUp_MovesFullPage(t *testing.T) {
+	m := NewModel(testFiles) // 4 files
+	m.Height = 6             // visibleRows = 2
+	m.Cursor = 3
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyPgUp})
+	m = result.(Model)
+
+	if m.Cursor != 1 {
+		t.Errorf("after pgup: cursor = %d, want 1", m.Cursor)
+	}
+}
+
+func TestUpdate_PageUp_ClampsAtStart(t *testing.T) {
+	m := NewModel(testFiles)
+	m.Cursor = 0
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyPgUp})
+	m = result.(Model)
+
+	if m.Cursor != 0 {
+		t.Errorf("pgup at start: cursor = %d, want 0", m.Cursor)
+	}
+}
+
 func TestUpdate_Enter_WithCursorAtSecondItem(t *testing.T) {
 	m := NewModel(testFiles)
 	m.Cursor = 1


### PR DESCRIPTION
Fix several issues with `know browse` TUI and add piping support.

## New Features
- Piping support: `know browse | head` renders picker on stderr, pipes selected file content to stdout
- Page up/down scrolling in file picker

## Bug Fixes
- ESC key not working in viewer (bubbletea v2 returns `"esc"` not `"escape"`)
- Fuzzy search text input not responding (Focus() lost through value-receiver Init() chain)
- Search placeholder truncated to 1 char (textinput width not propagated on WindowSizeMsg)
- Prompt style eating input width (pre-rendered ANSI in prompt string)

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)