### PR TITLE
feat: Scalar API docs, RFC 9457 errors, standardized list envelope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,8 @@ All env vars use the `KNOW_` prefix: `KNOW_LOG_LEVEL`, `KNOW_LOG_FILE`, etc.
 
 The server exposes a REST API at `/api/` for CLI and TUI communication, and agent endpoints at `/agent/`. Auth via `Authorization: Bearer` header.
 
+**IMPORTANT**: When adding, modifying, or removing REST API endpoints, always update the OpenAPI spec at `internal/api/openapi.yaml` to keep it in sync. This includes changes to routes, request/response schemas, query parameters, and error responses. The spec powers the interactive API docs served at `/`.
+
 All routes are registered in `internal/api/server.go` (REST) and `cmd/know/cmd_serve.go` (agent). Key resource groups:
 
 - **Vaults**: list, info, settings (get/patch)

--- a/cmd/know/cmd_remote.go
+++ b/cmd/know/cmd_remote.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/spf13/cobra"
 )
 
@@ -57,10 +58,11 @@ type remoteListResponse struct {
 func runRemoteList(_ *cobra.Command, _ []string) error {
 	client := remoteAPIFlags.newClient()
 
-	var remotes []remoteListResponse
-	if err := client.Get(context.Background(), "/api/v1/remotes", &remotes); err != nil {
+	var resp httputil.ListResponse[remoteListResponse]
+	if err := client.Get(context.Background(), "/api/v1/remotes", &resp); err != nil {
 		return fmt.Errorf("list remotes: %w", err)
 	}
+	remotes := resp.Items
 
 	if len(remotes) == 0 {
 		fmt.Println("No remotes configured.")

--- a/cmd/know/cmd_serve.go
+++ b/cmd/know/cmd_serve.go
@@ -184,6 +184,9 @@ func runServe(_ *cobra.Command, _ []string) error {
 	apiServer := api.NewServer(app)
 	apiServer.Register(mux, authMw, app.AgentRunner())
 
+	// API documentation (Scalar UI at /, spec at /api/v1/openapi.yaml)
+	api.RegisterDocs(mux)
+
 	// Document change events (SSE) — vault-scoped
 	// Uses the apiServer's vault scope middleware for consistent vault resolution.
 	mux.Handle("GET /api/v1/vaults/{vault}/events", authMw(apiServer.VaultScopeHandler(event.HandleEvents(app.EventBus()))))
@@ -342,6 +345,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 
 	go func() {
 		slog.Info("REST API available", "url", fmt.Sprintf("http://localhost:%s/api/v1/", port))
+		slog.Info("API docs available", "url", fmt.Sprintf("http://localhost:%s/", port))
 
 		if err := httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
 			slog.Error("server error", "error", err)

--- a/cmd/know/cmd_task.go
+++ b/cmd/know/cmd_task.go
@@ -94,7 +94,7 @@ func runTask(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("task: %w", err)
 	}
 
-	model := tui.NewTaskModel(client, *taskVaultID, filter, resp.Tasks)
+	model := tui.NewTaskModel(client, *taskVaultID, filter, resp.Items)
 	p := tea.NewProgram(model)
 	if _, err := p.Run(); err != nil {
 		return fmt.Errorf("task: %w", err)

--- a/docs/feature-api-docs.md
+++ b/docs/feature-api-docs.md
@@ -1,0 +1,38 @@
+# API Documentation (Scalar)
+
+Interactive API reference for the Know REST API, powered by [Scalar](https://github.com/scalar/scalar).
+
+## Access
+
+Open `http://localhost:<port>/` in your browser (default: `http://localhost:8484/`).
+
+The raw OpenAPI 3.1 spec is available at `/api/v1/openapi.yaml`.
+
+## Features
+
+- Browse all REST API endpoints grouped by resource
+- View request/response schemas with examples
+- Try API calls directly in the browser (enter your Bearer token in the auth section)
+- Dark mode by default
+
+## Architecture
+
+- **OpenAPI spec**: Hand-written YAML at `internal/api/openapi.yaml`, embedded in the binary via `go:embed`
+- **Scalar UI**: Loaded from CDN (`cdn.jsdelivr.net/npm/@scalar/api-reference`), no bundled JS
+- **Routes**: `GET /` (Scalar UI) and `GET /api/v1/openapi.yaml` (spec) — both unauthenticated
+- **Registration**: `api.RegisterDocs(mux)` in `cmd/know/cmd_serve.go`
+
+## Maintaining the Spec
+
+When adding, modifying, or removing REST API endpoints, update `internal/api/openapi.yaml`:
+
+1. Add/update the path under `paths:`
+2. Add any new request/response schemas under `components.schemas:`
+3. Run `just build` to verify the embedded spec compiles
+4. Open `http://localhost:8484/` to verify it renders correctly
+
+## Example Prompts
+
+- "Show me the API docs" → Open `http://localhost:8484/`
+- "What endpoints does Know have?" → Browse the Scalar UI or read `internal/api/openapi.yaml`
+- "Try searching for documents" → Use the Scalar "Try it" feature on `GET /vaults/{vault}/search`

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -32,13 +33,13 @@ type chatResponseBody struct {
 func (rn *Runner) HandleChat() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			httputil.WriteProblem(w, http.StatusMethodNotAllowed, "method not allowed")
 			return
 		}
 
 		ac, err := auth.FromContext(r.Context())
 		if err != nil {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			httputil.WriteProblem(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}
 
@@ -47,30 +48,30 @@ func (rn *Runner) HandleChat() http.HandlerFunc {
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			var maxBytesErr *http.MaxBytesError
 			if errors.As(err, &maxBytesErr) {
-				http.Error(w, "request body too large (max 50MB)", http.StatusRequestEntityTooLarge)
+				httputil.WriteProblem(w, http.StatusRequestEntityTooLarge, "request body too large (max 50MB)")
 				return
 			}
-			http.Error(w, "invalid request body", http.StatusBadRequest)
+			httputil.WriteProblem(w, http.StatusBadRequest, "invalid request body")
 			return
 		}
 
 		vaultID := auth.MustVaultIDFromCtx(r.Context())
 
 		if body.Content == "" {
-			http.Error(w, "content is required", http.StatusBadRequest)
+			httputil.WriteProblem(w, http.StatusBadRequest, "content is required")
 			return
 		}
 		if len(body.Attachments) > maxAttachments {
-			http.Error(w, fmt.Sprintf("too many attachments (max %d)", maxAttachments), http.StatusBadRequest)
+			httputil.WriteProblem(w, http.StatusBadRequest, fmt.Sprintf("too many attachments (max %d)", maxAttachments))
 			return
 		}
 		for _, att := range body.Attachments {
 			if att.Path == "" || att.Content == "" {
-				http.Error(w, "attachments must have non-empty path and content", http.StatusBadRequest)
+				httputil.WriteProblem(w, http.StatusBadRequest, "attachments must have non-empty path and content")
 				return
 			}
 			if att.Type != models.AttachmentTypeText && att.Type != models.AttachmentTypeImage {
-				http.Error(w, fmt.Sprintf("unsupported attachment type: %q", att.Type), http.StatusBadRequest)
+				httputil.WriteProblem(w, http.StatusBadRequest, fmt.Sprintf("unsupported attachment type: %q", att.Type))
 				return
 			}
 			if att.Type == models.AttachmentTypeImage {
@@ -78,14 +79,14 @@ func (rn *Runner) HandleChat() http.HandlerFunc {
 				case "image/png", "image/jpeg", "image/gif", "image/webp":
 					// valid
 				default:
-					http.Error(w, fmt.Sprintf("invalid mime type %q for image attachment %s", att.MimeType, att.Path), http.StatusBadRequest)
+					httputil.WriteProblem(w, http.StatusBadRequest, fmt.Sprintf("invalid mime type %q for image attachment %s", att.MimeType, att.Path))
 					return
 				}
 			}
 		}
 
 		if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleWrite); err != nil {
-			http.Error(w, "forbidden", http.StatusForbidden)
+			httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 			return
 		}
 
@@ -102,7 +103,7 @@ func (rn *Runner) HandleChat() http.HandlerFunc {
 		convID, err := rn.Start(r.Context(), req)
 		if err != nil {
 			logutil.FromCtx(r.Context()).Error("failed to start agent", "error", err)
-			http.Error(w, "failed to start agent", http.StatusInternalServerError)
+			httputil.WriteProblem(w, http.StatusInternalServerError, "failed to start agent")
 			return
 		}
 
@@ -122,18 +123,18 @@ func (rn *Runner) HandleChat() http.HandlerFunc {
 func (rn *Runner) HandleEvents() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			httputil.WriteProblem(w, http.StatusMethodNotAllowed, "method not allowed")
 			return
 		}
 
 		if _, err := auth.FromContext(r.Context()); err != nil {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			httputil.WriteProblem(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}
 
 		convID := r.PathValue("id")
 		if convID == "" {
-			http.Error(w, "conversation ID required", http.StatusBadRequest)
+			httputil.WriteProblem(w, http.StatusBadRequest, "conversation ID required")
 			return
 		}
 
@@ -144,22 +145,22 @@ func (rn *Runner) HandleEvents() http.HandlerFunc {
 			conv, dbErr := rn.db.GetConversation(r.Context(), convID)
 			if dbErr != nil {
 				logutil.FromCtx(r.Context()).Error("get conversation for events", "conversation_id", convID, "error", dbErr)
-				http.Error(w, "internal server error", http.StatusInternalServerError)
+				httputil.WriteProblem(w, http.StatusInternalServerError, "internal server error")
 				return
 			}
 			if conv == nil {
-				http.Error(w, "conversation not found", http.StatusNotFound)
+				httputil.WriteProblem(w, http.StatusNotFound, "conversation not found")
 				return
 			}
 			if conv.BgStatus == nil {
-				http.Error(w, "not a background task", http.StatusNotFound)
+				httputil.WriteProblem(w, http.StatusNotFound, "not a background task")
 				return
 			}
 
 			// Return terminal status as SSE
 			flusher, ok := w.(http.Flusher)
 			if !ok {
-				http.Error(w, "streaming not supported", http.StatusInternalServerError)
+				httputil.WriteProblem(w, http.StatusInternalServerError, "streaming not supported")
 				return
 			}
 			w.Header().Set("Content-Type", "text/event-stream")
@@ -178,7 +179,7 @@ func (rn *Runner) HandleEvents() http.HandlerFunc {
 				writeSSE(w, flusher, StreamEvent{Type: "error", Content: errMsg})
 			default:
 				// "running" but not in tasks map — race condition or server restart
-				http.Error(w, "task not available", http.StatusNotFound)
+				httputil.WriteProblem(w, http.StatusNotFound, "task not available")
 			}
 			return
 		}
@@ -187,7 +188,7 @@ func (rn *Runner) HandleEvents() http.HandlerFunc {
 		// Set up SSE
 		flusher, ok := w.(http.Flusher)
 		if !ok {
-			http.Error(w, "streaming not supported", http.StatusInternalServerError)
+			httputil.WriteProblem(w, http.StatusInternalServerError, "streaming not supported")
 			return
 		}
 
@@ -225,23 +226,23 @@ func (rn *Runner) HandleEvents() http.HandlerFunc {
 func (rn *Runner) HandleCancel() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			httputil.WriteProblem(w, http.StatusMethodNotAllowed, "method not allowed")
 			return
 		}
 
 		if _, err := auth.FromContext(r.Context()); err != nil {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			httputil.WriteProblem(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}
 
 		convID := r.PathValue("id")
 		if convID == "" {
-			http.Error(w, "conversation ID required", http.StatusBadRequest)
+			httputil.WriteProblem(w, http.StatusBadRequest, "conversation ID required")
 			return
 		}
 
 		if err := rn.Cancel(convID); err != nil {
-			http.Error(w, "no running task for this conversation", http.StatusNotFound)
+			httputil.WriteProblem(w, http.StatusNotFound, "no running task for this conversation")
 			return
 		}
 
@@ -276,25 +277,25 @@ type approvalRequestBody struct {
 func (rn *Runner) HandleApproval() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			httputil.WriteProblem(w, http.StatusMethodNotAllowed, "method not allowed")
 			return
 		}
 
 		ac, err := auth.FromContext(r.Context())
 		if err != nil {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			httputil.WriteProblem(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}
 
 		r.Body = http.MaxBytesReader(w, r.Body, 16*1024)
 		var body approvalRequestBody
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, "invalid request body", http.StatusBadRequest)
+			httputil.WriteProblem(w, http.StatusBadRequest, "invalid request body")
 			return
 		}
 
 		if body.ConversationID == "" || body.InterruptID == "" {
-			http.Error(w, "conversationId and interruptId are required", http.StatusBadRequest)
+			httputil.WriteProblem(w, http.StatusBadRequest, "conversationId and interruptId are required")
 			return
 		}
 
@@ -302,7 +303,7 @@ func (rn *Runner) HandleApproval() http.HandlerFunc {
 		case ApprovalApproveAll, ApprovalApproveHunks, ApprovalReject:
 			// valid
 		default:
-			http.Error(w, "invalid action", http.StatusBadRequest)
+			httputil.WriteProblem(w, http.StatusBadRequest, "invalid action")
 			return
 		}
 
@@ -310,22 +311,22 @@ func (rn *Runner) HandleApproval() http.HandlerFunc {
 		conv, dbErr := rn.db.GetConversation(r.Context(), body.ConversationID)
 		if dbErr != nil {
 			logutil.FromCtx(r.Context()).Error("get conversation for approval", "conversation_id", body.ConversationID, "error", dbErr)
-			http.Error(w, "internal server error", http.StatusInternalServerError)
+			httputil.WriteProblem(w, http.StatusInternalServerError, "internal server error")
 			return
 		}
 		if conv == nil {
-			http.Error(w, "conversation not found", http.StatusNotFound)
+			httputil.WriteProblem(w, http.StatusNotFound, "conversation not found")
 			return
 		}
 
 		vaultID, vaultErr := models.RecordIDString(conv.Vault)
 		if vaultErr != nil {
-			http.Error(w, "invalid vault reference", http.StatusInternalServerError)
+			httputil.WriteProblem(w, http.StatusInternalServerError, "invalid vault reference")
 			return
 		}
 
 		if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleWrite); err != nil {
-			http.Error(w, "forbidden", http.StatusForbidden)
+			httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 			return
 		}
 
@@ -341,7 +342,7 @@ func (rn *Runner) HandleApproval() http.HandlerFunc {
 		})
 		if resumeErr != nil {
 			logutil.FromCtx(r.Context()).Error("failed to resume agent", "error", resumeErr)
-			http.Error(w, "failed to resume agent", http.StatusInternalServerError)
+			httputil.WriteProblem(w, http.StatusInternalServerError, "failed to resume agent")
 			return
 		}
 

--- a/internal/api/assets.go
+++ b/internal/api/assets.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -17,38 +18,38 @@ func (s *Server) uploadAsset(w http.ResponseWriter, r *http.Request) {
 	// 32 MB max memory for multipart parsing
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
 		logger.Warn("parse multipart form", "error", err)
-		writeError(w, http.StatusBadRequest, "invalid multipart form")
+		httputil.WriteProblem(w, http.StatusBadRequest, "invalid multipart form")
 		return
 	}
 
 	vaultID := auth.MustVaultIDFromCtx(r.Context())
 	path := r.FormValue("path")
 	if path == "" {
-		writeError(w, http.StatusBadRequest, "path field is required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "path field is required")
 		return
 	}
 
 	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleWrite); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
 	if !models.IsImageFile(path) {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("unsupported image format: %s", path))
+		httputil.WriteProblem(w, http.StatusBadRequest, fmt.Sprintf("unsupported image format: %s", path))
 		return
 	}
 
 	file, _, err := r.FormFile("file")
 	if err != nil {
 		logger.Warn("form file extraction failed", "error", err)
-		writeError(w, http.StatusBadRequest, "file field is required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "file field is required")
 		return
 	}
 	defer file.Close()
 
 	data, err := io.ReadAll(file)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to read file")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to read file")
 		logger.Error("read upload file", "error", err)
 		return
 	}
@@ -59,7 +60,7 @@ func (s *Server) uploadAsset(w http.ResponseWriter, r *http.Request) {
 		Data:    data,
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to upload asset")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to upload asset")
 		logger.Error("upload asset", "error", err)
 		return
 	}
@@ -80,36 +81,36 @@ func (s *Server) getAsset(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Query().Get("path")
 
 	if path == "" {
-		writeError(w, http.StatusBadRequest, "path query parameter required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "path query parameter required")
 		return
 	}
 
 	asset, err := s.app.FileService().Get(r.Context(), vaultID, path)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get asset")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get asset")
 		logutil.FromCtx(r.Context()).Error("get asset", "error", err)
 		return
 	}
 	if asset == nil {
-		writeError(w, http.StatusNotFound, "asset not found")
+		httputil.WriteProblem(w, http.StatusNotFound, "asset not found")
 		return
 	}
 
 	if asset.ContentHash == nil {
-		writeError(w, http.StatusNotFound, "asset has no content")
+		httputil.WriteProblem(w, http.StatusNotFound, "asset has no content")
 		return
 	}
 
 	rc, err := s.app.BlobStore().Get(r.Context(), *asset.ContentHash)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to read asset data")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to read asset data")
 		logutil.FromCtx(r.Context()).Error("get asset blob", "hash", *asset.ContentHash, "error", err)
 		return
 	}
 	defer rc.Close()
 	data, err := io.ReadAll(rc)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to read asset data")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to read asset data")
 		logutil.FromCtx(r.Context()).Error("read asset blob", "error", err)
 		return
 	}
@@ -124,18 +125,18 @@ func (s *Server) getAssetMeta(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Query().Get("path")
 
 	if path == "" {
-		writeError(w, http.StatusBadRequest, "path query parameter required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "path query parameter required")
 		return
 	}
 
 	meta, err := s.app.FileService().GetMeta(r.Context(), vaultID, path)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get asset metadata")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get asset metadata")
 		logutil.FromCtx(r.Context()).Error("get asset meta", "error", err)
 		return
 	}
 	if meta == nil {
-		writeError(w, http.StatusNotFound, "asset not found")
+		httputil.WriteProblem(w, http.StatusNotFound, "asset not found")
 		return
 	}
 
@@ -155,12 +156,12 @@ func (s *Server) deleteAsset(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Query().Get("path")
 
 	if path == "" {
-		writeError(w, http.StatusBadRequest, "path query parameter required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "path query parameter required")
 		return
 	}
 
 	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleWrite); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
@@ -169,17 +170,17 @@ func (s *Server) deleteAsset(w http.ResponseWriter, r *http.Request) {
 	// Check existence first so we return 404 instead of silent 204
 	meta, err := s.app.FileService().GetMeta(r.Context(), vaultID, path)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to check asset")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to check asset")
 		logger.Error("delete asset: check existence", "error", err)
 		return
 	}
 	if meta == nil {
-		writeError(w, http.StatusNotFound, "asset not found")
+		httputil.WriteProblem(w, http.StatusNotFound, "asset not found")
 		return
 	}
 
 	if err := s.app.FileService().Delete(r.Context(), vaultID, path); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to delete asset")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to delete asset")
 		logger.Error("delete asset", "error", err)
 		return
 	}

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/raphi011/know/internal/auth"
 	"github.com/raphi011/know/internal/backup"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -32,7 +33,7 @@ func (s *Server) restoreBackup(w http.ResponseWriter, r *http.Request) {
 
 	authCtx, err := auth.FromContext(ctx)
 	if err != nil {
-		writeError(w, http.StatusUnauthorized, "authentication required")
+		httputil.WriteProblem(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
 
@@ -41,7 +42,7 @@ func (s *Server) restoreBackup(w http.ResponseWriter, r *http.Request) {
 
 	start := time.Now()
 	if err := backup.Restore(ctx, s.app.DBClient(), s.app.BlobStore(), s.app.VaultService(), authCtx.UserID, r.Body); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("restore failed: %v", err))
+		httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("restore failed: %v", err))
 		logger.Error("backup restore failed", "error", err)
 		return
 	}

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -37,30 +38,30 @@ func (s *Server) bulkUpload(w http.ResponseWriter, r *http.Request) {
 	// Use streaming multipart reader to avoid buffering the entire request in memory.
 	reader, err := r.MultipartReader()
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "expected multipart/form-data request")
+		httputil.WriteProblem(w, http.StatusBadRequest, "expected multipart/form-data request")
 		return
 	}
 
 	// First part must be "meta" with JSON metadata.
 	metaPart, err := reader.NextPart()
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "missing meta part")
+		httputil.WriteProblem(w, http.StatusBadRequest, "missing meta part")
 		return
 	}
 	if metaPart.FormName() != "meta" {
-		writeError(w, http.StatusBadRequest, "first part must be named 'meta'")
+		httputil.WriteProblem(w, http.StatusBadRequest, "first part must be named 'meta'")
 		return
 	}
 
 	var meta bulkMeta
 	if err := json.NewDecoder(metaPart).Decode(&meta); err != nil {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid meta JSON: %v", err))
+		httputil.WriteProblem(w, http.StatusBadRequest, fmt.Sprintf("invalid meta JSON: %v", err))
 		return
 	}
 	ctx := r.Context()
 	vaultID := auth.MustVaultIDFromCtx(ctx)
 	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 

--- a/internal/api/conversations.go
+++ b/internal/api/conversations.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -13,24 +14,24 @@ import (
 func (s *Server) listConversations(w http.ResponseWriter, r *http.Request) {
 	vaultID := r.URL.Query().Get("vault")
 	if vaultID == "" {
-		writeError(w, http.StatusBadRequest, "vault query parameter required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "vault query parameter required")
 		return
 	}
 
 	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
 	ac, err := auth.FromContext(r.Context())
 	if err != nil {
-		writeError(w, http.StatusUnauthorized, "unauthorized")
+		httputil.WriteProblem(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 
 	convs, err := s.app.DBClient().ListConversations(r.Context(), vaultID, ac.UserID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list conversations")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list conversations")
 		logutil.FromCtx(r.Context()).Error("list conversations", "error", err)
 		return
 	}
@@ -39,7 +40,7 @@ func (s *Server) listConversations(w http.ResponseWriter, r *http.Request) {
 	for i := range convs {
 		result[i] = conversationFromModel(&convs[i])
 	}
-	writeJSON(w, http.StatusOK, result)
+	writeJSON(w, http.StatusOK, httputil.NewListResponse(result, len(result)))
 }
 
 func (s *Server) getConversation(w http.ResponseWriter, r *http.Request) {
@@ -48,22 +49,22 @@ func (s *Server) getConversation(w http.ResponseWriter, r *http.Request) {
 
 	conv, err := s.app.DBClient().GetConversation(r.Context(), id)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get conversation")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get conversation")
 		logger.Error("get conversation", "error", err)
 		return
 	}
 	if conv == nil {
-		writeError(w, http.StatusNotFound, "conversation not found")
+		httputil.WriteProblem(w, http.StatusNotFound, "conversation not found")
 		return
 	}
 
 	vaultID, err := models.RecordIDString(conv.Vault)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "invalid vault ID")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "invalid vault ID")
 		return
 	}
 	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
@@ -71,7 +72,7 @@ func (s *Server) getConversation(w http.ResponseWriter, r *http.Request) {
 
 	msgs, err := s.app.DBClient().ListMessages(r.Context(), id)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list messages")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list messages")
 		logger.Error("list messages", "error", err)
 		return
 	}
@@ -93,24 +94,24 @@ func (s *Server) createConversation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if body.VaultID == "" {
-		writeError(w, http.StatusBadRequest, "vaultId is required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "vaultId is required")
 		return
 	}
 
 	if err := auth.RequireVaultRole(r.Context(), body.VaultID, models.RoleWrite); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
 	ac, err := auth.FromContext(r.Context())
 	if err != nil {
-		writeError(w, http.StatusUnauthorized, "unauthorized")
+		httputil.WriteProblem(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 
 	conv, err := s.app.DBClient().CreateConversation(r.Context(), body.VaultID, ac.UserID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to create conversation")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to create conversation")
 		logutil.FromCtx(r.Context()).Error("create conversation", "error", err)
 		return
 	}
@@ -126,27 +127,27 @@ func (s *Server) deleteConversation(w http.ResponseWriter, r *http.Request) {
 
 	conv, err := s.app.DBClient().GetConversation(r.Context(), id)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get conversation")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get conversation")
 		logger.Error("get conversation for delete", "error", err)
 		return
 	}
 	if conv == nil {
-		writeError(w, http.StatusNotFound, "conversation not found")
+		httputil.WriteProblem(w, http.StatusNotFound, "conversation not found")
 		return
 	}
 
 	vaultID, err := models.RecordIDString(conv.Vault)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "invalid vault ID")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "invalid vault ID")
 		return
 	}
 	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleWrite); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
 	if err := s.app.DBClient().DeleteConversation(r.Context(), id); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to delete conversation")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to delete conversation")
 		logger.Error("delete conversation", "error", err)
 		return
 	}
@@ -166,40 +167,40 @@ func (s *Server) renameConversation(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	logger := logutil.FromCtx(r.Context())
 	if body.Title == "" {
-		writeError(w, http.StatusBadRequest, "title is required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "title is required")
 		return
 	}
 
 	conv, err := s.app.DBClient().GetConversation(r.Context(), id)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get conversation")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get conversation")
 		logger.Error("get conversation for rename", "error", err)
 		return
 	}
 	if conv == nil {
-		writeError(w, http.StatusNotFound, "conversation not found")
+		httputil.WriteProblem(w, http.StatusNotFound, "conversation not found")
 		return
 	}
 
 	vaultID, err := models.RecordIDString(conv.Vault)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "invalid vault ID")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "invalid vault ID")
 		return
 	}
 	if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleWrite); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
 	if err := s.app.DBClient().UpdateConversationTitle(r.Context(), id, body.Title); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to rename conversation")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to rename conversation")
 		logger.Error("rename conversation", "error", err)
 		return
 	}
 
 	updated, err := s.app.DBClient().GetConversation(r.Context(), id)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get updated conversation")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get updated conversation")
 		logger.Error("get renamed conversation", "error", err)
 		return
 	}

--- a/internal/api/docs.go
+++ b/internal/api/docs.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	_ "embed"
+	"net/http"
+)
+
+//go:embed openapi.yaml
+var openapiSpec []byte
+
+//go:embed docs.html
+var docsHTML []byte
+
+// RegisterDocs registers the API documentation endpoints (unauthenticated).
+// GET /              — Scalar API reference UI
+// GET /api/v1/openapi.yaml — OpenAPI 3.1 spec
+func RegisterDocs(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/openapi.yaml", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		_, _ = w.Write(openapiSpec) // client disconnected — nothing to do
+	})
+	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write(docsHTML) // client disconnected — nothing to do
+	})
+}

--- a/internal/api/docs.html
+++ b/internal/api/docs.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <title>Know API Reference</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+    <div id="app"></div>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.28.12"></script>
+    <script>
+        Scalar.createApiReference('#app', {
+            url: '/api/v1/openapi.yaml',
+            darkMode: true,
+            authentication: {
+                preferredSecurityScheme: 'BearerAuth'
+            }
+        })
+    </script>
+</body>
+</html>

--- a/internal/api/docs_test.go
+++ b/internal/api/docs_test.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.yaml.in/yaml/v2"
+)
+
+func TestEmbeddedOpenAPISpecIsValidYAML(t *testing.T) {
+	if len(openapiSpec) == 0 {
+		t.Fatal("embedded openapi.yaml is empty")
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(openapiSpec, &doc); err != nil {
+		t.Fatalf("openapi.yaml is not valid YAML: %v", err)
+	}
+	if _, ok := doc["openapi"]; !ok {
+		t.Fatal("openapi.yaml missing 'openapi' version field")
+	}
+	if _, ok := doc["paths"]; !ok {
+		t.Fatal("openapi.yaml missing 'paths' field")
+	}
+}
+
+func TestDocsEndpoints(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterDocs(mux)
+
+	t.Run("GET /api/v1/openapi.yaml", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/openapi.yaml", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		ct := rec.Header().Get("Content-Type")
+		if ct != "application/yaml" {
+			t.Fatalf("expected Content-Type application/yaml, got %q", ct)
+		}
+		if rec.Body.Len() == 0 {
+			t.Fatal("response body is empty")
+		}
+	})
+
+	t.Run("GET /", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		ct := rec.Header().Get("Content-Type")
+		if ct != "text/html; charset=utf-8" {
+			t.Fatalf("expected Content-Type text/html; charset=utf-8, got %q", ct)
+		}
+		body := rec.Body.String()
+		if len(body) == 0 {
+			t.Fatal("response body is empty")
+		}
+		if !strings.Contains(body, "scalar") && !strings.Contains(body, "Scalar") {
+			t.Fatal("HTML does not reference Scalar")
+		}
+	})
+}

--- a/internal/api/export.go
+++ b/internal/api/export.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/raphi011/know/internal/auth"
 	"github.com/raphi011/know/internal/db"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -37,7 +38,7 @@ func (s *Server) export(w http.ResponseWriter, r *http.Request) {
 			Offset:   offset,
 		})
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, fmt.Sprintf("list files: %v", err))
+			httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("list files: %v", err))
 			return
 		}
 		fileMetas = append(fileMetas, batch...)
@@ -49,7 +50,7 @@ func (s *Server) export(w http.ResponseWriter, r *http.Request) {
 	// Phase 2: Write tar.gz to temp file.
 	tmp, err := os.CreateTemp("", "know-export-*.tar.gz")
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("create temp file: %v", err))
+		httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("create temp file: %v", err))
 		return
 	}
 	defer os.Remove(tmp.Name())
@@ -61,7 +62,7 @@ func (s *Server) export(w http.ResponseWriter, r *http.Request) {
 	for _, meta := range fileMetas {
 		f, err := dbClient.GetFileByPath(ctx, vaultID, meta.Path)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, fmt.Sprintf("get file %s: %v", meta.Path, err))
+			httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("get file %s: %v", meta.Path, err))
 			return
 		}
 		if f == nil {
@@ -72,34 +73,34 @@ func (s *Server) export(w http.ResponseWriter, r *http.Request) {
 		if f.ContentHash != nil {
 			rc, err := s.app.BlobStore().Get(ctx, *f.ContentHash)
 			if err != nil {
-				writeError(w, http.StatusInternalServerError, fmt.Sprintf("read blob for %s: %v", meta.Path, err))
+				httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("read blob for %s: %v", meta.Path, err))
 				return
 			}
 			data, err = io.ReadAll(rc)
 			rc.Close()
 			if err != nil {
-				writeError(w, http.StatusInternalServerError, fmt.Sprintf("read blob data for %s: %v", meta.Path, err))
+				httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("read blob data for %s: %v", meta.Path, err))
 				return
 			}
 		}
 		if err := writeTarEntry(tw, f.Path, data, f.UpdatedAt); err != nil {
-			writeError(w, http.StatusInternalServerError, fmt.Sprintf("write file %s: %v", meta.Path, err))
+			httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("write file %s: %v", meta.Path, err))
 			return
 		}
 	}
 
 	if err := tw.Close(); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("close tar writer: %v", err))
+		httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("close tar writer: %v", err))
 		return
 	}
 	if err := gzw.Close(); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("close gzip writer: %v", err))
+		httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("close gzip writer: %v", err))
 		return
 	}
 
 	// Phase 3: Serve completed file.
 	if _, err := tmp.Seek(0, 0); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("seek temp file: %v", err))
+		httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("seek temp file: %v", err))
 		return
 	}
 

--- a/internal/api/export_epub.go
+++ b/internal/api/export_epub.go
@@ -13,6 +13,7 @@ import (
 	"github.com/raphi011/know/internal/auth"
 	"github.com/raphi011/know/internal/db"
 	"github.com/raphi011/know/internal/epub"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 )
 
@@ -23,7 +24,7 @@ func (s *Server) exportEPUB(w http.ResponseWriter, r *http.Request) {
 	vaultID := auth.MustVaultIDFromCtx(ctx)
 	filePath := r.URL.Query().Get("path")
 	if filePath == "" {
-		writeError(w, http.StatusBadRequest, "path query parameter is required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "path query parameter is required")
 		return
 	}
 
@@ -33,7 +34,7 @@ func (s *Server) exportEPUB(w http.ResponseWriter, r *http.Request) {
 	var chapters []epub.Chapter
 	f, err := dbClient.GetFileByPath(ctx, vaultID, filePath)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("get file: %v", err))
+		httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("get file: %v", err))
 		return
 	}
 
@@ -43,7 +44,7 @@ func (s *Server) exportEPUB(w http.ResponseWriter, r *http.Request) {
 		// Single document mode.
 		content, err := fileSvc.ReadFileContent(ctx, f)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, fmt.Sprintf("read content: %v", err))
+			httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("read content: %v", err))
 			return
 		}
 		chapters = append(chapters, epub.Chapter{
@@ -53,7 +54,7 @@ func (s *Server) exportEPUB(w http.ResponseWriter, r *http.Request) {
 		})
 	} else if f == nil && path.Ext(filePath) != "" {
 		// Specific file requested but not found.
-		writeError(w, http.StatusNotFound, fmt.Sprintf("document not found: %s", filePath))
+		httputil.WriteProblem(w, http.StatusNotFound, fmt.Sprintf("document not found: %s", filePath))
 		return
 	} else {
 		// Folder mode — list markdown files under this path.
@@ -74,7 +75,7 @@ func (s *Server) exportEPUB(w http.ResponseWriter, r *http.Request) {
 				Offset:   offset,
 			})
 			if err != nil {
-				writeError(w, http.StatusInternalServerError, fmt.Sprintf("list files: %v", err))
+				httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("list files: %v", err))
 				return
 			}
 			for _, file := range batch {
@@ -95,7 +96,7 @@ func (s *Server) exportEPUB(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if len(chapters) == 0 {
-			writeError(w, http.StatusNotFound, "no markdown files found at path")
+			httputil.WriteProblem(w, http.StatusNotFound, "no markdown files found at path")
 			return
 		}
 	}
@@ -119,7 +120,7 @@ func (s *Server) exportEPUB(w http.ResponseWriter, r *http.Request) {
 	// Resolve images.
 	images, err := s.resolveImages(ctx, vaultID, imagePaths, chapterDirs)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("resolve images: %v", err))
+		httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("resolve images: %v", err))
 		return
 	}
 
@@ -145,7 +146,7 @@ func (s *Server) exportEPUB(w http.ResponseWriter, r *http.Request) {
 
 	data, err := epub.Generate(opts, chapters, images)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("generate epub: %v", err))
+		httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("generate epub: %v", err))
 		return
 	}
 

--- a/internal/api/external_links.go
+++ b/internal/api/external_links.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/raphi011/know/internal/auth"
 	"github.com/raphi011/know/internal/db"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
-	"github.com/raphi011/know/internal/models"
 )
 
 func (s *Server) externalLinkStats(w http.ResponseWriter, r *http.Request) {
@@ -16,15 +16,11 @@ func (s *Server) externalLinkStats(w http.ResponseWriter, r *http.Request) {
 	stats, err := s.app.DBClient().GetExternalLinkStats(r.Context(), vaultID)
 	if err != nil {
 		logutil.FromCtx(r.Context()).Error("get external link stats", "vault_id", vaultID, "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to get external link stats")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get external link stats")
 		return
 	}
 
-	if stats == nil {
-		stats = []db.ExternalLinkHostStats{}
-	}
-
-	writeJSON(w, http.StatusOK, map[string]any{"stats": stats})
+	writeJSON(w, http.StatusOK, httputil.NewListResponse(stats, len(stats)))
 }
 
 func (s *Server) listExternalLinks(w http.ResponseWriter, r *http.Request) {
@@ -56,23 +52,16 @@ func (s *Server) listExternalLinks(w http.ResponseWriter, r *http.Request) {
 	links, err := s.app.DBClient().ListExternalLinks(r.Context(), filter)
 	if err != nil {
 		logger.Error("list external links", "vault_id", vaultID, "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to list external links")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list external links")
 		return
 	}
 
 	total, err := s.app.DBClient().CountExternalLinks(r.Context(), filter)
 	if err != nil {
 		logger.Error("count external links", "vault_id", vaultID, "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to count external links")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to count external links")
 		return
 	}
 
-	if links == nil {
-		links = []models.ExternalLink{}
-	}
-
-	writeJSON(w, http.StatusOK, map[string]any{
-		"links": links,
-		"total": total,
-	})
+	writeJSON(w, http.StatusOK, httputil.NewListResponse(links, total))
 }

--- a/internal/api/fetch.go
+++ b/internal/api/fetch.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 	"github.com/raphi011/know/internal/webclip"
@@ -27,7 +28,7 @@ func (s *Server) fetchWebpage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if strings.TrimSpace(req.URL) == "" {
-		writeError(w, http.StatusBadRequest, "url is required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "url is required")
 		return
 	}
 
@@ -36,7 +37,7 @@ func (s *Server) fetchWebpage(w http.ResponseWriter, r *http.Request) {
 	vaultID := auth.MustVaultIDFromCtx(ctx)
 
 	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
@@ -46,11 +47,11 @@ func (s *Server) fetchWebpage(w http.ResponseWriter, r *http.Request) {
 	v, err := s.app.DBClient().GetVault(ctx, vaultID)
 	if err != nil {
 		logger.Warn("fetch: load vault failed", "vault", vaultID, "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to load vault")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to load vault")
 		return
 	}
 	if v == nil {
-		writeError(w, http.StatusNotFound, "vault not found")
+		httputil.WriteProblem(w, http.StatusNotFound, "vault not found")
 		return
 	}
 	settings := v.Defaults()
@@ -58,7 +59,7 @@ func (s *Server) fetchWebpage(w http.ResponseWriter, r *http.Request) {
 	result, err := webclip.FetchAndSave(ctx, jinaClient, s.app.FileService(), vaultID, req.URL, req.Path, settings)
 	if err != nil {
 		logger.Warn("fetch: fetch and save failed", "url", req.URL, "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to fetch and save page")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to fetch and save page")
 		return
 	}
 

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/raphi011/know/internal/auth"
 	"github.com/raphi011/know/internal/db"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -16,7 +17,7 @@ func (s *Server) getDocument(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Query().Get("path")
 
 	if path == "" {
-		writeError(w, http.StatusBadRequest, "path query parameter required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "path query parameter required")
 		return
 	}
 
@@ -25,18 +26,18 @@ func (s *Server) getDocument(w http.ResponseWriter, r *http.Request) {
 
 	doc, err := s.app.DBClient().GetFileByPath(ctx, vaultID, path)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get document")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get document")
 		logger.Error("get document", "error", err)
 		return
 	}
 	if doc == nil {
-		writeError(w, http.StatusNotFound, "document not found")
+		httputil.WriteProblem(w, http.StatusNotFound, "document not found")
 		return
 	}
 
 	content, err := s.app.FileService().ReadFileContent(ctx, doc)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to read document content")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to read document content")
 		logger.Error("read document content", "error", err)
 		return
 	}
@@ -85,14 +86,14 @@ func (s *Server) upsertDocument(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if body.Path == "" {
-		writeError(w, http.StatusBadRequest, "path is required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "path is required")
 		return
 	}
 
 	ctx := r.Context()
 	vaultID := auth.MustVaultIDFromCtx(ctx)
 	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
@@ -104,7 +105,7 @@ func (s *Server) upsertDocument(w http.ResponseWriter, r *http.Request) {
 		Content: body.Content,
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to create/update document")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to create/update document")
 		logger.Error("upsert document", "error", err)
 		return
 	}
@@ -124,12 +125,12 @@ func (s *Server) deleteDocuments(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Query().Get("path")
 
 	if path == "" {
-		writeError(w, http.StatusBadRequest, "path query parameter required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "path query parameter required")
 		return
 	}
 
 	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
@@ -142,12 +143,12 @@ func (s *Server) deleteDocuments(w http.ResponseWriter, r *http.Request) {
 	// Check if path exists (documents and folders are in the same table)
 	doc, err := s.app.DBClient().GetFileByPath(ctx, vaultID, path)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to check file")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to check file")
 		logger.Error("delete documents: get file", "error", err)
 		return
 	}
 	if doc == nil {
-		writeError(w, http.StatusNotFound, "not found")
+		httputil.WriteProblem(w, http.StatusNotFound, "not found")
 		return
 	}
 
@@ -155,7 +156,7 @@ func (s *Server) deleteDocuments(w http.ResponseWriter, r *http.Request) {
 	if !doc.IsFolder {
 		if !dryRun {
 			if err := s.app.FileService().Delete(ctx, vaultID, path); err != nil {
-				writeError(w, http.StatusInternalServerError, "failed to delete document")
+				httputil.WriteProblem(w, http.StatusInternalServerError, "failed to delete document")
 				logger.Error("delete document", "path", path, "error", err)
 				return
 			}
@@ -169,7 +170,7 @@ func (s *Server) deleteDocuments(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !recursive {
-		writeError(w, http.StatusBadRequest, "path is a directory, use recursive=true")
+		httputil.WriteProblem(w, http.StatusBadRequest, "path is a directory, use recursive=true")
 		return
 	}
 
@@ -183,7 +184,7 @@ func (s *Server) deleteDocuments(w http.ResponseWriter, r *http.Request) {
 		Limit:    10000,
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list folder contents")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list folder contents")
 		logger.Error("delete documents: list metas", "error", err)
 		return
 	}
@@ -195,7 +196,7 @@ func (s *Server) deleteDocuments(w http.ResponseWriter, r *http.Request) {
 
 	if !dryRun {
 		if err := s.app.VaultService().DeleteFolder(ctx, vaultID, path); err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to delete folder")
+			httputil.WriteProblem(w, http.StatusInternalServerError, "failed to delete folder")
 			logger.Error("delete folder", "path", path, "error", err)
 			return
 		}
@@ -227,14 +228,14 @@ func (s *Server) move(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if body.Source == "" || body.Destination == "" {
-		writeError(w, http.StatusBadRequest, "source and destination are required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "source and destination are required")
 		return
 	}
 
 	ctx := r.Context()
 	vaultID := auth.MustVaultIDFromCtx(ctx)
 	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
@@ -242,7 +243,7 @@ func (s *Server) move(w http.ResponseWriter, r *http.Request) {
 	destination := models.NormalizePath(body.Destination)
 
 	if source == destination {
-		writeError(w, http.StatusBadRequest, "source and destination must be different")
+		httputil.WriteProblem(w, http.StatusBadRequest, "source and destination must be different")
 		return
 	}
 
@@ -251,31 +252,31 @@ func (s *Server) move(w http.ResponseWriter, r *http.Request) {
 	// Single lookup — documents and folders are in the same table
 	sourceFile, err := s.app.DBClient().GetFileByPath(ctx, vaultID, source)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to check source: %s", source))
+		httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("failed to check source: %s", source))
 		logger.Error("move: get source", "source", source, "error", err)
 		return
 	}
 	if sourceFile == nil {
-		writeError(w, http.StatusNotFound, fmt.Sprintf("source not found: %s", source))
+		httputil.WriteProblem(w, http.StatusNotFound, fmt.Sprintf("source not found: %s", source))
 		return
 	}
 
 	// Check for destination conflict (same table — covers both docs and folders)
 	existing, err := s.app.DBClient().GetFileByPath(ctx, vaultID, destination)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to check destination: %s", destination))
+		httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("failed to check destination: %s", destination))
 		logger.Error("move: check destination", "destination", destination, "error", err)
 		return
 	}
 	if existing != nil {
 		if sourceFile.IsFolder != existing.IsFolder {
 			if sourceFile.IsFolder {
-				writeError(w, http.StatusConflict, fmt.Sprintf("cannot move folder to existing document path: %s", destination))
+				httputil.WriteProblem(w, http.StatusConflict, fmt.Sprintf("cannot move folder to existing document path: %s", destination))
 			} else {
-				writeError(w, http.StatusConflict, fmt.Sprintf("cannot move document to existing folder path: %s", destination))
+				httputil.WriteProblem(w, http.StatusConflict, fmt.Sprintf("cannot move document to existing folder path: %s", destination))
 			}
 		} else {
-			writeError(w, http.StatusConflict, fmt.Sprintf("destination already exists: %s", destination))
+			httputil.WriteProblem(w, http.StatusConflict, fmt.Sprintf("destination already exists: %s", destination))
 		}
 		return
 	}
@@ -284,7 +285,7 @@ func (s *Server) move(w http.ResponseWriter, r *http.Request) {
 	if !sourceFile.IsFolder {
 		if !body.DryRun {
 			if _, err := s.app.FileService().Move(ctx, vaultID, source, destination); err != nil {
-				writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to move document: %s", source))
+				httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("failed to move document: %s", source))
 				logger.Error("move document", "source", source, "destination", destination, "error", err)
 				return
 			}
@@ -308,7 +309,7 @@ func (s *Server) move(w http.ResponseWriter, r *http.Request) {
 		Limit:    10000,
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to list folder contents: %s", source))
+		httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("failed to list folder contents: %s", source))
 		logger.Error("move: list metas", "source", source, "error", err)
 		return
 	}
@@ -320,7 +321,7 @@ func (s *Server) move(w http.ResponseWriter, r *http.Request) {
 
 	if !body.DryRun {
 		if err := s.app.VaultService().MoveFolder(ctx, vaultID, source, destination); err != nil {
-			writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to move folder: %s", source))
+			httputil.WriteProblem(w, http.StatusInternalServerError, fmt.Sprintf("failed to move folder: %s", source))
 			logger.Error("move folder", "source", source, "destination", destination, "error", err)
 			return
 		}

--- a/internal/api/folders.go
+++ b/internal/api/folders.go
@@ -5,6 +5,7 @@ import (
 	"path"
 
 	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 	"github.com/raphi011/know/internal/pathutil"
@@ -26,7 +27,7 @@ func (s *Server) listFolders(w http.ResponseWriter, r *http.Request) {
 
 	folders, err := s.app.DBClient().ListFolders(ctx, vaultID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list folders")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list folders")
 		logger.Error("list folders", "vault_id", vaultID, "error", err)
 		return
 	}
@@ -52,7 +53,7 @@ func (s *Server) listFolders(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, http.StatusOK, httputil.NewListResponse(resp, len(resp)))
 }
 
 func (s *Server) updateFolder(w http.ResponseWriter, r *http.Request) {
@@ -62,14 +63,14 @@ func (s *Server) updateFolder(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Path == "" {
-		writeError(w, http.StatusBadRequest, "path is required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "path is required")
 		return
 	}
 
 	ctx := r.Context()
 	vaultID := auth.MustVaultIDFromCtx(ctx)
 	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
@@ -80,12 +81,12 @@ func (s *Server) updateFolder(w http.ResponseWriter, r *http.Request) {
 
 	folder, err := db.GetFolderByPath(ctx, vaultID, req.Path)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get folder")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get folder")
 		logger.Error("update folder: get folder", "vault_id", vaultID, "path", req.Path, "error", err)
 		return
 	}
 	if folder == nil {
-		writeError(w, http.StatusNotFound, "folder not found")
+		httputil.WriteProblem(w, http.StatusNotFound, "folder not found")
 		return
 	}
 
@@ -93,14 +94,14 @@ func (s *Server) updateFolder(w http.ResponseWriter, r *http.Request) {
 
 	if req.NoEmbed != nil {
 		if err := db.SetFolderNoEmbed(ctx, vaultID, req.Path, *req.NoEmbed); err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to update folder")
+			httputil.WriteProblem(w, http.StatusInternalServerError, "failed to update folder")
 			logger.Error("update folder: set no_embed", "vault_id", vaultID, "path", req.Path, "error", err)
 			return
 		}
 		if *req.NoEmbed {
 			n, err := db.StripEmbeddingsByFolder(ctx, vaultID, req.Path)
 			if err != nil {
-				writeError(w, http.StatusInternalServerError, "failed to strip embeddings")
+				httputil.WriteProblem(w, http.StatusInternalServerError, "failed to strip embeddings")
 				logger.Error("update folder: strip embeddings", "vault_id", vaultID, "path", req.Path, "error", err)
 				return
 			}

--- a/internal/api/import.go
+++ b/internal/api/import.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/raphi011/know/internal/auth"
 	"github.com/raphi011/know/internal/blob"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -89,7 +90,7 @@ func (s *Server) importManifest(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	vaultID := auth.MustVaultIDFromCtx(ctx)
 	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
@@ -103,7 +104,7 @@ func (s *Server) importManifest(w http.ResponseWriter, r *http.Request) {
 	existingMap, err := s.app.DBClient().GetFileMetaByPaths(ctx, vaultID, paths)
 	if err != nil {
 		logger.Error("import manifest: batch query", "vault", vaultID, "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to check existing files")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to check existing files")
 		return
 	}
 
@@ -161,30 +162,30 @@ type importUploadMeta struct {
 func (s *Server) importUpload(w http.ResponseWriter, r *http.Request) {
 	reader, err := r.MultipartReader()
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "expected multipart/form-data request")
+		httputil.WriteProblem(w, http.StatusBadRequest, "expected multipart/form-data request")
 		return
 	}
 
 	// First part must be "meta" with JSON metadata including per-file hashes.
 	metaPart, err := reader.NextPart()
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "missing meta part")
+		httputil.WriteProblem(w, http.StatusBadRequest, "missing meta part")
 		return
 	}
 	if metaPart.FormName() != "meta" {
-		writeError(w, http.StatusBadRequest, "first part must be named 'meta'")
+		httputil.WriteProblem(w, http.StatusBadRequest, "first part must be named 'meta'")
 		return
 	}
 
 	var meta importUploadMeta
 	if err := json.NewDecoder(metaPart).Decode(&meta); err != nil {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid meta JSON: %v", err))
+		httputil.WriteProblem(w, http.StatusBadRequest, fmt.Sprintf("invalid meta JSON: %v", err))
 		return
 	}
 	ctx := r.Context()
 	vaultID := auth.MustVaultIDFromCtx(ctx)
 	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 

--- a/internal/api/jobs.go
+++ b/internal/api/jobs.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -30,7 +31,7 @@ func (s *Server) getJobStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	sinceDur, err := parseSinceDuration(sinceStr)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid since parameter: %q is not a valid duration", sinceStr))
+		httputil.WriteProblem(w, http.StatusBadRequest, fmt.Sprintf("invalid since parameter: %q is not a valid duration", sinceStr))
 		return
 	}
 	since := time.Now().Add(-sinceDur)
@@ -40,7 +41,7 @@ func (s *Server) getJobStatus(w http.ResponseWriter, r *http.Request) {
 	if v := r.URL.Query().Get("limit"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n <= 0 {
-			writeError(w, http.StatusBadRequest, "limit must be a positive integer")
+			httputil.WriteProblem(w, http.StatusBadRequest, "limit must be a positive integer")
 			return
 		}
 		limit = n
@@ -49,28 +50,28 @@ func (s *Server) getJobStatus(w http.ResponseWriter, r *http.Request) {
 	stats, err := db.GetJobStats(ctx, since)
 	if err != nil {
 		logger.Error("get job stats", "since", since, "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to get job stats")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get job stats")
 		return
 	}
 
 	active, err := db.ListRecentJobs(ctx, limit, []string{"running"})
 	if err != nil {
 		logger.Error("list active jobs", "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to list active jobs")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list active jobs")
 		return
 	}
 
 	recentFailed, err := db.ListRecentJobs(ctx, limit, []string{"failed"})
 	if err != nil {
 		logger.Error("list failed jobs", "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to list failed jobs")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list failed jobs")
 		return
 	}
 
 	durations, err := db.GetJobTypeDurations(ctx, since)
 	if err != nil {
 		logger.Error("get job type durations", "since", since, "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to get job durations")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get job durations")
 		return
 	}
 

--- a/internal/api/labels.go
+++ b/internal/api/labels.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 )
 
@@ -15,19 +16,19 @@ func (s *Server) listLabels(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Query().Get("counts") == "true" {
 		counts, err := s.app.DBClient().ListLabelsWithCounts(r.Context(), vaultID)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to list labels")
+			httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list labels")
 			logger.Error("list labels with counts", "vault_id", vaultID, "error", err)
 			return
 		}
-		writeJSON(w, http.StatusOK, counts)
+		writeJSON(w, http.StatusOK, httputil.NewListResponse(counts, len(counts)))
 		return
 	}
 
 	labels, err := s.app.DBClient().ListLabels(r.Context(), vaultID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list labels")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list labels")
 		logger.Error("list labels", "vault_id", vaultID, "error", err)
 		return
 	}
-	writeJSON(w, http.StatusOK, labels)
+	writeJSON(w, http.StatusOK, httputil.NewListResponse(labels, len(labels)))
 }

--- a/internal/api/ls.go
+++ b/internal/api/ls.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/raphi011/know/internal/auth"
 	"github.com/raphi011/know/internal/db"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -41,7 +42,7 @@ func (s *Server) ls(w http.ResponseWriter, r *http.Request) {
 		Limit:    10000,
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list documents")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list documents")
 		logger.Error("ls documents", "vault_id", vaultID, "path", folder, "error", err)
 		return
 	}
@@ -53,7 +54,7 @@ func (s *Server) ls(w http.ResponseWriter, r *http.Request) {
 		// ListFolders(nil) returns all vault folders; filter to those under the prefix.
 		allFolders, err := s.app.VaultService().ListFolders(r.Context(), vaultID, nil)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to list folders")
+			httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list folders")
 			logger.Error("ls folders", "vault_id", vaultID, "path", folder, "error", err)
 			return
 		}
@@ -78,7 +79,7 @@ func (s *Server) ls(w http.ResponseWriter, r *http.Request) {
 		// Non-recursive: only direct children
 		childFolders, err := s.app.DBClient().ListChildFolders(r.Context(), vaultID, folder)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to list folders")
+			httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list folders")
 			logger.Error("ls child folders", "vault_id", vaultID, "path", folder, "error", err)
 			return
 		}
@@ -104,9 +105,5 @@ func (s *Server) ls(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if entries == nil {
-		entries = []models.FileEntry{}
-	}
-
-	writeJSON(w, http.StatusOK, entries)
+	writeJSON(w, http.StatusOK, httputil.NewListResponse(entries, len(entries)))
 }

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1,0 +1,1988 @@
+openapi: 3.1.0
+info:
+  title: Know API
+  description: |
+    REST API for the Know knowledge management server.
+
+    All vault-scoped endpoints use `{vault}` as a **vault name** (e.g. `default`), which is resolved server-side to the vault ID.
+  version: 0.1.0
+
+servers:
+  - url: /api/v1
+    description: Local server
+
+security:
+  - BearerAuth: []
+
+tags:
+  - name: Vaults
+    description: Vault management and settings
+  - name: Documents
+    description: Document CRUD, listing, move, web clipping
+  - name: Import
+    description: Two-phase manifest + upload import
+  - name: Export
+    description: Export vault as tar.gz or EPUB
+  - name: Backup
+    description: Manifest-based vault backup and restore
+  - name: Search
+    description: Hybrid BM25 + vector search
+  - name: Folders
+    description: Folder listing and settings
+  - name: Versions
+    description: Document version history
+  - name: Labels
+    description: Label listing with optional counts
+  - name: Tasks
+    description: Task listing and status toggling
+  - name: Assets
+    description: Binary asset upload, download, and metadata
+  - name: External Links
+    description: Outgoing link stats and listing
+  - name: Conversations
+    description: Agent conversation CRUD
+  - name: Agent
+    description: Agent chat, SSE events, cancellation, tool approval
+  - name: Remotes
+    description: Multi-server federation (system admin)
+  - name: Jobs
+    description: Pipeline job status and stats
+  - name: Config
+    description: Server configuration
+  - name: Events
+    description: SSE document change stream
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: "Token from `know db seed`. Format: `kh_...`"
+
+  parameters:
+    vault:
+      name: vault
+      in: path
+      required: true
+      description: Vault name (e.g. `default`)
+      schema:
+        type: string
+
+  schemas:
+    ProblemDetail:
+      type: object
+      description: "RFC 9457 Problem Details for HTTP APIs"
+      required: [type, title, status, detail]
+      properties:
+        type:
+          type: string
+          example: "about:blank"
+        title:
+          type: string
+          example: "Not Found"
+        status:
+          type: integer
+          example: 404
+        detail:
+          type: string
+          example: "document not found"
+
+    RecordID:
+      type: object
+      description: SurrealDB record identifier (serialized as `{"Table":"<table>","ID":"<id>"}`)
+      properties:
+        Table:
+          type: string
+        ID:
+          type: string
+
+    Vault:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        createdBy:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        remote:
+          type: string
+          description: Remote name if this vault is federated
+
+    VaultInfo:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        documentCount:
+          type: integer
+        unprocessedDocs:
+          type: integer
+        chunkTotal:
+          type: integer
+        chunkWithEmbedding:
+          type: integer
+        chunkPending:
+          type: integer
+        labelCount:
+          type: integer
+        topLabels:
+          type: array
+          items:
+            $ref: "#/components/schemas/LabelStat"
+        members:
+          type: array
+          items:
+            $ref: "#/components/schemas/MemberStat"
+        assetCount:
+          type: integer
+        assetTotalSize:
+          type: integer
+          format: int64
+        wikiLinkTotal:
+          type: integer
+        wikiLinkBroken:
+          type: integer
+        versionCount:
+          type: integer
+        conversationCount:
+          type: integer
+        tokenInput:
+          type: integer
+          format: int64
+        tokenOutput:
+          type: integer
+          format: int64
+
+    LabelStat:
+      type: object
+      properties:
+        name:
+          type: string
+        count:
+          type: integer
+
+    MemberStat:
+      type: object
+      properties:
+        name:
+          type: string
+        role:
+          type: string
+
+    VaultSettings:
+      type: object
+      properties:
+        memory_path:
+          type: string
+        memory_merge_threshold:
+          type: number
+        memory_archive_threshold:
+          type: number
+        memory_decay_half_life:
+          type: integer
+        template_path:
+          type: string
+        daily_note_path:
+          type: string
+        transcript_template:
+          type: string
+        rrf_k:
+          type: integer
+        hnsw_ef:
+          type: integer
+        default_search_limit:
+          type: integer
+        max_search_limit:
+          type: integer
+        version_coalesce_minutes:
+          type: integer
+        version_retention_count:
+          type: integer
+        web_clip_path:
+          type: string
+
+    Document:
+      type: object
+      properties:
+        id:
+          type: string
+        vaultId:
+          type: string
+        path:
+          type: string
+        title:
+          type: string
+        content:
+          type: string
+        labels:
+          type: array
+          items:
+            type: string
+        docType:
+          type: string
+        contentHash:
+          type: [string, "null"]
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        wikiLinks:
+          type: array
+          items:
+            $ref: "#/components/schemas/WikiLinkInfo"
+
+    WikiLinkInfo:
+      type: object
+      properties:
+        rawTarget:
+          type: string
+        path:
+          type: string
+        title:
+          type: string
+
+    UpsertDocumentRequest:
+      type: object
+      required: [path, content]
+      properties:
+        path:
+          type: string
+        content:
+          type: string
+
+    DeleteDocumentsResponse:
+      type: object
+      properties:
+        deleted:
+          type: array
+          items:
+            type: string
+        count:
+          type: integer
+        dryRun:
+          type: boolean
+
+    MoveRequest:
+      type: object
+      required: [source, destination]
+      properties:
+        source:
+          type: string
+        destination:
+          type: string
+        dryRun:
+          type: boolean
+
+    MoveResponse:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [document, folder]
+        moved:
+          type: array
+          items:
+            type: string
+        count:
+          type: integer
+        dryRun:
+          type: boolean
+
+    FileEntry:
+      type: object
+      properties:
+        name:
+          type: string
+        path:
+          type: string
+        title:
+          type: string
+        isDir:
+          type: boolean
+        size:
+          type: integer
+
+    FetchRequest:
+      type: object
+      required: [url]
+      properties:
+        url:
+          type: string
+        path:
+          type: string
+          description: Optional vault path to save under
+
+    FetchResponse:
+      type: object
+      properties:
+        path:
+          type: string
+        title:
+          type: string
+
+    SearchResult:
+      type: object
+      properties:
+        documentId:
+          type: string
+        path:
+          type: string
+        title:
+          type: string
+        labels:
+          type: array
+          items:
+            type: string
+        docType:
+          type: string
+        score:
+          type: number
+        matchedChunks:
+          type: array
+          items:
+            $ref: "#/components/schemas/ChunkMatch"
+
+    ChunkMatch:
+      type: object
+      properties:
+        snippet:
+          type: string
+        headingPath:
+          type: string
+        position:
+          type: integer
+        score:
+          type: number
+
+    FolderResponse:
+      type: object
+      properties:
+        path:
+          type: string
+        name:
+          type: string
+        noEmbed:
+          type: boolean
+
+    UpdateFolderRequest:
+      type: object
+      required: [path]
+      properties:
+        path:
+          type: string
+        no_embed:
+          type: boolean
+
+    UpdateFolderResponse:
+      type: object
+      properties:
+        strippedChunks:
+          type: integer
+
+    VersionResponse:
+      type: object
+      properties:
+        version:
+          type: integer
+        title:
+          type: string
+        contentHash:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    LabelCount:
+      type: object
+      properties:
+        label:
+          type: string
+        count:
+          type: integer
+
+    TaskResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        documentPath:
+          type: string
+        documentTitle:
+          type: string
+        status:
+          type: string
+          enum: [open, done]
+        text:
+          type: string
+        labels:
+          type: array
+          items:
+            type: string
+        dueDate:
+          type: string
+        headingPath:
+          type: string
+        lineNumber:
+          type: integer
+
+    TaskListResponse:
+      type: object
+      required: [items, total]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/TaskResponse"
+        total:
+          type: integer
+
+    AssetMeta:
+      type: object
+      properties:
+        vaultId:
+          type: string
+        path:
+          type: string
+        mimeType:
+          type: string
+        size:
+          type: integer
+        contentHash:
+          type: [string, "null"]
+        updatedAt:
+          type: string
+          format: date-time
+
+    ExternalLink:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/RecordID"
+        from_file:
+          $ref: "#/components/schemas/RecordID"
+        vault:
+          $ref: "#/components/schemas/RecordID"
+        hostname:
+          type: string
+        url_path:
+          type: string
+        full_url:
+          type: string
+        link_text:
+          type: [string, "null"]
+
+    ExternalLinkHostStats:
+      type: object
+      properties:
+        hostname:
+          type: string
+        count:
+          type: integer
+
+    ExternalLinkListResponse:
+      type: object
+      required: [items, total]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/ExternalLink"
+        total:
+          type: integer
+
+    ExternalLinkStatsResponse:
+      type: object
+      required: [items, total]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/ExternalLinkHostStats"
+        total:
+          type: integer
+
+    Conversation:
+      type: object
+      properties:
+        id:
+          type: string
+        vaultId:
+          type: string
+        title:
+          type: string
+        tokenInput:
+          type: integer
+          format: int64
+        tokenOutput:
+          type: integer
+          format: int64
+        bgStatus:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/ChatMessage"
+
+    ChatMessage:
+      type: object
+      properties:
+        id:
+          type: string
+        role:
+          type: string
+          enum: [user, assistant, tool]
+        content:
+          type: string
+        docRefs:
+          type: array
+          items:
+            type: string
+        toolName:
+          type: string
+        toolInput:
+          type: string
+        toolCallId:
+          type: string
+        toolCalls:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    CreateConversationRequest:
+      type: object
+      required: [vaultId]
+      properties:
+        vaultId:
+          type: string
+
+    RenameConversationRequest:
+      type: object
+      required: [title]
+      properties:
+        title:
+          type: string
+
+    RemoteResponse:
+      type: object
+      properties:
+        name:
+          type: string
+        url:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    AddRemoteRequest:
+      type: object
+      required: [name, url, token]
+      properties:
+        name:
+          type: string
+        url:
+          type: string
+        token:
+          type: string
+
+    JobStats:
+      type: object
+      properties:
+        pending:
+          type: integer
+        running:
+          type: integer
+        done:
+          type: integer
+        failed:
+          type: integer
+        cancelled:
+          type: integer
+
+    JobTypeDuration:
+      type: object
+      properties:
+        type:
+          type: string
+        count:
+          type: integer
+        min_ms:
+          type: integer
+          format: int64
+        max_ms:
+          type: integer
+          format: int64
+        avg_ms:
+          type: number
+
+    PipelineJobDetail:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/RecordID"
+        file:
+          $ref: "#/components/schemas/RecordID"
+        type:
+          type: string
+        status:
+          type: string
+        priority:
+          type: integer
+        attempt:
+          type: integer
+        max_attempts:
+          type: integer
+        run_after:
+          type: string
+          format: date-time
+        error:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        file_path:
+          type: string
+
+    JobStatusResponse:
+      type: object
+      properties:
+        stats:
+          $ref: "#/components/schemas/JobStats"
+        durations:
+          type: array
+          items:
+            $ref: "#/components/schemas/JobTypeDuration"
+        active:
+          type: array
+          items:
+            $ref: "#/components/schemas/PipelineJobDetail"
+        recent_failed:
+          type: array
+          items:
+            $ref: "#/components/schemas/PipelineJobDetail"
+
+    ServerConfig:
+      type: object
+      properties:
+        version:
+          type: string
+        commit:
+          type: string
+        surrealdbURL:
+          type: string
+        authEnabled:
+          type: boolean
+        llmProvider:
+          type: string
+        llmModel:
+          type: string
+        embedProvider:
+          type: string
+        embedModel:
+          type: string
+        embedDimension:
+          type: integer
+        semanticSearchEnabled:
+          type: boolean
+        agentChatEnabled:
+          type: boolean
+        webSearchEnabled:
+          type: boolean
+        chunkThreshold:
+          type: integer
+        chunkTargetSize:
+          type: integer
+        chunkMaxSize:
+          type: integer
+        versionCoalesceMinutes:
+          type: integer
+        versionRetentionCount:
+          type: integer
+        sttProvider:
+          type: string
+        sttModel:
+          type: string
+        transcriptionEnabled:
+          type: boolean
+        ffmpegInstalled:
+          type: boolean
+        popplerInstalled:
+          type: boolean
+        pdfIngestionEnabled:
+          type: boolean
+        multimodalEmbedProvider:
+          type: string
+        multimodalEmbedModel:
+          type: string
+        multimodalEmbedEnabled:
+          type: boolean
+        textExtractorModel:
+          type: string
+        textExtractorEnabled:
+          type: boolean
+
+    ImportManifestFile:
+      type: object
+      required: [path, hash]
+      properties:
+        path:
+          type: string
+        hash:
+          type: string
+          description: SHA256 content hash
+
+    ImportManifestRequest:
+      type: object
+      required: [files]
+      properties:
+        force:
+          type: boolean
+          description: Re-upload even if hash differs
+        dryRun:
+          type: boolean
+        files:
+          type: array
+          items:
+            $ref: "#/components/schemas/ImportManifestFile"
+
+    ImportFileResult:
+      type: object
+      properties:
+        path:
+          type: string
+        status:
+          type: string
+          enum: [created, updated, skipped, error]
+        reason:
+          type: string
+        error:
+          type: string
+
+    ImportManifestResponse:
+      type: object
+      properties:
+        needed:
+          type: array
+          items:
+            type: string
+          description: Paths that need to be uploaded in phase 2
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/ImportFileResult"
+
+    ImportUploadResponse:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/ImportFileResult"
+        error:
+          type: string
+
+    BulkResponse:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/ImportFileResult"
+        error:
+          type: string
+
+  responses:
+    BadRequest:
+      description: Invalid request
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetail"
+    Unauthorized:
+      description: Missing or invalid Bearer token
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetail"
+    Forbidden:
+      description: Insufficient permissions
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetail"
+    NotFound:
+      description: Resource not found
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetail"
+
+paths:
+  # ── Vaults ──────────────────────────────────────────────
+  /vaults:
+    get:
+      tags: [Vaults]
+      summary: List vaults
+      description: Returns vaults accessible to the authenticated user, including federated remote vaults.
+      responses:
+        "200":
+          description: List of vaults
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, total]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Vault"
+                  total:
+                    type: integer
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /vaults/{vault}:
+    get:
+      tags: [Vaults]
+      summary: Get vault info
+      description: Returns comprehensive stats about a vault (document counts, chunk stats, labels, members, etc.).
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      responses:
+        "200":
+          description: Vault info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VaultInfo"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /vaults/{vault}/settings:
+    get:
+      tags: [Vaults]
+      summary: Get vault settings
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      responses:
+        "200":
+          description: Current vault settings (with defaults applied)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VaultSettings"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      tags: [Vaults]
+      summary: Update vault settings
+      description: Partially updates vault settings. Only provided fields are changed. Requires admin role.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VaultSettings"
+      responses:
+        "200":
+          description: Updated settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VaultSettings"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  # ── Documents ───────────────────────────────────────────
+  /vaults/{vault}/documents:
+    get:
+      tags: [Documents]
+      summary: Get document by path
+      parameters:
+        - $ref: "#/components/parameters/vault"
+        - name: path
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Document path (e.g. `/notes/hello.md`)
+      responses:
+        "200":
+          description: Document with content and resolved wiki-links
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Document"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    post:
+      tags: [Documents]
+      summary: Create or update a document
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpsertDocumentRequest"
+      responses:
+        "200":
+          description: Upserted document
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Document"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    delete:
+      tags: [Documents]
+      summary: Delete document or folder
+      description: |
+        Deletes a document or folder. For folders, `recursive=true` is required.
+        Use `dry-run=true` to preview what would be deleted.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+        - name: path
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: recursive
+          in: query
+          schema:
+            type: boolean
+        - name: dry-run
+          in: query
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: Deletion result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteDocumentsResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /vaults/{vault}/documents/ls:
+    get:
+      tags: [Documents]
+      summary: List directory contents
+      parameters:
+        - $ref: "#/components/parameters/vault"
+        - name: path
+          in: query
+          schema:
+            type: string
+            default: "/"
+          description: Folder path to list
+        - name: recursive
+          in: query
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: Directory entries (files and folders)
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, total]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/FileEntry"
+                  total:
+                    type: integer
+
+  /vaults/{vault}/documents/move:
+    post:
+      tags: [Documents]
+      summary: Move a document or folder
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MoveRequest"
+      responses:
+        "200":
+          description: Move result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MoveResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Destination already exists
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+
+  /vaults/{vault}/documents/bulk:
+    post:
+      tags: [Documents]
+      summary: Bulk upload documents and assets
+      description: |
+        Multipart upload. First part must be `meta` (JSON with `force` and `dryRun` flags).
+        Subsequent parts are files identified by form name (vault path).
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                meta:
+                  type: string
+                  description: 'JSON: `{"force": false, "dryRun": false}`'
+      responses:
+        "200":
+          description: Per-file results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BulkResponse"
+
+  /vaults/{vault}/documents/clip:
+    post:
+      tags: [Documents]
+      summary: Fetch a web page and save as document
+      description: Uses Jina Reader to convert a URL to markdown and saves it in the vault.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FetchRequest"
+      responses:
+        "200":
+          description: Saved document info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FetchResponse"
+
+  # ── Import ──────────────────────────────────────────────
+  /vaults/{vault}/import/manifest:
+    post:
+      tags: [Import]
+      summary: "Phase 1: Check which files need uploading"
+      description: |
+        Send a list of files with their SHA256 hashes. The server responds with
+        which files need to be uploaded (phase 2) and which can be skipped.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportManifestRequest"
+      responses:
+        "200":
+          description: Manifest check results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportManifestResponse"
+
+  /vaults/{vault}/import/upload:
+    post:
+      tags: [Import]
+      summary: "Phase 2: Upload needed files"
+      description: |
+        Multipart upload of files indicated as "needed" by the manifest phase.
+        First part must be `meta` (JSON with `hashes` map: path → SHA256).
+        Subsequent parts are files identified by form name (vault path).
+        Hash verification is enforced — mismatches abort the import.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                meta:
+                  type: string
+                  description: 'JSON: `{"hashes": {"path": "sha256hash"}}`'
+      responses:
+        "200":
+          description: Per-file upload results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportUploadResponse"
+        "400":
+          description: Hash mismatch or oversized file
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+
+  # ── Export ──────────────────────────────────────────────
+  /vaults/{vault}/export:
+    get:
+      tags: [Export]
+      summary: Export vault as tar.gz
+      description: Streams the vault contents as a gzipped tar archive.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      responses:
+        "200":
+          description: Vault archive
+          content:
+            application/gzip:
+              schema:
+                type: string
+                format: binary
+
+  /vaults/{vault}/export/epub:
+    get:
+      tags: [Export]
+      summary: Export vault as EPUB
+      description: |
+        Exports a single document or all markdown files under a folder as an EPUB book.
+        When `path` points to a file, that file becomes the sole chapter.
+        When `path` points to a folder, all `.md` files underneath are included.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+        - name: path
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Document or folder path to export
+        - name: title
+          in: query
+          schema:
+            type: string
+          description: EPUB title (defaults to document title or folder name)
+        - name: author
+          in: query
+          schema:
+            type: string
+          description: EPUB author metadata
+      responses:
+        "200":
+          description: EPUB file
+          content:
+            application/epub+zip:
+              schema:
+                type: string
+                format: binary
+
+  # ── Backup / Restore ────────────────────────────────────
+  /vaults/{vault}/backup:
+    get:
+      tags: [Backup]
+      summary: Export vault backup
+      description: Manifest-based backup as tar.gz archive including all documents, assets, and metadata.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      responses:
+        "200":
+          description: Backup archive
+          content:
+            application/gzip:
+              schema:
+                type: string
+                format: binary
+
+  /backup/restore:
+    post:
+      tags: [Backup]
+      summary: Restore vault from backup
+      description: |
+        Restores a vault from a tar.gz backup archive. Creates the vault if it doesn't exist.
+        Send the archive as the raw request body with `Content-Type: application/gzip`.
+      requestBody:
+        required: true
+        content:
+          application/gzip:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "200":
+          description: Restore completed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+
+  # ── Search ──────────────────────────────────────────────
+  /vaults/{vault}/search:
+    get:
+      tags: [Search]
+      summary: Search documents
+      description: Hybrid BM25 + vector search with reciprocal rank fusion.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+        - name: query
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+        - name: labels
+          in: query
+          schema:
+            type: string
+          description: Comma-separated label filter
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, total]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/SearchResult"
+                  total:
+                    type: integer
+
+  # ── Folders ─────────────────────────────────────────────
+  /vaults/{vault}/folders:
+    get:
+      tags: [Folders]
+      summary: List folders
+      parameters:
+        - $ref: "#/components/parameters/vault"
+        - name: parent
+          in: query
+          schema:
+            type: string
+          description: Filter to immediate children of this folder
+      responses:
+        "200":
+          description: List of folders
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, total]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/FolderResponse"
+                  total:
+                    type: integer
+    patch:
+      tags: [Folders]
+      summary: Update folder settings
+      description: Currently supports toggling the `no_embed` flag. When enabled, strips existing embeddings.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateFolderRequest"
+      responses:
+        "200":
+          description: Update result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpdateFolderResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ── Versions ────────────────────────────────────────────
+  /vaults/{vault}/versions:
+    get:
+      tags: [Versions]
+      summary: List document versions
+      parameters:
+        - $ref: "#/components/parameters/vault"
+        - name: path
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Document path
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+      responses:
+        "200":
+          description: Version history
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, total]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/VersionResponse"
+                  total:
+                    type: integer
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ── Labels ──────────────────────────────────────────────
+  /vaults/{vault}/labels:
+    get:
+      tags: [Labels]
+      summary: List labels
+      description: Returns label names, or label names with document counts when `counts=true`.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+        - name: counts
+          in: query
+          schema:
+            type: boolean
+          description: Include document counts per label
+      responses:
+        "200":
+          description: Label list (string array) or label counts (object array), wrapped in items/total envelope
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, total]
+                properties:
+                  items:
+                    oneOf:
+                      - type: array
+                        items:
+                          type: string
+                      - type: array
+                        items:
+                          $ref: "#/components/schemas/LabelCount"
+                  total:
+                    type: integer
+
+  # ── Tasks ───────────────────────────────────────────────
+  /vaults/{vault}/tasks:
+    get:
+      tags: [Tasks]
+      summary: List tasks
+      description: Lists tasks extracted from document checkboxes, with optional filters.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [open, done]
+        - name: labels
+          in: query
+          schema:
+            type: string
+          description: Comma-separated label filter
+        - name: due_before
+          in: query
+          schema:
+            type: string
+            format: date
+          description: "Filter: due date before (YYYY-MM-DD)"
+        - name: due_after
+          in: query
+          schema:
+            type: string
+            format: date
+          description: "Filter: due date after (YYYY-MM-DD)"
+        - name: folder
+          in: query
+          schema:
+            type: string
+        - name: path
+          in: query
+          schema:
+            type: string
+          description: Filter to tasks from a specific document
+        - name: limit
+          in: query
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Paginated task list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskListResponse"
+
+  /vaults/{vault}/tasks/{id}/toggle:
+    post:
+      tags: [Tasks]
+      summary: Toggle task status
+      description: Toggles a task between `open` and `done`, updating the source document's checkbox.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Updated task
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskResponse"
+
+  # ── Assets ──────────────────────────────────────────────
+  /vaults/{vault}/assets:
+    post:
+      tags: [Assets]
+      summary: Upload an image asset
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [path, file]
+              properties:
+                path:
+                  type: string
+                  description: Vault path for the asset
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "201":
+          description: Uploaded asset metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssetMeta"
+    get:
+      tags: [Assets]
+      summary: Download asset binary
+      parameters:
+        - $ref: "#/components/parameters/vault"
+        - name: path
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Asset binary data
+          content:
+            "*/*":
+              schema:
+                type: string
+                format: binary
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags: [Assets]
+      summary: Delete an asset
+      parameters:
+        - $ref: "#/components/parameters/vault"
+        - name: path
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Asset deleted
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /vaults/{vault}/assets/meta:
+    get:
+      tags: [Assets]
+      summary: Get asset metadata
+      parameters:
+        - $ref: "#/components/parameters/vault"
+        - name: path
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Asset metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssetMeta"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ── External Links ──────────────────────────────────────
+  /vaults/{vault}/external-links:
+    get:
+      tags: [External Links]
+      summary: List external links
+      parameters:
+        - $ref: "#/components/parameters/vault"
+        - name: hostname
+          in: query
+          schema:
+            type: string
+        - name: file
+          in: query
+          schema:
+            type: string
+          description: Filter by file ID
+        - name: limit
+          in: query
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Paginated link list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalLinkListResponse"
+
+  /vaults/{vault}/external-links/stats:
+    get:
+      tags: [External Links]
+      summary: External link stats by hostname
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      responses:
+        "200":
+          description: Link count per hostname
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalLinkStatsResponse"
+
+  # ── SSE Events ──────────────────────────────────────────
+  /vaults/{vault}/events:
+    get:
+      tags: [Events]
+      summary: SSE document change stream
+      description: |
+        Server-Sent Events stream for real-time document change notifications.
+        Connect with `EventSource` or any SSE client. The connection stays open
+        until the client disconnects.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      responses:
+        "200":
+          description: SSE event stream
+          content:
+            text/event-stream:
+              schema:
+                type: string
+
+  # ── Conversations ───────────────────────────────────────
+  /conversations:
+    get:
+      tags: [Conversations]
+      summary: List conversations
+      parameters:
+        - name: vault
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Vault record ID (not name — unlike path-scoped endpoints, this takes the raw vault ID)
+      responses:
+        "200":
+          description: List of conversations (without messages)
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, total]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Conversation"
+                  total:
+                    type: integer
+    post:
+      tags: [Conversations]
+      summary: Create a conversation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateConversationRequest"
+      responses:
+        "201":
+          description: Created conversation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Conversation"
+
+  /conversations/{id}:
+    get:
+      tags: [Conversations]
+      summary: Get conversation with messages
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Conversation with full message history
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Conversation"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      tags: [Conversations]
+      summary: Rename a conversation
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RenameConversationRequest"
+      responses:
+        "200":
+          description: Renamed conversation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Conversation"
+    delete:
+      tags: [Conversations]
+      summary: Delete a conversation
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Conversation deleted
+
+  # ── Agent ───────────────────────────────────────────────
+  /vaults/{vault}/agent/chat:
+    post:
+      tags: [Agent]
+      summary: Start agent chat
+      description: |
+        Sends a user message to the agent. Returns a conversation ID.
+        Subscribe to `/agent/events/{id}` for the streamed response.
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [content]
+              properties:
+                content:
+                  type: string
+                conversationId:
+                  type: string
+                  description: Existing conversation ID (omit to create new)
+                docRefs:
+                  type: array
+                  items:
+                    type: string
+                  description: Document paths to include as context
+                attachments:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      path:
+                        type: string
+                      content:
+                        type: string
+                      mimeType:
+                        type: string
+                      language:
+                        type: string
+                      type:
+                        type: string
+                        enum: [text, image]
+                autoApprove:
+                  type: boolean
+                  description: Auto-approve all tool executions
+      responses:
+        "202":
+          description: Chat started (subscribe to `/agent/events/{id}` for response)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  status:
+                    type: string
+                    enum: [running]
+
+  /agent/events/{id}:
+    get:
+      tags: [Agent]
+      summary: SSE stream for agent response
+      description: |
+        Server-Sent Events stream for a running agent conversation.
+        Events include text chunks, tool calls, tool results, and completion.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Stream ID from the chat response
+      responses:
+        "200":
+          description: SSE event stream
+          content:
+            text/event-stream:
+              schema:
+                type: string
+
+  /agent/cancel/{id}:
+    post:
+      tags: [Agent]
+      summary: Cancel an agent run
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Cancellation requested
+
+  /agent/approval:
+    post:
+      tags: [Agent]
+      summary: Approve or deny a tool execution
+      description: |
+        Responds to an approval interrupt from an agent run.
+        The agent resumes execution based on the chosen action.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [conversationId, interruptId, action]
+              properties:
+                conversationId:
+                  type: string
+                interruptId:
+                  type: string
+                action:
+                  type: string
+                  enum: [approve_all, approve_hunks, reject]
+                hunkIndexes:
+                  type: array
+                  items:
+                    type: integer
+                  description: Hunk indexes to approve (only for `approve_hunks` action)
+      responses:
+        "202":
+          description: Agent resumed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  status:
+                    type: string
+                    enum: [running]
+
+  # ── Remotes ─────────────────────────────────────────────
+  /remotes:
+    get:
+      tags: [Remotes]
+      summary: List remotes
+      description: System admin only.
+      responses:
+        "200":
+          description: List of configured remotes
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, total]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/RemoteResponse"
+                  total:
+                    type: integer
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags: [Remotes]
+      summary: Add a remote
+      description: Registers a new federated remote server. System admin only.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddRemoteRequest"
+      responses:
+        "201":
+          description: Created remote
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RemoteResponse"
+        "400":
+          description: Validation error or remote unreachable
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+
+  /remotes/{name}:
+    delete:
+      tags: [Remotes]
+      summary: Remove a remote
+      description: System admin only.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Remote removed
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ── Jobs ────────────────────────────────────────────────
+  /jobs:
+    get:
+      tags: [Jobs]
+      summary: Pipeline job status
+      description: Returns aggregate stats, per-type durations, active jobs, and recent failures.
+      parameters:
+        - name: since
+          in: query
+          schema:
+            type: string
+            default: "24h"
+          description: "Time window for stats (e.g. `1h`, `24h`, `7d`, `30d`)"
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 10
+          description: Max number of active/failed jobs to return
+      responses:
+        "200":
+          description: Job status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JobStatusResponse"
+
+  # ── Config ──────────────────────────────────────────────
+  /config:
+    get:
+      tags: [Config]
+      summary: Server configuration
+      description: Returns the server's effective configuration (providers, models, feature flags).
+      responses:
+        "200":
+          description: Server config
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerConfig"

--- a/internal/api/remotes.go
+++ b/internal/api/remotes.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/raphi011/know/internal/auth"
 	"github.com/raphi011/know/internal/db"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -24,19 +25,19 @@ type remoteResponse struct {
 
 func (s *Server) listRemotes(w http.ResponseWriter, r *http.Request) {
 	if err := auth.RequireSystemAdmin(r.Context()); err != nil {
-		writeError(w, http.StatusForbidden, "system admin required")
+		httputil.WriteProblem(w, http.StatusForbidden, "system admin required")
 		return
 	}
 
 	remoteSvc := s.app.RemoteService()
 	if remoteSvc == nil {
-		writeJSON(w, http.StatusOK, []remoteResponse{})
+		writeJSON(w, http.StatusOK, httputil.NewListResponse([]remoteResponse{}, 0))
 		return
 	}
 
 	remotes, err := remoteSvc.List(r.Context())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list remotes")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list remotes")
 		logutil.FromCtx(r.Context()).Error("list remotes", "error", err)
 		return
 	}
@@ -51,7 +52,7 @@ func (s *Server) listRemotes(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, http.StatusOK, httputil.NewListResponse(resp, len(resp)))
 }
 
 type addRemoteRequest struct {
@@ -62,27 +63,27 @@ type addRemoteRequest struct {
 
 func (s *Server) addRemote(w http.ResponseWriter, r *http.Request) {
 	if err := auth.RequireSystemAdmin(r.Context()); err != nil {
-		writeError(w, http.StatusForbidden, "system admin required")
+		httputil.WriteProblem(w, http.StatusForbidden, "system admin required")
 		return
 	}
 
 	var body addRemoteRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+		httputil.WriteProblem(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 	if body.Name == "" || body.URL == "" || body.Token == "" {
-		writeError(w, http.StatusBadRequest, "name, url, and token are required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "name, url, and token are required")
 		return
 	}
 	if strings.Contains(body.Name, "/") || strings.Contains(body.Name, " ") {
-		writeError(w, http.StatusBadRequest, "remote name must not contain '/' or spaces")
+		httputil.WriteProblem(w, http.StatusBadRequest, "remote name must not contain '/' or spaces")
 		return
 	}
 
 	remoteSvc := s.app.RemoteService()
 	if remoteSvc == nil {
-		writeError(w, http.StatusServiceUnavailable, "remote service not available")
+		httputil.WriteProblem(w, http.StatusServiceUnavailable, "remote service not available")
 		return
 	}
 
@@ -91,13 +92,13 @@ func (s *Server) addRemote(w http.ResponseWriter, r *http.Request) {
 
 	// Validate connectivity by calling /health on the remote
 	if err := checkRemoteHealth(ctx, body.URL); err != nil {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("cannot reach remote: %v", err))
+		httputil.WriteProblem(w, http.StatusBadRequest, fmt.Sprintf("cannot reach remote: %v", err))
 		return
 	}
 
 	ac, err := auth.FromContext(ctx)
 	if err != nil {
-		writeError(w, http.StatusUnauthorized, "unauthorized")
+		httputil.WriteProblem(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 
@@ -107,7 +108,7 @@ func (s *Server) addRemote(w http.ResponseWriter, r *http.Request) {
 		Token: body.Token,
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to add remote")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to add remote")
 		logger.Error("add remote", "name", body.Name, "error", err)
 		return
 	}
@@ -122,19 +123,19 @@ func (s *Server) addRemote(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) removeRemote(w http.ResponseWriter, r *http.Request) {
 	if err := auth.RequireSystemAdmin(r.Context()); err != nil {
-		writeError(w, http.StatusForbidden, "system admin required")
+		httputil.WriteProblem(w, http.StatusForbidden, "system admin required")
 		return
 	}
 
 	name := r.PathValue("name")
 	if name == "" {
-		writeError(w, http.StatusBadRequest, "remote name required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "remote name required")
 		return
 	}
 
 	remoteSvc := s.app.RemoteService()
 	if remoteSvc == nil {
-		writeError(w, http.StatusServiceUnavailable, "remote service not available")
+		httputil.WriteProblem(w, http.StatusServiceUnavailable, "remote service not available")
 		return
 	}
 
@@ -142,10 +143,10 @@ func (s *Server) removeRemote(w http.ResponseWriter, r *http.Request) {
 
 	if err := remoteSvc.Remove(r.Context(), name); err != nil {
 		if errors.Is(err, db.ErrNotFound) {
-			writeError(w, http.StatusNotFound, fmt.Sprintf("remote not found: %s", name))
+			httputil.WriteProblem(w, http.StatusNotFound, fmt.Sprintf("remote not found: %s", name))
 			return
 		}
-		writeError(w, http.StatusInternalServerError, "failed to remove remote")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to remove remote")
 		logger.Error("remove remote", "name", name, "error", err)
 		return
 	}

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/search"
 )
@@ -15,7 +16,7 @@ func (s *Server) searchDocuments(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query().Get("query")
 
 	if query == "" {
-		writeError(w, http.StatusBadRequest, "query parameter required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "query parameter required")
 		return
 	}
 
@@ -41,7 +42,7 @@ func (s *Server) searchDocuments(w http.ResponseWriter, r *http.Request) {
 		Limit:   limit,
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "search failed")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "search failed")
 		logger.Error("search documents", "vault_id", vaultID, "error", err)
 		return
 	}
@@ -68,5 +69,5 @@ func (s *Server) searchDocuments(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, http.StatusOK, httputil.NewListResponse(resp, len(resp)))
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/raphi011/know/internal/agent"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/server"
 )
@@ -128,11 +129,6 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	}
 }
 
-// writeError writes a JSON error response.
-func writeError(w http.ResponseWriter, status int, msg string) {
-	writeJSON(w, status, map[string]string{"error": msg})
-}
-
 // decodeBody reads and JSON-decodes the request body with a size limit.
 // Returns the decoded value and true on success, or writes an error response and returns nil, false.
 func decodeBody[T any](w http.ResponseWriter, r *http.Request, maxBytes int64) (*T, bool) {
@@ -141,10 +137,10 @@ func decodeBody[T any](w http.ResponseWriter, r *http.Request, maxBytes int64) (
 	if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
-			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			httputil.WriteProblem(w, http.StatusRequestEntityTooLarge, "request body too large")
 		} else {
 			logutil.FromCtx(r.Context()).Debug("invalid request body", "error", err)
-			writeError(w, http.StatusBadRequest, "invalid request body")
+			httputil.WriteProblem(w, http.StatusBadRequest, "invalid request body")
 		}
 		return nil, false
 	}

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/raphi011/know/internal/auth"
 	"github.com/raphi011/know/internal/db"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -24,7 +25,7 @@ func (s *Server) listTasks(w http.ResponseWriter, r *http.Request) {
 	if v := r.URL.Query().Get("status"); v != "" {
 		status := models.TaskStatus(v)
 		if !status.Valid() {
-			writeError(w, http.StatusBadRequest, "status must be 'open' or 'done'")
+			httputil.WriteProblem(w, http.StatusBadRequest, "status must be 'open' or 'done'")
 			return
 		}
 		filter.Status = &status
@@ -34,14 +35,14 @@ func (s *Server) listTasks(w http.ResponseWriter, r *http.Request) {
 	}
 	if v := r.URL.Query().Get("due_before"); v != "" {
 		if !models.IsValidDate(v) {
-			writeError(w, http.StatusBadRequest, "due_before must be YYYY-MM-DD")
+			httputil.WriteProblem(w, http.StatusBadRequest, "due_before must be YYYY-MM-DD")
 			return
 		}
 		filter.DueBefore = &v
 	}
 	if v := r.URL.Query().Get("due_after"); v != "" {
 		if !models.IsValidDate(v) {
-			writeError(w, http.StatusBadRequest, "due_after must be YYYY-MM-DD")
+			httputil.WriteProblem(w, http.StatusBadRequest, "due_after must be YYYY-MM-DD")
 			return
 		}
 		filter.DueAfter = &v
@@ -55,7 +56,7 @@ func (s *Server) listTasks(w http.ResponseWriter, r *http.Request) {
 	if v := r.URL.Query().Get("limit"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n <= 0 {
-			writeError(w, http.StatusBadRequest, "limit must be a positive integer")
+			httputil.WriteProblem(w, http.StatusBadRequest, "limit must be a positive integer")
 			return
 		}
 		filter.Limit = n
@@ -63,7 +64,7 @@ func (s *Server) listTasks(w http.ResponseWriter, r *http.Request) {
 	if v := r.URL.Query().Get("offset"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n < 0 {
-			writeError(w, http.StatusBadRequest, "offset must be a non-negative integer")
+			httputil.WriteProblem(w, http.StatusBadRequest, "offset must be a non-negative integer")
 			return
 		}
 		filter.Offset = n
@@ -71,53 +72,42 @@ func (s *Server) listTasks(w http.ResponseWriter, r *http.Request) {
 
 	tasks, err := s.app.DBClient().ListTasks(ctx, filter)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list tasks")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list tasks")
 		logger.Error("list tasks", "vault_id", vaultID, "error", err)
 		return
 	}
 
 	total, err := s.app.DBClient().CountTasks(ctx, filter)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to count tasks")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to count tasks")
 		logger.Error("count tasks", "vault_id", vaultID, "error", err)
 		return
-	}
-
-	if tasks == nil {
-		tasks = []models.TaskWithDoc{}
 	}
 
 	var resp []TaskResponse
 	for _, t := range tasks {
 		tr, err := taskResponseFromModel(t)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "invalid task record ID")
+			httputil.WriteProblem(w, http.StatusInternalServerError, "invalid task record ID")
 			logger.Error("task with corrupt record ID", "error", err)
 			return
 		}
 		resp = append(resp, tr)
 	}
-	if resp == nil {
-		resp = []TaskResponse{}
-	}
-
-	writeJSON(w, http.StatusOK, map[string]any{
-		"tasks": resp,
-		"total": total,
-	})
+	writeJSON(w, http.StatusOK, httputil.NewListResponse(resp, total))
 }
 
 func (s *Server) toggleTask(w http.ResponseWriter, r *http.Request) {
 	taskID := r.PathValue("id")
 	if taskID == "" {
-		writeError(w, http.StatusBadRequest, "task id required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "task id required")
 		return
 	}
 
 	ctx := r.Context()
 	vaultID := auth.MustVaultIDFromCtx(ctx)
 	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleWrite); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
@@ -125,7 +115,7 @@ func (s *Server) toggleTask(w http.ResponseWriter, r *http.Request) {
 
 	updated, err := s.app.FileService().ToggleTask(ctx, vaultID, taskID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to toggle task")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to toggle task")
 		logger.Error("toggle task", "task_id", taskID, "error", err)
 		return
 	}
@@ -134,7 +124,7 @@ func (s *Server) toggleTask(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := taskResponseFromTask(*updated)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "invalid task id in response")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "invalid task id in response")
 		logger.Error("extract task id", "error", err)
 		return
 	}

--- a/internal/api/vault_scope.go
+++ b/internal/api/vault_scope.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -25,7 +26,7 @@ func (s *Server) vaultScope(next http.HandlerFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		name := r.PathValue("vault")
 		if name == "" {
-			writeError(w, http.StatusBadRequest, "vault name required")
+			httputil.WriteProblem(w, http.StatusBadRequest, "vault name required")
 			return
 		}
 
@@ -33,30 +34,30 @@ func (s *Server) vaultScope(next http.HandlerFunc) http.Handler {
 
 		ac, err := auth.FromContext(ctx)
 		if err != nil {
-			writeError(w, http.StatusUnauthorized, "unauthorized")
+			httputil.WriteProblem(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}
 
 		v, err := s.app.VaultService().GetByName(ctx, name)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to resolve vault")
+			httputil.WriteProblem(w, http.StatusInternalServerError, "failed to resolve vault")
 			logutil.FromCtx(ctx).Error("vault scope: get by name", "name", name, "error", err)
 			return
 		}
 		if v == nil {
-			writeError(w, http.StatusNotFound, "vault not found")
+			httputil.WriteProblem(w, http.StatusNotFound, "vault not found")
 			return
 		}
 
 		vaultID, err := models.RecordIDString(v.ID)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "invalid vault ID")
+			httputil.WriteProblem(w, http.StatusInternalServerError, "invalid vault ID")
 			logutil.FromCtx(ctx).Error("vault scope: extract ID", "name", name, "error", err)
 			return
 		}
 
 		if err := auth.CheckVaultRole(ac, vaultID, models.RoleRead); err != nil {
-			writeError(w, http.StatusForbidden, "forbidden")
+			httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 			return
 		}
 

--- a/internal/api/vaults.go
+++ b/internal/api/vaults.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -13,13 +14,13 @@ import (
 func (s *Server) listVaults(w http.ResponseWriter, r *http.Request) {
 	ac, err := auth.FromContext(r.Context())
 	if err != nil {
-		writeError(w, http.StatusUnauthorized, "unauthorized")
+		httputil.WriteProblem(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 
 	all, err := s.app.VaultService().List(r.Context())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list vaults")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list vaults")
 		logutil.FromCtx(r.Context()).Error("list vaults", "error", err)
 		return
 	}
@@ -81,10 +82,7 @@ func (s *Server) listVaults(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if result == nil {
-		result = []Vault{}
-	}
-	writeJSON(w, http.StatusOK, result)
+	writeJSON(w, http.StatusOK, httputil.NewListResponse(result, len(result)))
 }
 
 func (s *Server) getVaultInfo(w http.ResponseWriter, r *http.Request) {
@@ -94,18 +92,18 @@ func (s *Server) getVaultInfo(w http.ResponseWriter, r *http.Request) {
 
 	v, err := s.app.DBClient().GetVault(ctx, vaultID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get vault")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get vault")
 		logger.Error("get vault", "vault_id", vaultID, "error", err)
 		return
 	}
 	if v == nil {
-		writeError(w, http.StatusNotFound, "vault not found")
+		httputil.WriteProblem(w, http.StatusNotFound, "vault not found")
 		return
 	}
 
 	stats, err := s.app.DBClient().GetVaultInfo(ctx, vaultID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get vault info")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get vault info")
 		logger.Error("get vault info", "vault_id", vaultID, "error", err)
 		return
 	}
@@ -142,12 +140,12 @@ func (s *Server) getVaultSettings(w http.ResponseWriter, r *http.Request) {
 
 	v, err := s.app.DBClient().GetVault(ctx, vaultID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get vault")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get vault")
 		logutil.FromCtx(ctx).Error("get vault", "vault_id", vaultID, "error", err)
 		return
 	}
 	if v == nil {
-		writeError(w, http.StatusNotFound, "vault not found")
+		httputil.WriteProblem(w, http.StatusNotFound, "vault not found")
 		return
 	}
 
@@ -161,25 +159,25 @@ func (s *Server) updateVaultSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := patch.Validate(); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		httputil.WriteProblem(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
 	ctx := r.Context()
 	vaultID := auth.MustVaultIDFromCtx(ctx)
 	if err := auth.RequireVaultRole(ctx, vaultID, models.RoleAdmin); err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
+		httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
 	v, err := s.app.DBClient().GetVault(ctx, vaultID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get vault")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get vault")
 		logutil.FromCtx(ctx).Error("get vault", "vault_id", vaultID, "error", err)
 		return
 	}
 	if v == nil {
-		writeError(w, http.StatusNotFound, "vault not found")
+		httputil.WriteProblem(w, http.StatusNotFound, "vault not found")
 		return
 	}
 
@@ -189,19 +187,19 @@ func (s *Server) updateVaultSettings(w http.ResponseWriter, r *http.Request) {
 	if path := patch.TranscriptTemplate; path != "" && path != "-" {
 		f, err := s.app.DBClient().GetFileByPath(ctx, vaultID, path)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to validate transcript_template")
+			httputil.WriteProblem(w, http.StatusInternalServerError, "failed to validate transcript_template")
 			logutil.FromCtx(ctx).Error("validate transcript_template", "path", path, "error", err)
 			return
 		}
 		if f == nil {
-			writeError(w, http.StatusBadRequest, fmt.Sprintf("transcript_template: file not found at %s", path))
+			httputil.WriteProblem(w, http.StatusBadRequest, fmt.Sprintf("transcript_template: file not found at %s", path))
 			return
 		}
 	}
 
 	updated, err := s.app.DBClient().UpdateVaultSettings(ctx, vaultID, merged)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to update settings")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to update settings")
 		logutil.FromCtx(ctx).Error("update vault settings", "vault_id", vaultID, "error", err)
 		return
 	}

--- a/internal/api/versions.go
+++ b/internal/api/versions.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -14,7 +15,7 @@ func (s *Server) listVersions(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Query().Get("path")
 
 	if path == "" {
-		writeError(w, http.StatusBadRequest, "path parameter required")
+		httputil.WriteProblem(w, http.StatusBadRequest, "path parameter required")
 		return
 	}
 
@@ -30,25 +31,25 @@ func (s *Server) listVersions(w http.ResponseWriter, r *http.Request) {
 
 	doc, err := s.app.DBClient().GetFileByPath(ctx, vaultID, path)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get document")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to get document")
 		logger.Error("list versions: get document", "vault_id", vaultID, "path", path, "error", err)
 		return
 	}
 	if doc == nil {
-		writeError(w, http.StatusNotFound, "document not found")
+		httputil.WriteProblem(w, http.StatusNotFound, "document not found")
 		return
 	}
 
 	docID, err := models.RecordIDString(doc.ID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "invalid document ID")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "invalid document ID")
 		logger.Error("list versions: extract doc ID", "path", path, "error", err)
 		return
 	}
 
 	versions, err := s.app.DBClient().ListVersions(ctx, docID, limit, 0)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list versions")
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list versions")
 		logger.Error("list versions", "doc_id", docID, "error", err)
 		return
 	}
@@ -63,5 +64,5 @@ func (s *Server) listVersions(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, http.StatusOK, httputil.NewListResponse(resp, len(resp)))
 }

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 
 	"github.com/raphi011/know/internal/models"
@@ -332,11 +333,9 @@ func (c *Client) ImportUpload(ctx context.Context, vaultName string, files []Imp
 
 	if resp2.StatusCode >= 400 {
 		<-errCh
-		var errResp struct {
-			Error string `json:"error"`
-		}
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error != "" {
-			return nil, &HTTPError{StatusCode: resp2.StatusCode, Message: errResp.Error}
+		var pd httputil.ProblemDetail
+		if json.Unmarshal(respBody, &pd) == nil && pd.Detail != "" {
+			return nil, &HTTPError{StatusCode: resp2.StatusCode, Message: pd.Detail}
 		}
 		return nil, &HTTPError{StatusCode: resp2.StatusCode, Message: string(respBody)}
 	}
@@ -413,11 +412,11 @@ type Vault struct {
 
 // ListVaults returns all accessible vaults.
 func (c *Client) ListVaults(ctx context.Context) ([]Vault, error) {
-	var vaults []Vault
-	if err := c.Get(ctx, "/api/v1/vaults", &vaults); err != nil {
+	var resp httputil.ListResponse[Vault]
+	if err := c.Get(ctx, "/api/v1/vaults", &resp); err != nil {
 		return nil, fmt.Errorf("list vaults: %w", err)
 	}
-	return vaults, nil
+	return resp.Items, nil
 }
 
 // SearchResult is the JSON representation of a search result from the REST API.
@@ -442,11 +441,11 @@ func (c *Client) SearchDocuments(ctx context.Context, vaultName, query string, l
 	if limit > 0 {
 		q.Set("limit", fmt.Sprintf("%d", limit))
 	}
-	var results []SearchResult
-	if err := c.Get(ctx, vaultPath(vaultName, "/search")+"?"+q.Encode(), &results); err != nil {
+	var resp httputil.ListResponse[SearchResult]
+	if err := c.Get(ctx, vaultPath(vaultName, "/search")+"?"+q.Encode(), &resp); err != nil {
 		return nil, fmt.Errorf("search documents: %w", err)
 	}
-	return results, nil
+	return resp.Items, nil
 }
 
 // Folder is the JSON representation of a folder from the REST API.
@@ -465,11 +464,11 @@ func (c *Client) ListFolders(ctx context.Context, vaultName string, parent *stri
 	if len(q) > 0 {
 		path += "?" + q.Encode()
 	}
-	var folders []Folder
-	if err := c.Get(ctx, path, &folders); err != nil {
+	var resp httputil.ListResponse[Folder]
+	if err := c.Get(ctx, path, &resp); err != nil {
 		return nil, fmt.Errorf("list folders: %w", err)
 	}
-	return folders, nil
+	return resp.Items, nil
 }
 
 // CreateDocumentRequest is the body for creating a document via REST API.
@@ -515,11 +514,11 @@ func (c *Client) ListVersions(ctx context.Context, vaultName, path string, limit
 	if limit > 0 {
 		q.Set("limit", fmt.Sprintf("%d", limit))
 	}
-	var versions []Version
-	if err := c.Get(ctx, vaultPath(vaultName, "/versions")+"?"+q.Encode(), &versions); err != nil {
+	var resp httputil.ListResponse[Version]
+	if err := c.Get(ctx, vaultPath(vaultName, "/versions")+"?"+q.Encode(), &resp); err != nil {
 		return nil, fmt.Errorf("list versions: %w", err)
 	}
-	return versions, nil
+	return resp.Items, nil
 }
 
 // Document is the JSON representation of a document returned by the REST API.
@@ -571,29 +570,29 @@ func (c *Client) ListFiles(ctx context.Context, vaultName, path string, recursiv
 	if recursive {
 		q.Set("recursive", "true")
 	}
-	var entries []models.FileEntry
-	if err := c.Get(ctx, vaultPath(vaultName, "/documents/ls")+"?"+q.Encode(), &entries); err != nil {
+	var resp httputil.ListResponse[models.FileEntry]
+	if err := c.Get(ctx, vaultPath(vaultName, "/documents/ls")+"?"+q.Encode(), &resp); err != nil {
 		return nil, fmt.Errorf("list files: %w", err)
 	}
-	return entries, nil
+	return resp.Items, nil
 }
 
 // ListLabels returns all distinct labels in the given vault.
 func (c *Client) ListLabels(ctx context.Context, vaultName string) ([]string, error) {
-	var labels []string
-	if err := c.Get(ctx, vaultPath(vaultName, "/labels"), &labels); err != nil {
+	var resp httputil.ListResponse[string]
+	if err := c.Get(ctx, vaultPath(vaultName, "/labels"), &resp); err != nil {
 		return nil, fmt.Errorf("list labels: %w", err)
 	}
-	return labels, nil
+	return resp.Items, nil
 }
 
 // ListLabelsWithCounts returns labels with their document counts for the given vault.
 func (c *Client) ListLabelsWithCounts(ctx context.Context, vaultName string) ([]models.LabelCount, error) {
-	var counts []models.LabelCount
-	if err := c.Get(ctx, vaultPath(vaultName, "/labels")+"?counts=true", &counts); err != nil {
+	var resp httputil.ListResponse[models.LabelCount]
+	if err := c.Get(ctx, vaultPath(vaultName, "/labels")+"?counts=true", &resp); err != nil {
 		return nil, fmt.Errorf("list labels with counts: %w", err)
 	}
-	return counts, nil
+	return resp.Items, nil
 }
 
 // JobStatusResponse is the response from GET /api/jobs.
@@ -740,6 +739,10 @@ func (c *Client) RestoreBackup(ctx context.Context, archivePath string) error {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		var pd httputil.ProblemDetail
+		if json.Unmarshal(body, &pd) == nil && pd.Detail != "" {
+			return &HTTPError{StatusCode: resp.StatusCode, Message: pd.Detail}
+		}
 		return &HTTPError{StatusCode: resp.StatusCode, Message: string(body)}
 	}
 	return nil
@@ -781,11 +784,9 @@ func (c *Client) downloadToFile(ctx context.Context, apiPath, outputPath string)
 		if readErr != nil {
 			return 0, fmt.Errorf("HTTP %d (failed to read error body: %w)", resp.StatusCode, readErr)
 		}
-		var errResp struct {
-			Error string `json:"error"`
-		}
-		if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
-			return 0, &HTTPError{StatusCode: resp.StatusCode, Message: errResp.Error}
+		var pd httputil.ProblemDetail
+		if json.Unmarshal(body, &pd) == nil && pd.Detail != "" {
+			return 0, &HTTPError{StatusCode: resp.StatusCode, Message: pd.Detail}
 		}
 		return 0, &HTTPError{StatusCode: resp.StatusCode, Message: string(body)}
 	}
@@ -823,11 +824,9 @@ func (c *Client) handleResponse(req *http.Request, target any) error {
 	}
 
 	if resp.StatusCode >= 400 {
-		var errResp struct {
-			Error string `json:"error"`
-		}
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error != "" {
-			return &HTTPError{StatusCode: resp.StatusCode, Message: errResp.Error}
+		var pd httputil.ProblemDetail
+		if json.Unmarshal(respBody, &pd) == nil && pd.Detail != "" {
+			return &HTTPError{StatusCode: resp.StatusCode, Message: pd.Detail}
 		}
 		return &HTTPError{StatusCode: resp.StatusCode, Message: string(respBody)}
 	}

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+
+	"github.com/raphi011/know/internal/httputil"
 )
 
 // TaskFilter holds query parameters for listing tasks.
@@ -30,10 +32,7 @@ type TaskResponse struct {
 }
 
 // TaskListResponse is the JSON envelope for listing tasks.
-type TaskListResponse struct {
-	Tasks []TaskResponse `json:"tasks"`
-	Total int            `json:"total"`
-}
+type TaskListResponse = httputil.ListResponse[TaskResponse]
 
 // ToggleTaskResponse holds the response from toggling a task.
 // If ID is non-empty, the task was returned directly.

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/raphi011/know/internal/db"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/metrics"
 )
@@ -18,7 +19,7 @@ func NoAuthMiddleware(next http.Handler) http.Handler {
 		ac, err := Authenticate(r.Context(), nil, "", true)
 		if err != nil {
 			slog.Error("no-auth mode: unexpected error", "error", err)
-			http.Error(w, "internal error", http.StatusInternalServerError)
+			httputil.WriteProblem(w, http.StatusInternalServerError, "internal error")
 			return
 		}
 		ctx := WithAuth(r.Context(), ac)
@@ -40,7 +41,7 @@ func Middleware(dbClient *db.Client, m *metrics.Metrics) func(http.Handler) http
 					slog.String("ip", clientIP(r)),
 				)
 				m.RecordAuthEvent(string(event), string(event.Result()))
-				http.Error(w, "missing authorization header", http.StatusUnauthorized)
+				httputil.WriteProblem(w, http.StatusUnauthorized, "missing authorization header")
 				return
 			}
 			rawToken := strings.TrimPrefix(header, "Bearer ")
@@ -58,7 +59,7 @@ func Middleware(dbClient *db.Client, m *metrics.Metrics) func(http.Handler) http
 					slog.String("ip", clientIP(r)),
 				)
 				m.RecordAuthEvent(string(event), string(event.Result()))
-				http.Error(w, "invalid token", http.StatusUnauthorized)
+				httputil.WriteProblem(w, http.StatusUnauthorized, "invalid token")
 				return
 			}
 

--- a/internal/event/handler.go
+++ b/internal/event/handler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
 )
@@ -15,28 +16,28 @@ import (
 func HandleEvents(bus *Bus) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			httputil.WriteProblem(w, http.StatusMethodNotAllowed, "method not allowed")
 			return
 		}
 
 		vaultID := r.URL.Query().Get("vaultId")
 		if vaultID == "" {
-			http.Error(w, "vaultId query parameter required", http.StatusBadRequest)
+			httputil.WriteProblem(w, http.StatusBadRequest, "vaultId query parameter required")
 			return
 		}
 
 		if _, err := auth.FromContext(r.Context()); err != nil {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			httputil.WriteProblem(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}
 		if err := auth.RequireVaultRole(r.Context(), vaultID, models.RoleRead); err != nil {
-			http.Error(w, "forbidden", http.StatusForbidden)
+			httputil.WriteProblem(w, http.StatusForbidden, "forbidden")
 			return
 		}
 
 		flusher, ok := w.(http.Flusher)
 		if !ok {
-			http.Error(w, "streaming not supported", http.StatusInternalServerError)
+			httputil.WriteProblem(w, http.StatusInternalServerError, "streaming not supported")
 			return
 		}
 

--- a/internal/httputil/httputil_test.go
+++ b/internal/httputil/httputil_test.go
@@ -1,0 +1,91 @@
+package httputil
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteProblem(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		detail string
+	}{
+		{"bad request", http.StatusBadRequest, "missing field"},
+		{"not found", http.StatusNotFound, "document not found"},
+		{"internal error", http.StatusInternalServerError, "unexpected failure"},
+		{"unauthorized", http.StatusUnauthorized, "invalid token"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			WriteProblem(rec, tt.status, tt.detail)
+
+			if rec.Code != tt.status {
+				t.Errorf("status = %d, want %d", rec.Code, tt.status)
+			}
+			if ct := rec.Header().Get("Content-Type"); ct != ProblemContentType {
+				t.Errorf("Content-Type = %q, want %q", ct, ProblemContentType)
+			}
+
+			var pd ProblemDetail
+			if err := json.NewDecoder(rec.Body).Decode(&pd); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if pd.Type != "about:blank" {
+				t.Errorf("type = %q, want %q", pd.Type, "about:blank")
+			}
+			if pd.Title != http.StatusText(tt.status) {
+				t.Errorf("title = %q, want %q", pd.Title, http.StatusText(tt.status))
+			}
+			if pd.Status != tt.status {
+				t.Errorf("status in body = %d, want %d", pd.Status, tt.status)
+			}
+			if pd.Detail != tt.detail {
+				t.Errorf("detail = %q, want %q", pd.Detail, tt.detail)
+			}
+		})
+	}
+}
+
+func TestNewListResponse_NilSlice(t *testing.T) {
+	resp := NewListResponse[string](nil, 0)
+
+	if resp.Items == nil {
+		t.Fatal("Items is nil, want non-nil empty slice")
+	}
+	if len(resp.Items) != 0 {
+		t.Errorf("len(Items) = %d, want 0", len(resp.Items))
+	}
+	if resp.Total != 0 {
+		t.Errorf("Total = %d, want 0", resp.Total)
+	}
+
+	// Verify JSON serializes as [] not null
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	if string(raw["items"]) != "[]" {
+		t.Errorf("items JSON = %s, want []", raw["items"])
+	}
+}
+
+func TestNewListResponse_WithItems(t *testing.T) {
+	items := []int{1, 2, 3}
+	resp := NewListResponse(items, 42)
+
+	if len(resp.Items) != 3 {
+		t.Errorf("len(Items) = %d, want 3", len(resp.Items))
+	}
+	if resp.Total != 42 {
+		t.Errorf("Total = %d, want 42", resp.Total)
+	}
+}

--- a/internal/httputil/list.go
+++ b/internal/httputil/list.go
@@ -1,0 +1,17 @@
+package httputil
+
+// ListResponse is the standard JSON envelope for all list endpoints.
+// Every list endpoint returns {"items": [...], "total": N}.
+type ListResponse[T any] struct {
+	Items []T `json:"items"`
+	Total int `json:"total"`
+}
+
+// NewListResponse creates a ListResponse, ensuring Items is never nil
+// so it serializes as [] instead of null.
+func NewListResponse[T any](items []T, total int) ListResponse[T] {
+	if items == nil {
+		items = []T{}
+	}
+	return ListResponse[T]{Items: items, Total: total}
+}

--- a/internal/httputil/problem.go
+++ b/internal/httputil/problem.go
@@ -1,0 +1,35 @@
+package httputil
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// ProblemDetail is an RFC 9457 (Problem Details for HTTP APIs) response body.
+// All error responses (4xx, 5xx) use this format with Content-Type: application/problem+json.
+type ProblemDetail struct {
+	Type   string `json:"type"`
+	Title  string `json:"title"`
+	Status int    `json:"status"`
+	Detail string `json:"detail"`
+}
+
+// ProblemContentType is the IANA media type for RFC 9457 problem details.
+const ProblemContentType = "application/problem+json"
+
+// WriteProblem writes an RFC 9457 Problem Details JSON response.
+// The title is derived from the HTTP status code; detail is the caller's message.
+func WriteProblem(w http.ResponseWriter, status int, detail string) {
+	p := ProblemDetail{
+		Type:   "about:blank",
+		Title:  http.StatusText(status),
+		Status: status,
+		Detail: detail,
+	}
+	w.Header().Set("Content-Type", ProblemContentType)
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(p); err != nil {
+		slog.Warn("failed to encode problem detail", "error", err)
+	}
+}

--- a/internal/integration/export_epub_test.go
+++ b/internal/integration/export_epub_test.go
@@ -196,13 +196,13 @@ func TestExportEPUB_MissingPath(t *testing.T) {
 	}
 
 	var errResp struct {
-		Error string `json:"error"`
+		Detail string `json:"detail"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
 		t.Fatalf("decode error: %v", err)
 	}
-	if errResp.Error == "" {
-		t.Error("expected non-empty error message")
+	if errResp.Detail == "" {
+		t.Error("expected non-empty error detail")
 	}
 }
 

--- a/internal/integration/ls_test.go
+++ b/internal/integration/ls_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/models"
 )
 
@@ -184,11 +185,11 @@ func lsRequest(t *testing.T, srv *httptest.Server, vaultName, path string, recur
 		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
 	}
 
-	var entries []models.FileEntry
-	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+	var listResp httputil.ListResponse[models.FileEntry]
+	if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	return entries
+	return listResp.Items
 }
 
 func entryNames(entries []models.FileEntry) []string {

--- a/internal/integration/move_test.go
+++ b/internal/integration/move_test.go
@@ -27,9 +27,9 @@ type moveResponse struct {
 	DryRun bool     `json:"dryRun"`
 }
 
-// errorResponse mirrors the server's error JSON.
+// errorResponse mirrors the server's RFC 9457 Problem Details JSON.
 type errorResponse struct {
-	Error string `json:"error"`
+	Detail string `json:"detail"`
 }
 
 // setupMoveServer creates a vault and httptest.Server with the move endpoint.
@@ -114,7 +114,7 @@ func TestMove_DocumentToExistingDocument_Conflict(t *testing.T) {
 	if err := json.Unmarshal(body, &errResp); err != nil {
 		t.Fatalf("decode error response: %v", err)
 	}
-	if errResp.Error == "" {
+	if errResp.Detail == "" {
 		t.Error("expected non-empty error message")
 	}
 }
@@ -136,8 +136,8 @@ func TestMove_DocumentToExistingFolder_Conflict(t *testing.T) {
 	if err := json.Unmarshal(body, &errResp); err != nil {
 		t.Fatalf("decode error response: %v", err)
 	}
-	if errResp.Error != "cannot move document to existing folder path: /myfolder" {
-		t.Errorf("unexpected error message: %s", errResp.Error)
+	if errResp.Detail != "cannot move document to existing folder path: /myfolder" {
+		t.Errorf("unexpected error message: %s", errResp.Detail)
 	}
 }
 
@@ -158,8 +158,8 @@ func TestMove_FolderToExistingDocument_Conflict(t *testing.T) {
 	if err := json.Unmarshal(body, &errResp); err != nil {
 		t.Fatalf("decode error response: %v", err)
 	}
-	if errResp.Error != "cannot move folder to existing document path: /target.md" {
-		t.Errorf("unexpected error message: %s", errResp.Error)
+	if errResp.Detail != "cannot move folder to existing document path: /target.md" {
+		t.Errorf("unexpected error message: %s", errResp.Detail)
 	}
 }
 

--- a/internal/tui/tasks.go
+++ b/internal/tui/tasks.go
@@ -182,7 +182,7 @@ func refetchTasksCmd(client *apiclient.Client, vaultID string, filter apiclient.
 		if err != nil {
 			return refetchResultMsg{err: err}
 		}
-		return refetchResultMsg{tasks: resp.Tasks}
+		return refetchResultMsg{tasks: resp.Items}
 	}
 }
 

--- a/internal/webdav/handler.go
+++ b/internal/webdav/handler.go
@@ -54,6 +54,9 @@ func (vm *vaultMap[T]) Range(fn func(vaultID string, v T) bool) {
 // The path prefix is stripped from incoming requests (e.g. "/dav/default/").
 // Auth uses HTTP Basic Auth where the password is a know API token.
 // maxPutBytes limits the size of PUT request bodies (0 = no limit).
+//
+// Note: errors use plain http.Error (not httputil.WriteProblem) because WebDAV
+// clients (macOS Finder, etc.) expect text/plain error bodies, not JSON.
 func NewHandler(
 	ctx context.Context,
 	pathPrefix string,


### PR DESCRIPTION
## Summary

- **Scalar API docs** at `/` with interactive "Try it" UI, powered by an OpenAPI 3.1 spec embedded via `go:embed`
- **RFC 9457 Problem Details** (`application/problem+json`) for all error responses, replacing `http.Error` and `{"error": ...}` patterns
- **Standardized list envelope** `{"items": [...], "total": N}` via generic `httputil.ListResponse[T]` for all list endpoints
- New `internal/httputil` package with `WriteProblem` and `NewListResponse` + unit tests

## Changes

### New files
- `internal/httputil/problem.go` — RFC 9457 `WriteProblem` helper
- `internal/httputil/list.go` — Generic `ListResponse[T]` with nil-guard
- `internal/httputil/httputil_test.go` — Unit tests for both
- `internal/api/docs.go` — Scalar UI + OpenAPI spec endpoints (unauthenticated)
- `internal/api/docs.html` — Scalar HTML shell (CDN pinned to v1.28.12)
- `internal/api/docs_test.go` — Tests for doc endpoints + YAML validity
- `internal/api/openapi.yaml` — OpenAPI 3.1 spec covering all 35+ routes
- `docs/feature-api-docs.md` — Feature documentation

### Migrated
- All `http.Error()` calls in `internal/api/`, `internal/agent/`, `internal/auth/`, `internal/event/` → `httputil.WriteProblem()`
- All list endpoints → `httputil.NewListResponse()`
- All clients (`apiclient`, CLI, TUI, integration tests) → new response shapes
- Removed `writeError` wrapper (pure delegation) — all 187 call sites now use `httputil.WriteProblem` directly
- Removed redundant nil-guards in 4 handlers (superseded by `NewListResponse`)
- `TaskListResponse` in `apiclient/tasks.go` → type alias for `httputil.ListResponse[TaskResponse]`

### Non-functional
- Fixed import ordering (`goimports`)
- Documented WebDAV handler's intentional exclusion from Problem Details migration
- Added `lang="en"` to docs HTML

## Test plan

- [x] `just build` succeeds
- [x] `just test` — all tests pass
- [x] New `httputil` tests verify `WriteProblem` Content-Type, status, JSON fields
- [x] New `httputil` tests verify `NewListResponse` nil-guard and JSON serialization
- [x] Existing integration tests updated for new response shapes (ls, move, export_epub)
- [ ] Manual: open `http://localhost:8484/` and verify Scalar UI renders
- [ ] Manual: try an API call in the Scalar UI with a Bearer token

🤖 Generated with [Claude Code](https://claude.com/claude-code)