### PR TITLE
feat: incremental sync endpoint with iOS catch-up on reconnect

### DIFF
--- a/docs/feature-apple-app.md
+++ b/docs/feature-apple-app.md
@@ -93,8 +93,9 @@ The app communicates with the Know server via REST API (`RESTClient.swift`). No 
 
 1. **Initial sync**: `GET /api/ls?vault=&recursive=true` fetches all file paths, populates SwiftData cache
 2. **On-demand content**: document body fetched via `GET /api/documents` when user opens it
-3. **Real-time updates**: SSE stream at `GET /events?vaultId=` for document create/update/delete/move events
-4. **Offline support**: SwiftData caches document metadata and content for offline browsing
+3. **Real-time updates**: SSE stream at `GET /events?vaultId=` for `file.created`, `file.updated`, `file.deleted`, `file.moved`, and `file.processed` events
+4. **Reconnect recovery**: On SSE reconnect, calls `GET /api/vaults/{vault}/changes?since=<lastSyncedAt>` for incremental catch-up. Falls back to full metadata sync if incremental sync fails.
+5. **Offline support**: SwiftData caches document metadata and content for offline browsing
 
 ### Auth Flow
 

--- a/internal/api/changes.go
+++ b/internal/api/changes.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/db"
+	"github.com/raphi011/know/internal/httputil"
+	"github.com/raphi011/know/internal/logutil"
+	"github.com/raphi011/know/internal/models"
+)
+
+func (s *Server) getChanges(w http.ResponseWriter, r *http.Request) {
+	sinceStr := r.URL.Query().Get("since")
+	if sinceStr == "" {
+		httputil.WriteProblem(w, http.StatusBadRequest, "since query parameter required (RFC3339)")
+		return
+	}
+
+	since, err := time.Parse(time.RFC3339Nano, sinceStr)
+	if err != nil {
+		httputil.WriteProblem(w, http.StatusBadRequest, "invalid since timestamp: expected RFC3339 format")
+		return
+	}
+
+	ctx := r.Context()
+	vaultID := auth.MustVaultIDFromCtx(ctx)
+	logger := logutil.FromCtx(ctx)
+
+	// Capture sync token before queries to avoid missing concurrent changes.
+	syncToken := time.Now().UTC()
+
+	// Fetch files updated since the given timestamp.
+	notFolder := false
+	files, err := s.app.DBClient().ListFiles(ctx, db.ListFilesFilter{
+		VaultID:      vaultID,
+		IsFolder:     &notFolder,
+		UpdatedSince: &since,
+		OrderBy:      db.OrderByUpdatedAtAsc,
+		Limit:        10000,
+	})
+	if err != nil {
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list changed files")
+		logger.Error("get changes: list files", "vault_id", vaultID, "since", since, "error", err)
+		return
+	}
+
+	updated := make([]FileChange, 0, len(files))
+	for _, f := range files {
+		fileID, idErr := models.RecordIDString(f.ID)
+		if idErr != nil {
+			logger.Error("get changes: extract file ID", "vault_id", vaultID, "path", f.Path, "error", idErr)
+			httputil.WriteProblem(w, http.StatusInternalServerError, "internal error processing changed files")
+			return
+		}
+		updated = append(updated, FileChange{
+			FileID:      fileID,
+			Path:        f.Path,
+			ContentHash: f.ContentHash,
+			UpdatedAt:   f.UpdatedAt,
+		})
+	}
+
+	// Fetch tombstones (deleted files) since the given timestamp.
+	tombstones, err := s.app.DBClient().ListTombstonesSince(ctx, vaultID, since)
+	if err != nil {
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list deleted files")
+		logger.Error("get changes: list tombstones", "vault_id", vaultID, "since", since, "error", err)
+		return
+	}
+
+	deleted := make([]FileChange, 0, len(tombstones))
+	for _, t := range tombstones {
+		deleted = append(deleted, FileChange{
+			FileID:    t.FileID,
+			Path:      t.Path,
+			UpdatedAt: t.DeletedAt,
+		})
+	}
+
+	const maxResults = 10000
+	truncated := len(files) >= maxResults || len(tombstones) >= maxResults
+
+	writeJSON(w, http.StatusOK, ChangesResponse{
+		Updated:   updated,
+		Deleted:   deleted,
+		SyncToken: syncToken.Format(time.RFC3339Nano),
+		Truncated: truncated,
+	})
+}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -41,6 +41,8 @@ tags:
     description: Binary asset upload, download, and metadata
   - name: External Links
     description: Outgoing link stats and listing
+  - name: Changes
+    description: Incremental sync (changes since timestamp)
   - name: Conversations
     description: Agent conversation CRUD
   - name: Agent
@@ -503,6 +505,48 @@ components:
           type: string
         count:
           type: integer
+
+    ChangesResponse:
+      type: object
+      required: [updated, deleted, syncToken, truncated]
+      properties:
+        updated:
+          type: array
+          items:
+            $ref: "#/components/schemas/FileChange"
+          description: Files created or modified since the given timestamp
+        deleted:
+          type: array
+          items:
+            $ref: "#/components/schemas/FileChange"
+          description: Files deleted since the given timestamp (from tombstones)
+        syncToken:
+          type: string
+          format: date-time
+          description: "RFC3339Nano timestamp — pass as the next `since` value"
+          example: "2026-03-19T14:30:00.123456789Z"
+        truncated:
+          type: boolean
+          description: "True if results were capped at the server limit (client should fall back to full sync)"
+
+    FileChange:
+      type: object
+      required: [fileId, path, updatedAt]
+      properties:
+        fileId:
+          type: string
+          description: File record ID
+        path:
+          type: string
+          description: Vault-relative file path
+          example: "/notes/hello.md"
+        contentHash:
+          type: [string, "null"]
+          description: "Content hash (present for updated files, absent for deleted)"
+        updatedAt:
+          type: string
+          format: date-time
+          description: "When the change occurred (updated_at for updates, deleted_at for deletions)"
 
     ExternalLinkListResponse:
       type: object
@@ -1736,6 +1780,40 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ExternalLinkStatsResponse"
+
+  # ── Changes (incremental sync) ──────────────────────────
+  /vaults/{vault}/changes:
+    get:
+      tags: [Changes]
+      summary: Incremental changes since timestamp
+      description: |
+        Returns files updated and deleted since a given timestamp, for efficient
+        incremental sync. The response includes a `syncToken` to use as the next
+        `since` value. If `truncated` is true, results were capped and the client
+        should fall back to a full metadata sync.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+        - name: since
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+          description: "RFC3339 timestamp — return changes at or after this time"
+          example: "2026-03-19T14:00:00Z"
+      responses:
+        "200":
+          description: Incremental changes
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChangesResponse"
+        "400":
+          description: Missing or invalid `since` parameter
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
 
   # ── SSE Events ──────────────────────────────────────────
   /vaults/{vault}/events:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -90,6 +90,9 @@ func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Han
 	mux.Handle("GET /api/v1/vaults/{vault}/external-links", vs(s.listExternalLinks))
 	mux.Handle("GET /api/v1/vaults/{vault}/external-links/stats", vs(s.externalLinkStats))
 
+	// --- Changes (incremental sync) ---
+	mux.Handle("GET /api/v1/vaults/{vault}/changes", vs(s.getChanges))
+
 	// --- SSE (document change stream, vault-scoped) ---
 	// Registered in cmd_serve.go since it depends on the event bus.
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -155,6 +155,22 @@ type VersionResponse struct {
 	CreatedAt   time.Time `json:"createdAt"`
 }
 
+// ChangesResponse is the JSON representation of incremental changes since a timestamp.
+type ChangesResponse struct {
+	Updated   []FileChange `json:"updated"`
+	Deleted   []FileChange `json:"deleted"`
+	SyncToken string       `json:"syncToken"`  // RFC3339Nano — use as next "since" value
+	Truncated bool         `json:"truncated"`   // true if results were capped at the server limit
+}
+
+// FileChange represents a single file change in the changes response.
+type FileChange struct {
+	FileID      string    `json:"fileId"`
+	Path        string    `json:"path"`
+	ContentHash *string   `json:"contentHash,omitempty"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
 // ServerConfig holds the server's effective configuration.
 type ServerConfig struct {
 	Version                string `json:"version"`

--- a/internal/db/queries_file.go
+++ b/internal/db/queries_file.go
@@ -58,15 +58,16 @@ var validOrderBy = map[FileOrderBy]bool{
 
 // ListFilesFilter controls filtering, ordering, and pagination for file list queries.
 type ListFilesFilter struct {
-	VaultID  string
-	Folder   *string
-	Labels   []string
-	DocType  *string
-	MimeType *string
-	IsFolder *bool
-	OrderBy  FileOrderBy // defaults to OrderByPathAsc
-	Limit    int
-	Offset   int
+	VaultID      string
+	Folder       *string
+	Labels       []string
+	DocType      *string
+	MimeType     *string
+	IsFolder     *bool
+	UpdatedSince *time.Time  // only return files updated at or after this timestamp
+	OrderBy      FileOrderBy // defaults to OrderByPathAsc
+	Limit        int
+	Offset       int
 }
 
 // buildFileFilter constructs the WHERE clause, variables, and pagination
@@ -98,6 +99,12 @@ func buildFileFilter(filter ListFilesFilter) (whereClause string, vars map[strin
 	if filter.IsFolder != nil {
 		conditions = append(conditions, `is_folder = $is_folder`)
 		vars["is_folder"] = *filter.IsFolder
+	}
+	if filter.UpdatedSince != nil {
+		// Format as RFC3339Nano string — passing time.Time directly loses sub-second
+		// precision in the SurrealDB Go SDK's CBOR encoding.
+		conditions = append(conditions, `updated_at >= <datetime>$updated_since`)
+		vars["updated_since"] = filter.UpdatedSince.Format(time.RFC3339Nano)
 	}
 
 	limit := 100

--- a/internal/db/queries_file_test.go
+++ b/internal/db/queries_file_test.go
@@ -1497,3 +1497,82 @@ func TestListFiles_IsFolderFilter(t *testing.T) {
 		}
 	}
 }
+
+func TestListFiles_UpdatedSinceFilter(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+
+	// Create two files with a sleep between them so they get different updated_at values.
+	oldDoc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/since-" + suffix + "/old.md", Title: "Old",
+	})
+	if err != nil {
+		t.Fatalf("CreateFile old failed: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	newDoc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/since-" + suffix + "/new.md", Title: "New",
+	})
+	if err != nil {
+		t.Fatalf("CreateFile new failed: %v", err)
+	}
+
+	// Sanity check: new.UpdatedAt must be strictly after old.UpdatedAt
+	if !newDoc.UpdatedAt.After(oldDoc.UpdatedAt) {
+		t.Fatalf("new.UpdatedAt (%v) should be after old.UpdatedAt (%v)", newDoc.UpdatedAt, oldDoc.UpdatedAt)
+	}
+
+	// Verify the filter works with a far-future cutoff first.
+	folder := "/since-" + suffix + "/"
+	farFuture := time.Now().Add(24 * time.Hour)
+	farDocs, err := testDB.ListFiles(ctx, ListFilesFilter{
+		VaultID: vaultID, Folder: &folder, UpdatedSince: &farFuture,
+	})
+	if err != nil {
+		t.Fatalf("ListFiles with far-future cutoff failed: %v", err)
+	}
+	if len(farDocs) != 0 {
+		t.Fatalf("expected 0 docs with far-future cutoff, got %d", len(farDocs))
+	}
+
+	// Use a cutoff between the two timestamps.
+	mid := oldDoc.UpdatedAt.Add(newDoc.UpdatedAt.Sub(oldDoc.UpdatedAt) / 2)
+	cutoff := mid
+	docs, err := testDB.ListFiles(ctx, ListFilesFilter{
+		VaultID:      vaultID,
+		Folder:       &folder,
+		UpdatedSince: &cutoff,
+	})
+	if err != nil {
+		t.Fatalf("ListFiles with UpdatedSince failed: %v", err)
+	}
+	if len(docs) != 1 {
+		for _, d := range docs {
+			t.Logf("  doc: %s updated_at=%v", d.Path, d.UpdatedAt)
+		}
+		t.Logf("  cutoff=%v", cutoff)
+		t.Fatalf("expected 1 doc with UpdatedSince, got %d", len(docs))
+	}
+	if !strings.HasSuffix(docs[0].Path, "/new.md") {
+		t.Errorf("expected new.md, got %s", docs[0].Path)
+	}
+
+	// Query without UpdatedSince — should return both
+	allDocs, err := testDB.ListFiles(ctx, ListFilesFilter{
+		VaultID: vaultID,
+		Folder:  &folder,
+	})
+	if err != nil {
+		t.Fatalf("ListFiles without UpdatedSince failed: %v", err)
+	}
+	if len(allDocs) != 2 {
+		t.Errorf("expected 2 docs total, got %d", len(allDocs))
+	}
+}

--- a/internal/db/queries_tombstone.go
+++ b/internal/db/queries_tombstone.go
@@ -1,0 +1,43 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/raphi011/know/internal/models"
+	"github.com/surrealdb/surrealdb.go"
+)
+
+// ListTombstonesSince returns tombstones for a vault created after the given timestamp.
+func (c *Client) ListTombstonesSince(ctx context.Context, vaultID string, since time.Time) ([]models.FileTombstone, error) {
+	defer c.logOp(ctx, "tombstone.list_since", time.Now())
+
+	// Format as RFC3339Nano string — passing time.Time directly loses sub-second
+	// precision in the SurrealDB Go SDK's CBOR encoding.
+	sql := `SELECT * FROM file_tombstone WHERE vault = type::record("vault", $vault_id) AND deleted_at >= <datetime>$since ORDER BY deleted_at ASC LIMIT 10000`
+	results, err := surrealdb.Query[[]models.FileTombstone](ctx, c.DB(), sql, map[string]any{
+		"vault_id": bareID("vault", vaultID),
+		"since":    since.Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list tombstones since: %w", err)
+	}
+	return allResults(results), nil
+}
+
+// PurgeTombstonesBefore deletes tombstones older than the given timestamp.
+// Returns the number of deleted tombstones.
+func (c *Client) PurgeTombstonesBefore(ctx context.Context, vaultID string, before time.Time) (int, error) {
+	defer c.logOp(ctx, "tombstone.purge", time.Now())
+
+	sql := `DELETE FROM file_tombstone WHERE vault = type::record("vault", $vault_id) AND deleted_at < <datetime>$before RETURN BEFORE`
+	results, err := surrealdb.Query[[]models.FileTombstone](ctx, c.DB(), sql, map[string]any{
+		"vault_id": bareID("vault", vaultID),
+		"before":   before.Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("purge tombstones: %w", err)
+	}
+	return countResults(results), nil
+}

--- a/internal/db/queries_tombstone_test.go
+++ b/internal/db/queries_tombstone_test.go
@@ -1,0 +1,131 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/raphi011/know/internal/models"
+)
+
+func TestListTombstonesSince(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+
+	// Create and then delete a file — SurrealDB event creates a tombstone.
+	doc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/tombstone-" + suffix + "/deleted.md", Title: "Deleted",
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	beforeDelete := time.Now()
+	time.Sleep(10 * time.Millisecond)
+
+	if err := testDB.DeleteFile(ctx, docID); err != nil {
+		t.Fatalf("DeleteFile failed: %v", err)
+	}
+
+	// SurrealDB ASYNC events may take a moment to complete.
+	time.Sleep(100 * time.Millisecond)
+
+	// Query tombstones since before the delete.
+	tombstones, err := testDB.ListTombstonesSince(ctx, vaultID, beforeDelete)
+	if err != nil {
+		t.Fatalf("ListTombstonesSince failed: %v", err)
+	}
+
+	found := false
+	for _, ts := range tombstones {
+		if ts.Path == "/tombstone-"+suffix+"/deleted.md" {
+			found = true
+			if ts.FileID == "" {
+				t.Error("tombstone file_id should not be empty")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected tombstone for /tombstone-%s/deleted.md, got %d tombstones", suffix, len(tombstones))
+	}
+
+	// Query tombstones since a time well in the future — should return none.
+	future := time.Now().Add(time.Hour)
+	tombstones, err = testDB.ListTombstonesSince(ctx, vaultID, future)
+	if err != nil {
+		t.Fatalf("ListTombstonesSince (future) failed: %v", err)
+	}
+	for _, ts := range tombstones {
+		if ts.Path == "/tombstone-"+suffix+"/deleted.md" {
+			t.Error("tombstone should not appear when querying after deletion time")
+		}
+	}
+}
+
+func TestPurgeTombstonesBefore(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+
+	// Create and delete two files.
+	for i := range 2 {
+		doc, err := testDB.CreateFile(ctx, models.FileInput{
+			VaultID: vaultID, Path: fmt.Sprintf("/purge-%s/%d.md", suffix, i), Title: fmt.Sprintf("Purge %d", i),
+		})
+		if err != nil {
+			t.Fatalf("CreateFile %d failed: %v", i, err)
+		}
+		if err := testDB.DeleteFile(ctx, models.MustRecordIDString(doc.ID)); err != nil {
+			t.Fatalf("DeleteFile %d failed: %v", i, err)
+		}
+	}
+
+	// Wait for ASYNC SurrealDB events.
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify tombstones exist.
+	tombstones, err := testDB.ListTombstonesSince(ctx, vaultID, time.Time{})
+	if err != nil {
+		t.Fatalf("ListTombstonesSince failed: %v", err)
+	}
+	count := 0
+	for _, ts := range tombstones {
+		if ts.Path == fmt.Sprintf("/purge-%s/0.md", suffix) || ts.Path == fmt.Sprintf("/purge-%s/1.md", suffix) {
+			count++
+		}
+	}
+	if count < 2 {
+		t.Fatalf("expected at least 2 tombstones, found %d matching", count)
+	}
+
+	// Purge tombstones before a future time — should remove them.
+	purged, err := testDB.PurgeTombstonesBefore(ctx, vaultID, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("PurgeTombstonesBefore failed: %v", err)
+	}
+	if purged < 2 {
+		t.Errorf("expected at least 2 purged, got %d", purged)
+	}
+
+	// Verify tombstones are gone.
+	tombstones, err = testDB.ListTombstonesSince(ctx, vaultID, time.Time{})
+	if err != nil {
+		t.Fatalf("ListTombstonesSince after purge failed: %v", err)
+	}
+	for _, ts := range tombstones {
+		if ts.Path == fmt.Sprintf("/purge-%s/0.md", suffix) || ts.Path == fmt.Sprintf("/purge-%s/1.md", suffix) {
+			t.Errorf("tombstone %s should have been purged", ts.Path)
+		}
+	}
+}

--- a/internal/models/file.go
+++ b/internal/models/file.go
@@ -95,6 +95,15 @@ type LabelCount struct {
 	Count int    `json:"count"`
 }
 
+// FileTombstone records a deleted file for sync purposes.
+type FileTombstone struct {
+	ID        surrealmodels.RecordID `json:"id"`
+	Vault     surrealmodels.RecordID `json:"vault"`
+	FileID    string                 `json:"file_id"`
+	Path      string                 `json:"path"`
+	DeletedAt time.Time              `json:"deleted_at"`
+}
+
 // FileEntry is a lightweight entry for directory listings (ls endpoint).
 type FileEntry struct {
 	Name  string `json:"name"`

--- a/ios/Models/Document.swift
+++ b/ios/Models/Document.swift
@@ -75,3 +75,29 @@ struct ChunkMatch: Codable, Identifiable {
 
     var id: Int { position }
 }
+
+// MARK: - Incremental Sync
+
+struct ChangesResponse: Codable {
+    let updated: [FileChange]
+    let deleted: [FileChange]
+    let syncToken: String
+    let truncated: Bool
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        updated = try container.decodeIfPresent([FileChange].self, forKey: .updated) ?? []
+        deleted = try container.decodeIfPresent([FileChange].self, forKey: .deleted) ?? []
+        syncToken = try container.decode(String.self, forKey: .syncToken)
+        truncated = try container.decodeIfPresent(Bool.self, forKey: .truncated) ?? false
+    }
+}
+
+struct FileChange: Codable, Identifiable {
+    let fileId: String
+    let path: String
+    let contentHash: String?
+    let updatedAt: Date
+
+    var id: String { fileId }
+}

--- a/ios/Services/KnowService.swift
+++ b/ios/Services/KnowService.swift
@@ -47,6 +47,16 @@ final class KnowService: Sendable {
 		)
 	}
 
+	func fetchChanges(vaultId: String, since: Date) async throws -> ChangesResponse {
+		let formatter = ISO8601DateFormatter()
+		formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+		let sinceStr = formatter.string(from: since)
+		return try await client.get(
+			path: "api/vaults/\(vaultId)/changes",
+			query: ["since": sinceStr]
+		)
+	}
+
 	func search(vaultId: String, query: String, labels: [String]? = nil, limit: Int? = nil) async throws -> [SearchResult] {
 		var params = ["vault": vaultId, "query": query]
 		if let labels, !labels.isEmpty {

--- a/ios/Services/SyncEngine.swift
+++ b/ios/Services/SyncEngine.swift
@@ -86,6 +86,93 @@ final class SyncEngine {
 		}
 	}
 
+	// MARK: - Incremental Sync
+
+	/// Fetches only changes since the last sync via GET /changes and applies them.
+	/// Returns true on success, false if the caller should fall back to full metadata sync.
+	func performIncrementalSync(vaultId: String, modelContext: ModelContext) async -> Bool {
+		guard let service else {
+			logger.warning("SyncEngine: no service configured")
+			return false
+		}
+
+		status = .syncing("Catching up...")
+		defer { if case .syncing = status { status = .idle } }
+
+		do {
+			let syncState = try fetchOrCreateSyncState(vaultId: vaultId, modelContext: modelContext)
+			guard let lastSynced = syncState.lastSyncedAt else {
+				logger.info("Incremental sync: no lastSyncedAt, falling back to full sync")
+				return false
+			}
+
+			let changes = try await service.fetchChanges(vaultId: vaultId, since: lastSynced)
+
+			// If results were truncated, fall back to full sync for completeness.
+			if changes.truncated {
+				logger.info("Incremental sync: results truncated, falling back to full sync")
+				return false
+			}
+
+			// Fetch all cached documents for this vault to avoid N+1 fetches.
+			let vid = vaultId
+			let allDescriptor = FetchDescriptor<CachedDocument>(
+				predicate: #Predicate { $0.vaultId == vid }
+			)
+			let cached = try modelContext.fetch(allDescriptor)
+			let cachedByCompositeId = Dictionary(uniqueKeysWithValues: cached.map { ($0.id, $0) })
+
+			// Apply updated files
+			for change in changes.updated {
+				let compositeId = CachedDocument.compositeId(vaultId: vaultId, path: change.path)
+				if let existing = cachedByCompositeId[compositeId] {
+					existing.contentHash = change.contentHash
+					existing.lastSyncedAt = .now
+					existing.invalidateContent()
+				} else {
+					let doc = CachedDocument(
+						id: compositeId,
+						vaultId: vaultId,
+						path: change.path,
+						title: CachedDocument.titleFromPath(change.path),
+						contentHash: change.contentHash,
+						serverUpdatedAt: change.updatedAt,
+						lastSyncedAt: .now
+					)
+					modelContext.insert(doc)
+				}
+			}
+
+			// Apply deleted files
+			for change in changes.deleted {
+				let compositeId = CachedDocument.compositeId(vaultId: vaultId, path: change.path)
+				if let existing = cachedByCompositeId[compositeId] {
+					modelContext.delete(existing)
+				}
+			}
+
+			// Parse syncToken and update state
+			let formatter = ISO8601DateFormatter()
+			formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+			guard let tokenDate = formatter.date(from: changes.syncToken) else {
+				logger.error("Incremental sync: failed to parse syncToken '\(changes.syncToken)', falling back to full sync")
+				return false
+			}
+			syncState.lastSyncedAt = tokenDate
+
+			try modelContext.save()
+			logger.info("Incremental sync complete: \(changes.updated.count) updated, \(changes.deleted.count) deleted")
+			return true
+		} catch APIError.unauthorized {
+			logger.error("Incremental sync: unauthorized")
+			status = .error("Unauthorized")
+			return false
+		} catch {
+			logger.warning("Incremental sync failed: \(error), falling back to full sync")
+			return false
+		}
+	}
+
 	// MARK: - On-Demand Content
 
 	func fetchContentIfNeeded(documentId: String, modelContext: ModelContext) async throws -> CachedDocument? {
@@ -175,6 +262,13 @@ final class SyncEngine {
 
 					retryDelay = 1 // reset on success
 
+					// Catch up on any events missed during the disconnect gap.
+					// Try incremental sync first, fall back to full metadata sync.
+					let synced = await performIncrementalSync(vaultId: vaultId, modelContext: modelContext)
+					if !synced {
+						await performMetadataSync(vaultId: vaultId, modelContext: modelContext)
+					}
+
 					var dataBuffer = ""
 
 					for try await line in bytes.lines {
@@ -241,7 +335,7 @@ final class SyncEngine {
 
 		do {
 			switch event.type {
-			case "document.created", "document.updated":
+			case "file.created", "file.updated", "file.processed":
 				guard let path = event.payload.path else {
 					logger.warning("SSE: \(event.type) event missing path, skipping")
 					return
@@ -268,17 +362,17 @@ final class SyncEngine {
 					modelContext.insert(doc)
 				}
 
-			case "document.deleted":
+			case "file.deleted":
 				guard let path = event.payload.path else {
-					logger.warning("SSE: document.deleted event missing path, skipping")
+					logger.warning("SSE: file.deleted event missing path, skipping")
 					return
 				}
 				let compositeId = CachedDocument.compositeId(vaultId: vaultId, path: path)
 				try deleteCachedDocument(compositeId: compositeId, modelContext: modelContext)
 
-			case "document.moved":
+			case "file.moved":
 				guard let path = event.payload.path, let oldPath = event.payload.oldPath else {
-					logger.warning("SSE: document.moved event missing path or oldPath, skipping")
+					logger.warning("SSE: file.moved event missing path or oldPath, skipping")
 					return
 				}
 				let oldCompositeId = CachedDocument.compositeId(vaultId: vaultId, path: oldPath)
@@ -290,7 +384,7 @@ final class SyncEngine {
 					modelContext.delete(existing)
 					modelContext.insert(moved)
 				} else {
-					logger.info("SSE: document.moved but \(oldPath) not in local cache, skipping")
+					logger.info("SSE: file.moved but \(oldPath) not in local cache, skipping")
 				}
 
 			default:


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/vaults/{vault}/changes?since=` endpoint returning updated files + tombstones (deleted files) since a timestamp, with an opaque sync token for cursor-based pagination
- iOS `SyncEngine` calls this on SSE reconnect to catch up on missed events, falling back to full metadata sync if incremental sync fails or results are truncated
- Tombstone tracking via SurrealDB event on file deletion, with `PurgeTombstonesBefore` for cleanup
- SSE event names updated from `document.*` to `file.*`
- Uses RFC 9457 `WriteProblem` for all error responses and documented in `openapi.yaml`

## Changes

**Go backend:**
- `internal/api/changes.go` — New handler: parses `since` (RFC3339Nano), queries changed files + tombstones, returns `ChangesResponse` with truncation flag. Uses `httputil.WriteProblem` for errors.
- `internal/api/types.go` — `ChangesResponse` and `FileChange` types with `truncated` field
- `internal/api/server.go` — Route registration
- `internal/api/openapi.yaml` — `Changes` tag, `GET /vaults/{vault}/changes` path, `ChangesResponse` + `FileChange` schemas
- `internal/db/queries_file.go` — `UpdatedSince` filter on `ListFilesFilter`
- `internal/db/queries_tombstone.go` — `ListTombstonesSince` (with LIMIT 10000) and `PurgeTombstonesBefore`
- `internal/models/file.go` — `FileTombstone` struct

**iOS:**
- `ios/Models/Document.swift` — `ChangesResponse`/`FileChange` with nil-safe Codable decoding and `truncated` field
- `ios/Services/KnowService.swift` — `fetchChanges` API method
- `ios/Services/SyncEngine.swift` — `performIncrementalSync` with batch lookup (no N+1), truncation handling, auth error separation, UI status updates

**Tests:**
- `internal/db/queries_file_test.go` — `TestListFiles_UpdatedSinceFilter`
- `internal/db/queries_tombstone_test.go` — `TestListTombstonesSince`, `TestPurgeTombstonesBefore`

## Test plan

- [ ] `just test` passes
- [ ] Verify incremental sync round-trip: first call returns syncToken, second call with that token succeeds (RFC3339Nano)
- [ ] Verify truncation: >10k changes returns `truncated: true`, iOS falls back to full sync
- [ ] Verify tombstones: delete a file, call `/changes?since=<before>`, see it in `deleted`
- [ ] Verify SSE reconnect: disconnect/reconnect, confirm catch-up via incremental sync
- [ ] Verify OpenAPI docs render at `/` (Scalar UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)