### PR TITLE
feat: add admin user management CLI and API

### DIFF
--- a/cmd/know/cmd_admin.go
+++ b/cmd/know/cmd_admin.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	adminAPI *apiFlags
+)
+
+var adminCmd = &cobra.Command{
+	Use:   "admin",
+	Short: "System administration commands (requires system admin token)",
+}
+
+var adminCreateUserCmd = &cobra.Command{
+	Use:   "create-user",
+	Short: "Create a new user with a private vault",
+	Long: `Create a new user with the given name and email address.
+A private vault is automatically created for the user with admin membership.
+
+The user can then log in via OIDC using their email address.
+
+Examples:
+  know admin create-user --name alice --email alice@example.com`,
+	RunE: runAdminCreateUser,
+}
+
+var adminListUsersCmd = &cobra.Command{
+	Use:   "list-users",
+	Short: "List all users",
+	Long: `List all users with their name, email, admin status, and OIDC provider.
+
+Examples:
+  know admin list-users`,
+	RunE: runAdminListUsers,
+}
+
+func init() {
+	adminAPI = addAPIFlags(adminCmd)
+
+	f := adminCreateUserCmd.Flags()
+	f.String("name", "", "user name (required)")
+	f.String("email", "", "user email (required)")
+	if err := adminCreateUserCmd.MarkFlagRequired("name"); err != nil {
+		panic(fmt.Sprintf("mark name required: %v", err))
+	}
+	if err := adminCreateUserCmd.MarkFlagRequired("email"); err != nil {
+		panic(fmt.Sprintf("mark email required: %v", err))
+	}
+
+	adminCmd.AddCommand(adminCreateUserCmd)
+	adminCmd.AddCommand(adminListUsersCmd)
+}
+
+func runAdminCreateUser(cmd *cobra.Command, _ []string) error {
+	name, _ := cmd.Flags().GetString("name")
+	email, _ := cmd.Flags().GetString("email")
+
+	client := adminAPI.newClient()
+	ctx := context.Background()
+
+	resp, err := client.AdminCreateUser(ctx, name, email)
+	if err != nil {
+		return fmt.Errorf("create user: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Created user: %s (id: %s)\n", resp.User.Name, resp.User.ID)
+	if resp.User.Email != nil {
+		fmt.Fprintf(os.Stderr, "  Email: %s\n", *resp.User.Email)
+	}
+	fmt.Fprintf(os.Stderr, "Created private vault: %s (id: %s)\n", resp.Vault.Name, resp.Vault.ID)
+	fmt.Fprintf(os.Stderr, "  Membership: admin\n")
+	fmt.Fprintf(os.Stderr, "\nUser can now log in via OIDC with %s\n", email)
+	return nil
+}
+
+func runAdminListUsers(_ *cobra.Command, _ []string) error {
+	client := adminAPI.newClient()
+	ctx := context.Background()
+
+	users, err := client.AdminListUsers(ctx)
+	if err != nil {
+		return fmt.Errorf("list users: %w", err)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tEMAIL\tADMIN\tOIDC")
+	for _, u := range users {
+		email := "-"
+		if u.Email != nil {
+			email = *u.Email
+		}
+		admin := "no"
+		if u.IsSystemAdmin {
+			admin = "yes"
+		}
+		oidc := "-"
+		if u.OIDCProvider != nil {
+			oidc = *u.OIDCProvider
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", u.Name, email, admin, oidc)
+	}
+	return w.Flush()
+}

--- a/cmd/know/main.go
+++ b/cmd/know/main.go
@@ -108,6 +108,7 @@ func main() {
 	rootCmd.AddCommand(restoreCmd)
 	rootCmd.AddCommand(completionCmd)
 	rootCmd.AddCommand(authCmd)
+	rootCmd.AddCommand(adminCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/docs/feature-auth.md
+++ b/docs/feature-auth.md
@@ -256,6 +256,33 @@ When disabled (default), only pre-existing users can log in via OIDC. An admin m
 | `KNOW_TOKEN_MAX_LIFETIME_DAYS`| `90`    | Max token lifetime in days (0 = no limit)       |
 | `KNOW_TOKEN`                  | —       | API token for CLI commands                      |
 
+## Admin User Management
+
+System admins can create and list users via the CLI. Created users get a private vault automatically.
+
+### CLI Commands
+
+```bash
+# Create a user (they can log in via OIDC using their email)
+know admin create-user --name alice --email alice@example.com
+
+# List all users
+know admin list-users
+```
+
+### Private vs Shared Vaults
+
+- **Private vault**: Has an `owner` field set to a user. Created automatically when a user is provisioned (via admin CLI or OIDC self-signup).
+- **Shared vault**: Has no `owner`. Created via `db seed` or manually. Any user can be granted membership.
+
+### User Onboarding Flow
+
+1. Admin creates user: `know admin create-user --name alice --email alice@example.com`
+2. User logs in via OIDC: `know auth login` → email-match links their OIDC identity
+3. User has access to their private vault immediately
+
+When self-signup is enabled (`KNOW_SELF_SIGNUP_ENABLED=true`), new OIDC users are automatically provisioned with a private vault on first login.
+
 ## Example Prompts
 
 - "List my API tokens"
@@ -264,12 +291,16 @@ When disabled (default), only pre-existing users can log in via OIDC. An admin m
 - "Set up OIDC with GitHub for my Know server"
 - "How do I log in from the CLI?"
 - "Enable self-signup so new users can register via GitHub"
+- "Create a new user alice with email alice@company.com"
+- "List all users on the server"
 
 ## Reference
 
 - OIDC provider: `internal/oidc/` (provider, device flow, PKCE, user resolution)
 - Auth endpoints: `internal/api/auth.go` (device start/poll, login/callback, token exchange)
+- Admin endpoints: `internal/api/admin.go` (list users, create user)
 - Token management: `internal/api/tokens.go` (list, create, delete, rotate)
 - CLI auth: `cmd/know/cmd_auth.go` (login, status, logout)
+- CLI admin: `cmd/know/cmd_admin.go` (create-user, list-users)
 - Token validation: `internal/auth/` (token format, hashing, context)
 - Config: `internal/config/config.go` (OIDC and token settings)

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/httputil"
+	"github.com/raphi011/know/internal/logutil"
+	"github.com/raphi011/know/internal/models"
+)
+
+func (s *Server) listUsers(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := logutil.FromCtx(ctx)
+	if err := auth.RequireSystemAdmin(ctx); err != nil {
+		logger.Warn("admin access denied", "error", err)
+		httputil.WriteProblem(w, http.StatusForbidden, "system admin required")
+		return
+	}
+
+	users, err := s.app.DBClient().ListUsers(ctx)
+	if err != nil {
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list users")
+		logger.Error("list users", "error", err)
+		return
+	}
+
+	type userResponse struct {
+		ID            string  `json:"id"`
+		Name          string  `json:"name"`
+		Email         *string `json:"email,omitempty"`
+		IsSystemAdmin bool    `json:"is_system_admin"`
+		OIDCProvider  *string `json:"oidc_provider,omitempty"`
+	}
+
+	items := make([]userResponse, 0, len(users))
+	for _, u := range users {
+		id, err := models.RecordIDString(u.ID)
+		if err != nil {
+			logger.Warn("list users: extract user ID, skipping", "name", u.Name, "error", err)
+			continue
+		}
+		items = append(items, userResponse{
+			ID:            id,
+			Name:          u.Name,
+			Email:         u.Email,
+			IsSystemAdmin: u.IsSystemAdmin,
+			OIDCProvider:  u.OIDCProvider,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, httputil.NewListResponse(items, len(items)))
+}
+
+func (s *Server) createUser(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := logutil.FromCtx(ctx)
+	if err := auth.RequireSystemAdmin(ctx); err != nil {
+		logger.Warn("admin access denied", "error", err)
+		httputil.WriteProblem(w, http.StatusForbidden, "system admin required")
+		return
+	}
+
+	body, ok := decodeBody[struct {
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	}](w, r, 4096)
+	if !ok {
+		return
+	}
+
+	if body.Name == "" {
+		httputil.WriteProblem(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if body.Email == "" {
+		httputil.WriteProblem(w, http.StatusBadRequest, "email is required")
+		return
+	}
+
+	// Check for duplicate email
+	existing, err := s.app.DBClient().GetUserByEmail(ctx, body.Email)
+	if err != nil {
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to check existing user")
+		logger.Error("check existing user", "error", err)
+		return
+	}
+	if existing != nil {
+		httputil.WriteProblem(w, http.StatusConflict, "user with this email already exists")
+		return
+	}
+
+	user, vault, err := s.app.DBClient().ProvisionUser(ctx, models.UserInput{
+		Name:  body.Name,
+		Email: &body.Email,
+	})
+	if err != nil {
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to create user")
+		logger.Error("provision user", "error", err)
+		return
+	}
+
+	userID, err := models.RecordIDString(user.ID)
+	if err != nil {
+		httputil.WriteProblem(w, http.StatusInternalServerError, "invalid user ID")
+		logger.Error("create user: extract user id", "error", err)
+		return
+	}
+	vaultID, err := models.RecordIDString(vault.ID)
+	if err != nil {
+		httputil.WriteProblem(w, http.StatusInternalServerError, "invalid vault ID")
+		logger.Error("create user: extract vault id", "error", err)
+		return
+	}
+
+	logger.Info("admin created user", "user_id", userID, "email", body.Email, "vault_id", vaultID)
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"user": map[string]any{
+			"id":    userID,
+			"name":  user.Name,
+			"email": user.Email,
+		},
+		"vault": map[string]any{
+			"id":   vaultID,
+			"name": vault.Name,
+		},
+	})
+}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -47,6 +47,8 @@ tags:
     description: Agent conversation CRUD
   - name: Agent
     description: Agent chat, SSE events, cancellation, tool approval
+  - name: Admin
+    description: System administration (user management, system admin only)
   - name: Remotes
     description: Multi-server federation (system admin)
   - name: Jobs
@@ -77,6 +79,20 @@ components:
         type: string
 
   schemas:
+    AdminUser:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+        is_system_admin:
+          type: boolean
+        oidc_provider:
+          type: string
+
     ProblemDetail:
       type: object
       description: "RFC 9457 Problem Details for HTTP APIs"
@@ -2069,6 +2085,96 @@ paths:
                   status:
                     type: string
                     enum: [running]
+
+  # ── Admin ───────────────────────────────────────────────
+  /admin/users:
+    get:
+      tags: [Admin]
+      summary: List all users
+      description: Returns all users. Requires system admin.
+      operationId: listUsers
+      responses:
+        "200":
+          description: List of users
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/AdminUser"
+                  total:
+                    type: integer
+        "403":
+          description: Forbidden (not a system admin)
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+    post:
+      tags: [Admin]
+      summary: Create a new user with a private vault
+      description: |
+        Creates a user with the given name and email, a private vault named after the user,
+        and admin membership on that vault. Requires system admin.
+      operationId: createUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, email]
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                  format: email
+      responses:
+        "201":
+          description: User and vault created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      email:
+                        type: string
+                  vault:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+        "400":
+          description: Invalid request (missing name or email)
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "403":
+          description: Forbidden (not a system admin)
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "409":
+          description: Conflict (user with this email already exists)
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
 
   # ── Remotes ─────────────────────────────────────────────
   /remotes:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -117,6 +117,10 @@ func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Han
 		mux.Handle("POST /api/v1/agent/approval", g(agentRunner.HandleApproval()))
 	}
 
+	// --- Admin (system admin only) ---
+	mux.Handle("GET /api/v1/admin/users", g(s.listUsers))
+	mux.Handle("POST /api/v1/admin/users", g(s.createUser))
+
 	// --- Remotes (federation, system admin only) ---
 	mux.Handle("GET /api/v1/remotes", g(s.listRemotes))
 	mux.Handle("POST /api/v1/remotes", g(s.addRemote))

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -380,6 +380,47 @@ func (c *Client) do(ctx context.Context, method, path string, body, target any) 
 	return c.handleResponse(req, target)
 }
 
+// AdminUser is the JSON representation of a user from the admin API.
+type AdminUser struct {
+	ID            string  `json:"id"`
+	Name          string  `json:"name"`
+	Email         *string `json:"email,omitempty"`
+	IsSystemAdmin bool    `json:"is_system_admin"`
+	OIDCProvider  *string `json:"oidc_provider,omitempty"`
+}
+
+// AdminCreateUserResponse is the response from POST /api/v1/admin/users.
+type AdminCreateUserResponse struct {
+	User struct {
+		ID    string  `json:"id"`
+		Name  string  `json:"name"`
+		Email *string `json:"email,omitempty"`
+	} `json:"user"`
+	Vault struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"vault"`
+}
+
+// AdminListUsers returns all users (system admin only).
+func (c *Client) AdminListUsers(ctx context.Context) ([]AdminUser, error) {
+	var resp httputil.ListResponse[AdminUser]
+	if err := c.Get(ctx, "/api/v1/admin/users", &resp); err != nil {
+		return nil, fmt.Errorf("list users: %w", err)
+	}
+	return resp.Items, nil
+}
+
+// AdminCreateUser creates a new user with a private vault (system admin only).
+func (c *Client) AdminCreateUser(ctx context.Context, name, email string) (*AdminCreateUserResponse, error) {
+	body := map[string]string{"name": name, "email": email}
+	var resp AdminCreateUserResponse
+	if err := c.Post(ctx, "/api/v1/admin/users", body, &resp); err != nil {
+		return nil, fmt.Errorf("create user: %w", err)
+	}
+	return &resp, nil
+}
+
 // DeviceFlowStartResponse is the response from POST /auth/device/start.
 type DeviceFlowStartResponse struct {
 	UserCode        string `json:"user_code"`

--- a/internal/db/queries_user.go
+++ b/internal/db/queries_user.go
@@ -134,6 +134,78 @@ func (c *Client) LinkOIDCIdentity(ctx context.Context, userID, provider, subject
 	return nil
 }
 
+// ListUsers returns all users ordered by name.
+func (c *Client) ListUsers(ctx context.Context) ([]models.User, error) {
+	defer c.logOp(ctx, "user.list", time.Now())
+	sql := `SELECT * FROM user ORDER BY name ASC`
+	results, err := surrealdb.Query[[]models.User](ctx, c.DB(), sql, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list users: %w", err)
+	}
+	return allResults(results), nil
+}
+
+// ProvisionUser creates a user with a private vault and admin membership.
+// Returns the created user and their private vault.
+func (c *Client) ProvisionUser(ctx context.Context, input models.UserInput) (*models.User, *models.Vault, error) {
+	defer c.logOp(ctx, "user.provision", time.Now())
+
+	user, err := c.CreateUser(ctx, input)
+	if err != nil {
+		return nil, nil, fmt.Errorf("provision user: %w", err)
+	}
+
+	vault, err := c.provisionVaultForUser(ctx, user)
+	if err != nil {
+		return nil, nil, fmt.Errorf("provision user: %w", err)
+	}
+
+	return user, vault, nil
+}
+
+// ProvisionUserFromOIDC creates a user from OIDC claims with a private vault and admin membership.
+func (c *Client) ProvisionUserFromOIDC(ctx context.Context, provider, subject, name, email string) (*models.User, *models.Vault, error) {
+	defer c.logOp(ctx, "user.provision_from_oidc", time.Now())
+
+	user, err := c.CreateUserFromOIDC(ctx, provider, subject, name, email)
+	if err != nil {
+		return nil, nil, fmt.Errorf("provision oidc user: %w", err)
+	}
+
+	vault, err := c.provisionVaultForUser(ctx, user)
+	if err != nil {
+		return nil, nil, fmt.Errorf("provision oidc user: %w", err)
+	}
+
+	return user, vault, nil
+}
+
+// provisionVaultForUser creates a private vault owned by the user and adds admin membership.
+func (c *Client) provisionVaultForUser(ctx context.Context, user *models.User) (*models.Vault, error) {
+	userID, err := models.RecordIDString(user.ID)
+	if err != nil {
+		return nil, fmt.Errorf("extract user id: %w", err)
+	}
+
+	vault, err := c.CreateVaultWithOwner(ctx, userID, models.VaultInput{
+		Name: user.Name,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create vault: %w", err)
+	}
+
+	vaultID, err := models.RecordIDString(vault.ID)
+	if err != nil {
+		return nil, fmt.Errorf("extract vault id: %w", err)
+	}
+
+	if _, err := c.CreateVaultMember(ctx, userID, vaultID, models.RoleAdmin); err != nil {
+		return nil, fmt.Errorf("create membership: %w", err)
+	}
+
+	return vault, nil
+}
+
 // UpdateUserSystemAdmin sets the is_system_admin flag on a user.
 func (c *Client) UpdateUserSystemAdmin(ctx context.Context, userID string, isAdmin bool) error {
 	defer c.logOp(ctx, "user.update_system_admin", time.Now())

--- a/internal/db/queries_user_test.go
+++ b/internal/db/queries_user_test.go
@@ -239,6 +239,151 @@ func TestLinkOIDCIdentity(t *testing.T) {
 	}
 }
 
+func TestListUsers(t *testing.T) {
+	ctx := context.Background()
+
+	name1 := fmt.Sprintf("list-user-a-%d", time.Now().UnixNano())
+	name2 := fmt.Sprintf("list-user-b-%d", time.Now().UnixNano())
+
+	if _, err := testDB.CreateUser(ctx, models.UserInput{Name: name1}); err != nil {
+		t.Fatalf("CreateUser 1 failed: %v", err)
+	}
+	if _, err := testDB.CreateUser(ctx, models.UserInput{Name: name2}); err != nil {
+		t.Fatalf("CreateUser 2 failed: %v", err)
+	}
+
+	users, err := testDB.ListUsers(ctx)
+	if err != nil {
+		t.Fatalf("ListUsers failed: %v", err)
+	}
+	if len(users) < 2 {
+		t.Fatalf("Expected at least 2 users, got %d", len(users))
+	}
+
+	// Verify created users appear in results
+	found := map[string]bool{}
+	for _, u := range users {
+		found[u.Name] = true
+	}
+	if !found[name1] {
+		t.Errorf("Expected user %q in list", name1)
+	}
+	if !found[name2] {
+		t.Errorf("Expected user %q in list", name2)
+	}
+
+	// Verify ordering (ASC by name)
+	for i := 1; i < len(users); i++ {
+		if users[i].Name < users[i-1].Name {
+			t.Errorf("Users not ordered by name: %q < %q", users[i].Name, users[i-1].Name)
+		}
+	}
+}
+
+func TestProvisionUser(t *testing.T) {
+	ctx := context.Background()
+
+	name := fmt.Sprintf("provision-%d", time.Now().UnixNano())
+	email := fmt.Sprintf("provision-%d@example.com", time.Now().UnixNano())
+
+	user, vault, err := testDB.ProvisionUser(ctx, models.UserInput{
+		Name:  name,
+		Email: &email,
+	})
+	if err != nil {
+		t.Fatalf("ProvisionUser failed: %v", err)
+	}
+
+	if user.Name != name {
+		t.Errorf("Expected user name %q, got %q", name, user.Name)
+	}
+	if user.Email == nil || *user.Email != email {
+		t.Errorf("Expected email %q, got %v", email, user.Email)
+	}
+
+	// Vault should be named after the user and owned by them
+	if vault.Name != name {
+		t.Errorf("Expected vault name %q, got %q", name, vault.Name)
+	}
+	if vault.Owner == nil {
+		t.Fatal("Expected vault to have an owner")
+	}
+
+	userID := models.MustRecordIDString(user.ID)
+	ownerID := models.MustRecordIDString(*vault.Owner)
+	if ownerID != userID {
+		t.Errorf("Expected vault owner %q, got %q", userID, ownerID)
+	}
+
+	// Verify vault membership
+	vaultID := models.MustRecordIDString(vault.ID)
+	members, err := testDB.GetVaultMembers(ctx, vaultID)
+	if err != nil {
+		t.Fatalf("GetVaultMembers failed: %v", err)
+	}
+	if len(members) != 1 {
+		t.Fatalf("Expected 1 vault member, got %d", len(members))
+	}
+	if members[0].Role != string(models.RoleAdmin) {
+		t.Errorf("Expected admin role, got %q", members[0].Role)
+	}
+}
+
+func TestProvisionUserFromOIDC(t *testing.T) {
+	ctx := context.Background()
+
+	provider := "https://accounts.google.com"
+	subject := fmt.Sprintf("provision-oidc-sub-%d", time.Now().UnixNano())
+	name := fmt.Sprintf("provision-oidc-%d", time.Now().UnixNano())
+	email := fmt.Sprintf("provision-oidc-%d@example.com", time.Now().UnixNano())
+
+	user, vault, err := testDB.ProvisionUserFromOIDC(ctx, provider, subject, name, email)
+	if err != nil {
+		t.Fatalf("ProvisionUserFromOIDC failed: %v", err)
+	}
+
+	// Verify user fields
+	if user.Name != name {
+		t.Errorf("Expected user name %q, got %q", name, user.Name)
+	}
+	if user.Email == nil || *user.Email != email {
+		t.Errorf("Expected email %q, got %v", email, user.Email)
+	}
+	if user.OIDCProvider == nil || *user.OIDCProvider != provider {
+		t.Errorf("Expected oidc_provider %q, got %v", provider, user.OIDCProvider)
+	}
+	if user.OIDCSubject == nil || *user.OIDCSubject != subject {
+		t.Errorf("Expected oidc_subject %q, got %v", subject, user.OIDCSubject)
+	}
+
+	// Vault should be named after the user and owned by them
+	if vault.Name != name {
+		t.Errorf("Expected vault name %q, got %q", name, vault.Name)
+	}
+	if vault.Owner == nil {
+		t.Fatal("Expected vault to have an owner")
+	}
+
+	userID := models.MustRecordIDString(user.ID)
+	ownerID := models.MustRecordIDString(*vault.Owner)
+	if ownerID != userID {
+		t.Errorf("Expected vault owner %q, got %q", userID, ownerID)
+	}
+
+	// Verify vault membership
+	vaultID := models.MustRecordIDString(vault.ID)
+	members, err := testDB.GetVaultMembers(ctx, vaultID)
+	if err != nil {
+		t.Fatalf("GetVaultMembers failed: %v", err)
+	}
+	if len(members) != 1 {
+		t.Fatalf("Expected 1 vault member, got %d", len(members))
+	}
+	if members[0].Role != string(models.RoleAdmin) {
+		t.Errorf("Expected admin role, got %q", members[0].Role)
+	}
+}
+
 func TestGetUserByName(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/db/queries_vault.go
+++ b/internal/db/queries_vault.go
@@ -52,6 +52,41 @@ func (c *Client) CreateVaultWithID(ctx context.Context, vaultID string, userID s
 	return firstResult(results, "create vault with id")
 }
 
+// CreateVaultWithOwner creates a vault owned by a specific user (private vault).
+func (c *Client) CreateVaultWithOwner(ctx context.Context, userID string, input models.VaultInput) (*models.Vault, error) {
+	defer c.logOp(ctx, "vault.create_with_owner", time.Now())
+	sql := `
+		CREATE vault SET
+			name = $name,
+			description = $description,
+			owner = type::record("user", $user_id),
+			created_by = type::record("user", $user_id)
+		RETURN AFTER
+	`
+	results, err := surrealdb.Query[[]models.Vault](ctx, c.DB(), sql, map[string]any{
+		"name":        input.Name,
+		"description": optionalString(input.Description),
+		"user_id":     bareID("user", userID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create vault with owner: %w", err)
+	}
+	return firstResult(results, "create vault with owner")
+}
+
+// GetVaultByOwner returns the private vault owned by the given user.
+func (c *Client) GetVaultByOwner(ctx context.Context, userID string) (*models.Vault, error) {
+	defer c.logOp(ctx, "vault.get_by_owner", time.Now())
+	sql := `SELECT * FROM vault WHERE owner = type::record("user", $user_id) LIMIT 1`
+	results, err := surrealdb.Query[[]models.Vault](ctx, c.DB(), sql, map[string]any{
+		"user_id": bareID("user", userID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get vault by owner: %w", err)
+	}
+	return firstResultOpt(results), nil
+}
+
 func (c *Client) GetVault(ctx context.Context, id string) (*models.Vault, error) {
 	defer c.logOp(ctx, "vault.get", time.Now())
 	sql := `SELECT * FROM type::record("vault", $id)`

--- a/internal/db/queries_vault_test.go
+++ b/internal/db/queries_vault_test.go
@@ -129,6 +129,73 @@ func TestCreateVaultWithID(t *testing.T) {
 	}
 }
 
+func TestCreateVaultWithOwner(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+
+	vault, err := testDB.CreateVaultWithOwner(ctx, userID, models.VaultInput{
+		Name: fmt.Sprintf("owned-vault-%d", time.Now().UnixNano()),
+	})
+	if err != nil {
+		t.Fatalf("CreateVaultWithOwner failed: %v", err)
+	}
+	if vault.Owner == nil {
+		t.Fatal("Expected vault to have an owner")
+	}
+	ownerID := models.MustRecordIDString(*vault.Owner)
+	if ownerID != userID {
+		t.Errorf("Expected owner %q, got %q", userID, ownerID)
+	}
+
+	// Shared vault (no owner) should have nil owner
+	shared, err := testDB.CreateVault(ctx, userID, models.VaultInput{
+		Name: fmt.Sprintf("shared-vault-%d", time.Now().UnixNano()),
+	})
+	if err != nil {
+		t.Fatalf("CreateVault failed: %v", err)
+	}
+	if shared.Owner != nil {
+		t.Error("Shared vault should not have an owner")
+	}
+}
+
+func TestGetVaultByOwner(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+
+	// No vault yet
+	notFound, err := testDB.GetVaultByOwner(ctx, userID)
+	if err != nil {
+		t.Fatalf("GetVaultByOwner should not error for missing: %v", err)
+	}
+	if notFound != nil {
+		t.Error("Expected nil for user with no owned vault")
+	}
+
+	// Create owned vault
+	created, err := testDB.CreateVaultWithOwner(ctx, userID, models.VaultInput{
+		Name: fmt.Sprintf("findable-vault-%d", time.Now().UnixNano()),
+	})
+	if err != nil {
+		t.Fatalf("CreateVaultWithOwner failed: %v", err)
+	}
+
+	found, err := testDB.GetVaultByOwner(ctx, userID)
+	if err != nil {
+		t.Fatalf("GetVaultByOwner failed: %v", err)
+	}
+	if found == nil {
+		t.Fatal("GetVaultByOwner returned nil for user with owned vault")
+	}
+	createdID := models.MustRecordIDString(created.ID)
+	foundID := models.MustRecordIDString(found.ID)
+	if foundID != createdID {
+		t.Errorf("Expected vault ID %q, got %q", createdID, foundID)
+	}
+}
+
 func TestGetVaultByName(t *testing.T) {
 	ctx := context.Background()
 	user := createTestUser(t, ctx)

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -36,6 +36,7 @@ func SchemaSQL(dimension int) string {
 
     DEFINE FIELD IF NOT EXISTS name        ON vault TYPE string;
     DEFINE FIELD IF NOT EXISTS description ON vault TYPE option<string>;
+    DEFINE FIELD IF NOT EXISTS owner       ON vault TYPE option<record<user>>;
     DEFINE FIELD IF NOT EXISTS settings    ON vault TYPE option<object> FLEXIBLE;
     DEFINE FIELD IF NOT EXISTS created_by  ON vault TYPE record<user>;
     DEFINE FIELD IF NOT EXISTS created_at  ON vault TYPE datetime DEFAULT time::now();

--- a/internal/models/vault.go
+++ b/internal/models/vault.go
@@ -8,14 +8,18 @@ import (
 )
 
 type Vault struct {
-	ID          surrealmodels.RecordID `json:"id"`
-	Name        string                 `json:"name"`
-	Description *string                `json:"description,omitempty"`
-	Settings    *VaultSettings         `json:"settings,omitempty"`
-	CreatedBy   surrealmodels.RecordID `json:"created_by"`
-	CreatedAt   time.Time              `json:"created_at"`
-	UpdatedAt   time.Time              `json:"updated_at"`
+	ID          surrealmodels.RecordID  `json:"id"`
+	Name        string                  `json:"name"`
+	Description *string                 `json:"description,omitempty"`
+	Owner       *surrealmodels.RecordID `json:"owner,omitempty"`
+	Settings    *VaultSettings          `json:"settings,omitempty"`
+	CreatedBy   surrealmodels.RecordID  `json:"created_by"`
+	CreatedAt   time.Time               `json:"created_at"`
+	UpdatedAt   time.Time               `json:"updated_at"`
 }
+
+// IsPrivate returns true if the vault is owned by a specific user.
+func (v *Vault) IsPrivate() bool { return v.Owner != nil }
 
 // VaultSettings holds per-vault configuration.
 type VaultSettings struct {

--- a/internal/oidc/user.go
+++ b/internal/oidc/user.go
@@ -51,9 +51,9 @@ func FindOrCreateUser(ctx context.Context, dbClient *db.Client, info *UserInfo, 
 		return nil, fmt.Errorf("registration disabled: no matching user for %s", info.Email)
 	}
 
-	user, err = dbClient.CreateUserFromOIDC(ctx, info.Provider, info.Subject, info.Name, info.Email)
+	user, _, err = dbClient.ProvisionUserFromOIDC(ctx, info.Provider, info.Subject, info.Name, info.Email)
 	if err != nil {
-		return nil, fmt.Errorf("create oidc user: %w", err)
+		return nil, fmt.Errorf("provision oidc user: %w", err)
 	}
 
 	return user, nil


### PR DESCRIPTION
Add admin endpoints and CLI commands for user provisioning. System admins can create users with private vaults and list all users via CLI or REST API. OIDC self-signup now also provisions private vaults automatically.

## New Features
- `know admin create-user --name X --email Y` — creates user + private vault + admin membership
- `know admin list-users` — tabular list of all users with admin/OIDC status
- REST API: `GET/POST /api/v1/admin/users` (system admin only, OpenAPI spec updated)
- Vault `owner` field distinguishes private vaults from shared vaults
- `Vault.IsPrivate()` helper method
- OIDC self-signup now provisions a private vault via `ProvisionUserFromOIDC`

## Breaking Changes
- None