### PR TITLE
feat: harden auth with rate limiting, token cleanup, and security improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,19 @@ KNOW_EMBED_DIMENSION=768
 # HTTPS_PROXY=...                                 # Set by Teleport proxy
 
 # =============================================================================
+# Authentication & Rate Limiting
+# =============================================================================
+# KNOW_NO_AUTH=false
+# KNOW_TOKEN_MAX_LIFETIME_DAYS=90
+# KNOW_TRUST_X_FORWARDED_FOR=false  # set true when behind a reverse proxy
+
+# Rate limiting (0 = disabled)
+# KNOW_RATE_LIMIT_AUTH_RPS=5
+# KNOW_RATE_LIMIT_AUTH_BURST=10
+# KNOW_RATE_LIMIT_GLOBAL_RPS=100
+# KNOW_RATE_LIMIT_GLOBAL_BURST=200
+
+# =============================================================================
 # Chunking Configuration
 # =============================================================================
 # Tune chunk sizes to match your embedding model's context window.

--- a/cmd/know/cmd_auth.go
+++ b/cmd/know/cmd_auth.go
@@ -76,6 +76,19 @@ var authLoginCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiURL, _ := cmd.Flags().GetString("api-url")
 
+		// Check if server has OIDC enabled
+		client := apiclient.New(apiURL, "")
+		cfg, err := client.GetConfig(context.Background())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not check server configuration: %v\n", err)
+			fmt.Println("Falling back to token-based login.")
+			return loginWithToken(apiURL)
+		}
+		if cfg == nil || !cfg.OIDCEnabled {
+			fmt.Println("OIDC is not enabled on this server.")
+			return loginWithToken(apiURL)
+		}
+
 		fmt.Println("How would you like to authenticate?")
 		fmt.Println("  1. Login with a web browser (OIDC)")
 		fmt.Println("  2. Paste an API token")

--- a/cmd/know/cmd_serve.go
+++ b/cmd/know/cmd_serve.go
@@ -177,6 +177,14 @@ func runServe(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// Auth rate limiter (wraps OIDC routes only)
+	var authRateLimiter *api.IPRateLimiter
+	if cfg.RateLimitAuthRPS > 0 {
+		authRateLimiter = api.NewIPRateLimiter(cfg.RateLimitAuthRPS, cfg.RateLimitAuthBurst, "auth", app.Metrics())
+		defer authRateLimiter.Stop()
+		slog.Info("auth rate limiting enabled", "rps", cfg.RateLimitAuthRPS, "burst", cfg.RateLimitAuthBurst)
+	}
+
 	// OIDC auth routes (unauthenticated — must be registered before auth middleware)
 	if cfg.OIDCEnabled {
 		oidcProvider, oidcErr := oidc.New(ctx, cfg.OIDCIssuerURL, cfg.OIDCClientID, cfg.OIDCClientSecret, cfg.OIDCRedirectURL, nil, cfg.OIDCProviderName)
@@ -187,25 +195,36 @@ func runServe(_ *cobra.Command, _ []string) error {
 		if oidcErr != nil {
 			return fmt.Errorf("init oidc handler: %w", oidcErr)
 		}
-		oidcHandler.RegisterRoutes(mux)
+		if authRateLimiter != nil {
+			oidcHandler.RegisterRoutes(mux, authRateLimiter.Middleware(cfg.TrustXForwardedFor))
+		} else {
+			oidcHandler.RegisterRoutes(mux)
+		}
 		slog.Info("OIDC authentication enabled", "issuer", cfg.OIDCIssuerURL, "provider_name", oidcProvider.ProviderName())
-
-		// Periodically clean up expired device codes
-		go func() {
-			ticker := time.NewTicker(5 * time.Minute)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ticker.C:
-					if err := app.DBClient().DeleteExpiredDeviceCodes(ctx); err != nil {
-						slog.Warn("failed to clean up expired device codes", "error", err)
-					}
-				case <-ctx.Done():
-					return
-				}
-			}
-		}()
 	}
+
+	// Periodic cleanup: expired tokens (always) and device codes (when OIDC enabled)
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := app.DBClient().DeleteExpiredTokens(serverCtx); err != nil {
+					slog.Warn("failed to clean up expired tokens", "error", err)
+					app.Metrics().RecordCleanupFailure("expired_tokens")
+				}
+				if cfg.OIDCEnabled {
+					if err := app.DBClient().DeleteExpiredDeviceCodes(serverCtx); err != nil {
+						slog.Warn("failed to clean up expired device codes", "error", err)
+						app.Metrics().RecordCleanupFailure("expired_device_codes")
+					}
+				}
+			case <-serverCtx.Done():
+				return
+			}
+		}
+	}()
 
 	// Auth middleware
 	var authMw func(http.Handler) http.Handler
@@ -213,7 +232,9 @@ func runServe(_ *cobra.Command, _ []string) error {
 		slog.Warn("no-auth mode enabled: skipping token validation")
 		authMw = auth.NoAuthMiddleware
 	} else {
-		authMw = auth.Middleware(app.DBClient(), app.Metrics())
+		authMw = auth.Middleware(app.DBClient(), app.Metrics(), auth.MiddlewareConfig{
+			TrustXForwardedFor: cfg.TrustXForwardedFor,
+		})
 	}
 
 	// REST API (includes agent routes)
@@ -366,9 +387,18 @@ func runServe(_ *cobra.Command, _ []string) error {
 		fmt.Fprintln(w, "ok")
 	})
 
+	// Global rate limiter (outermost middleware)
+	var handler http.Handler = api.RequestLogMiddleware(app.Metrics(), mux)
+	if cfg.RateLimitGlobalRPS > 0 {
+		globalRL := api.NewIPRateLimiter(cfg.RateLimitGlobalRPS, cfg.RateLimitGlobalBurst, "global", app.Metrics())
+		defer globalRL.Stop()
+		handler = globalRL.Middleware(cfg.TrustXForwardedFor)(handler)
+		slog.Info("global rate limiting enabled", "rps", cfg.RateLimitGlobalRPS, "burst", cfg.RateLimitGlobalBurst)
+	}
+
 	httpServer := &http.Server{
 		Addr:              listenHost + ":" + port,
-		Handler:           api.RequestLogMiddleware(app.Metrics(), mux),
+		Handler:           handler,
 		ReadHeaderTimeout: 5 * time.Second,
 		IdleTimeout:       120 * time.Second,
 		// WriteTimeout intentionally omitted: SSE endpoints are long-lived.

--- a/docs/feature-auth.md
+++ b/docs/feature-auth.md
@@ -255,6 +255,32 @@ When disabled (default), only pre-existing users can log in via OIDC. An admin m
 | `KNOW_SELF_SIGNUP_ENABLED`    | `false` | Auto-create users on first OIDC login           |
 | `KNOW_TOKEN_MAX_LIFETIME_DAYS`| `90`    | Max token lifetime in days (0 = no limit)       |
 | `KNOW_TOKEN`                  | —       | API token for CLI commands                      |
+| `KNOW_TRUST_X_FORWARDED_FOR` | `true`  | Trust X-Forwarded-For header for client IP      |
+| `KNOW_RATE_LIMIT_AUTH_RPS`   | `5`     | Requests/sec for `/auth/*` endpoints (0 = off)  |
+| `KNOW_RATE_LIMIT_AUTH_BURST` | `10`    | Burst size for auth rate limiter                |
+| `KNOW_RATE_LIMIT_GLOBAL_RPS` | `100`   | Requests/sec global per-IP (0 = off)            |
+| `KNOW_RATE_LIMIT_GLOBAL_BURST`| `200`  | Burst size for global rate limiter              |
+
+## Rate Limiting
+
+Two tiers of per-IP rate limiting protect the server from abuse:
+
+- **Auth tier** (`/auth/*` endpoints): Stricter limits on unauthenticated login/device-flow/token-exchange endpoints. Default: 5 req/s with burst of 10.
+- **Global tier** (all endpoints): A generous global limit applied to every request. Default: 100 req/s with burst of 200.
+
+Set any RPS value to `0` to disable that tier. When a request is rate-limited, the server returns `429 Too Many Requests` with a `Retry-After` header and an RFC 9457 problem detail body.
+
+Rate-limited requests are tracked via the `know_rate_limit_rejected_total` Prometheus counter (label: `tier`).
+
+## Token Limits
+
+- **Max tokens per user**: 50. Attempting to create more returns `409 Conflict`.
+- **Self-deletion guard**: You cannot delete the token you are currently authenticating with (returns `409 Conflict`). Token rotation is allowed on the current token.
+- **Expired token cleanup**: Expired tokens are automatically removed every 5 minutes.
+
+## Proxy Trust
+
+When deployed behind a reverse proxy (nginx, Traefik, etc.), set `KNOW_TRUST_X_FORWARDED_FOR=true` (default) to use the client IP from the `X-Forwarded-For` header. Set to `false` when the server is directly exposed to use `RemoteAddr` instead, preventing IP spoofing.
 
 ## Admin User Management
 

--- a/helm/know/templates/deployment.yaml
+++ b/helm/know/templates/deployment.yaml
@@ -83,6 +83,16 @@ spec:
             {{- end }}
             - name: KNOW_TOKEN_MAX_LIFETIME_DAYS
               value: {{ .Values.tokenMaxLifetimeDays | default 90 | quote }}
+            - name: KNOW_TRUST_X_FORWARDED_FOR
+              value: {{ .Values.trustXForwardedFor | default true | quote }}
+            - name: KNOW_RATE_LIMIT_AUTH_RPS
+              value: {{ .Values.rateLimit.authRPS | default 5 | quote }}
+            - name: KNOW_RATE_LIMIT_AUTH_BURST
+              value: {{ .Values.rateLimit.authBurst | default 10 | quote }}
+            - name: KNOW_RATE_LIMIT_GLOBAL_RPS
+              value: {{ .Values.rateLimit.globalRPS | default 100 | quote }}
+            - name: KNOW_RATE_LIMIT_GLOBAL_BURST
+              value: {{ .Values.rateLimit.globalBurst | default 200 | quote }}
             - name: KNOW_SERVER_PORT
               value: "8484"
             # Logging

--- a/helm/know/values.yaml
+++ b/helm/know/values.yaml
@@ -128,6 +128,16 @@ oidc:
   providerName: ""  # explicit provider name for DB key (default: derived from issuer URL)
   selfSignupEnabled: false
 
+# Rate limiting (0 = disabled)
+rateLimit:
+  authRPS: 5         # requests/sec for /auth/* endpoints
+  authBurst: 10
+  globalRPS: 100     # requests/sec global per-IP
+  globalBurst: 200
+
+# Proxy trust (default false; set true in K8s where the server is behind an ingress proxy)
+trustXForwardedFor: true
+
 # API keys (set via existingSecret or directly)
 # Prefer using existingSecret for production
 apiKeys:

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -55,12 +55,20 @@ func NewOIDCHandler(provider *oidc.Provider, dbClient *db.Client, selfSignup boo
 }
 
 // RegisterRoutes registers unauthenticated OIDC auth routes.
-func (h *OIDCHandler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("POST /auth/device/start", h.handleDeviceStart)
-	mux.HandleFunc("POST /auth/device/poll", h.handleDevicePoll)
-	mux.HandleFunc("POST /auth/token", h.handleTokenExchange)
-	mux.HandleFunc("GET /auth/login", h.handleOIDCLogin)
-	mux.HandleFunc("GET /auth/callback", h.handleOIDCCallback)
+// If mw is non-nil, each route is wrapped with the middleware (e.g. rate limiting).
+func (h *OIDCHandler) RegisterRoutes(mux *http.ServeMux, mw ...func(http.Handler) http.Handler) {
+	wrap := func(handler http.HandlerFunc) http.Handler {
+		var h http.Handler = handler
+		for _, m := range mw {
+			h = m(h)
+		}
+		return h
+	}
+	mux.Handle("POST /auth/device/start", wrap(h.handleDeviceStart))
+	mux.Handle("POST /auth/device/poll", wrap(h.handleDevicePoll))
+	mux.Handle("POST /auth/token", wrap(h.handleTokenExchange))
+	mux.Handle("GET /auth/login", wrap(h.handleOIDCLogin))
+	mux.Handle("GET /auth/callback", wrap(h.handleOIDCCallback))
 }
 
 // handleDeviceStart initiates the device authorization flow.
@@ -144,19 +152,26 @@ func (h *OIDCHandler) handleDevicePoll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Approved — return the token and delete the device code record
-	token := ""
+	// Approved — decrypt and return the token, then delete the device code record
+	encryptedToken := ""
 	if dc.RawToken != nil {
-		token = *dc.RawToken
+		encryptedToken = *dc.RawToken
 	}
-	if token == "" {
+	if encryptedToken == "" {
 		logger.Error("approved device code has no token", "device_code", body.DeviceCode)
 		httputil.WriteProblem(w, http.StatusInternalServerError, "device code approved but token missing")
 		return
 	}
 
+	token, err := oidc.DecryptWithDeviceCode(encryptedToken, body.DeviceCode)
+	if err != nil {
+		logger.Error("decrypt device code token", "error", err)
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to decrypt token")
+		return
+	}
+
 	if err := h.db.DeleteDeviceCode(ctx, body.DeviceCode); err != nil {
-		logger.Error("delete approved device code — raw token may linger until expiry cleanup", "error", err)
+		logger.Error("delete approved device code", "error", err)
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{
@@ -256,9 +271,28 @@ func (h *OIDCHandler) handleOIDCCallback(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Approve the device code with the raw token so the CLI can retrieve it.
-	// Raw token stored temporarily — record is deleted within 15 min after poll.
-	if err := h.db.ApproveDeviceCode(ctx, userCode, userID, rawToken); err != nil {
+	// Encrypt the raw token with the device code before storing — only the
+	// CLI that holds the device_code can decrypt it.
+	dc, err := h.db.GetDeviceCodeByUserCode(ctx, userCode)
+	if err != nil {
+		logger.Error("get device code for encryption", "error", err)
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to look up device code")
+		return
+	}
+	if dc == nil {
+		logger.Warn("device code not found during callback", "user_code", userCode)
+		httputil.WriteProblem(w, http.StatusNotFound, "device code not found or expired")
+		return
+	}
+	encryptedToken, err := oidc.EncryptWithDeviceCode(rawToken, dc.DeviceCode)
+	if err != nil {
+		logger.Error("encrypt token for device code", "error", err)
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to encrypt token")
+		return
+	}
+
+	// Store the encrypted token so only the CLI can retrieve it.
+	if err := h.db.ApproveDeviceCode(ctx, userCode, userID, encryptedToken); err != nil {
 		logger.Error("approve device code", "error", err)
 		// Clean up the orphaned token to avoid leaving a valid but undelivered credential
 		tokenID, idErr := models.RecordIDString(token.ID)

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -35,5 +35,6 @@ func (s *Server) getConfig(w http.ResponseWriter, r *http.Request) {
 		MultimodalEmbedEnabled:  cfg.MultimodalEmbedEnabled,
 		TextExtractorModel:      cfg.TextExtractorModel,
 		TextExtractorEnabled:    cfg.TextExtractorEnabled,
+		OIDCEnabled:             cfg.OIDCEnabled,
 	})
 }

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -820,6 +820,10 @@ components:
           type: string
         textExtractorEnabled:
           type: boolean
+        tokenMaxLifetimeDays:
+          type: integer
+        oidcEnabled:
+          type: boolean
 
     ImportManifestFile:
       type: object
@@ -1016,6 +1020,23 @@ components:
             $ref: "#/components/schemas/ProblemDetail"
     NotFound:
       description: Resource not found
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetail"
+    Conflict:
+      description: Conflict (e.g. resource limit reached, self-referential operation)
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetail"
+    TooManyRequests:
+      description: Rate limit exceeded
+      headers:
+        Retry-After:
+          description: Seconds until the client should retry
+          schema:
+            type: integer
       content:
         application/problem+json:
           schema:
@@ -2326,12 +2347,20 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "409":
+          description: Maximum number of tokens reached
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   /tokens/{id}:
     delete:
       tags: [Tokens]
       summary: Delete token
-      description: Deletes an API token. Users can only delete their own tokens.
+      description: Deletes an API token. Users can only delete their own tokens. Cannot delete the token currently in use.
       parameters:
         - name: id
           in: path
@@ -2347,6 +2376,12 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          description: Cannot delete the token currently in use
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
 
   /tokens/{id}/rotate:
     post:

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"log/slog"
+	"math"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/raphi011/know/internal/httputil"
+	"github.com/raphi011/know/internal/metrics"
+)
+
+// IPRateLimiter provides per-IP rate limiting using a token bucket algorithm.
+type IPRateLimiter struct {
+	limiters sync.Map // map[string]*limiterEntry
+	rps      rate.Limit
+	burst    int
+	tier     string // "auth" or "global", for metrics
+	metrics  *metrics.Metrics
+	done     chan struct{}
+}
+
+type limiterEntry struct {
+	limiter      *rate.Limiter
+	lastSeenUnix atomic.Int64 // unix timestamp, accessed concurrently
+}
+
+// NewIPRateLimiter creates a new per-IP rate limiter.
+// rps is the sustained requests per second; burst is the max burst size.
+// tier is used for metrics labels ("auth" or "global").
+// Starts a background goroutine to clean up stale entries every 10 minutes.
+func NewIPRateLimiter(rps float64, burst int, tier string, m *metrics.Metrics) *IPRateLimiter {
+	rl := &IPRateLimiter{
+		rps:     rate.Limit(rps),
+		burst:   burst,
+		tier:    tier,
+		metrics: m,
+		done:    make(chan struct{}),
+	}
+	go rl.cleanup()
+	return rl
+}
+
+// Stop terminates the background cleanup goroutine.
+func (rl *IPRateLimiter) Stop() {
+	close(rl.done)
+}
+
+// Middleware returns HTTP middleware that rate-limits requests by client IP.
+// Returns 429 Too Many Requests with a Retry-After header when the limit is exceeded.
+func (rl *IPRateLimiter) Middleware(trustXFF bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip := httputil.ClientIP(r, trustXFF)
+			limiter := rl.getLimiter(ip)
+
+			if !limiter.Allow() {
+				rl.metrics.RecordRateLimitRejection(rl.tier)
+				slog.Debug("rate limit exceeded", "tier", rl.tier, "ip", ip, "path", r.URL.Path)
+				retryAfter := int(math.Ceil(1.0 / float64(rl.rps)))
+				httputil.WriteProblemWithRetry(w, http.StatusTooManyRequests, "rate limit exceeded", retryAfter)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func (rl *IPRateLimiter) getLimiter(ip string) *rate.Limiter {
+	now := time.Now().Unix()
+	entry := &limiterEntry{limiter: rate.NewLimiter(rl.rps, rl.burst)}
+	entry.lastSeenUnix.Store(now)
+	if v, loaded := rl.limiters.LoadOrStore(ip, entry); loaded {
+		existing := v.(*limiterEntry)
+		existing.lastSeenUnix.Store(now)
+		return existing.limiter
+	}
+	return entry.limiter
+}
+
+// cleanup removes limiter entries not seen in 10 minutes.
+func (rl *IPRateLimiter) cleanup() {
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			cutoff := time.Now().Add(-10 * time.Minute).Unix()
+			rl.limiters.Range(func(key, value any) bool {
+				entry := value.(*limiterEntry)
+				if entry.lastSeenUnix.Load() < cutoff {
+					rl.limiters.Delete(key)
+				}
+				return true
+			})
+		case <-rl.done:
+			return
+		}
+	}
+}

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/raphi011/know/internal/httputil"
+)
+
+func TestIPRateLimiterMiddleware(t *testing.T) {
+	rl := NewIPRateLimiter(100, 3, "test", nil)
+	defer rl.Stop()
+
+	handler := rl.Middleware(false)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// First 3 requests should succeed (burst = 3)
+	for i := range 3 {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = "192.168.1.1:1234"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("request %d: expected 200, got %d", i+1, rec.Code)
+		}
+	}
+
+	// 4th request should be rate limited
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "192.168.1.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Errorf("expected 429, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != httputil.ProblemContentType {
+		t.Errorf("expected content type %q, got %q", httputil.ProblemContentType, ct)
+	}
+	if ra := rec.Header().Get("Retry-After"); ra == "" {
+		t.Error("expected Retry-After header to be set")
+	}
+
+	// Verify response body is valid problem detail
+	var problem httputil.ProblemDetail
+	if err := json.NewDecoder(rec.Body).Decode(&problem); err != nil {
+		t.Fatalf("failed to decode problem detail: %v", err)
+	}
+	if problem.Status != http.StatusTooManyRequests {
+		t.Errorf("problem status = %d, want %d", problem.Status, http.StatusTooManyRequests)
+	}
+
+	// Different IP should not be rate limited
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.RemoteAddr = "10.0.0.1:5678"
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Errorf("different IP should not be rate limited, got %d", rec2.Code)
+	}
+}

--- a/internal/api/tokens.go
+++ b/internal/api/tokens.go
@@ -11,6 +11,9 @@ import (
 	"github.com/raphi011/know/internal/models"
 )
 
+// maxTokensPerUser is the maximum number of API tokens a single user can have.
+const maxTokensPerUser = 50
+
 // TokenResponse is the public representation of an API token.
 // It never exposes the token hash.
 type TokenResponse struct {
@@ -100,6 +103,18 @@ func (s *Server) createToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Enforce max token count per user
+	count, err := s.app.DBClient().CountTokens(ctx, ac.UserID)
+	if err != nil {
+		logutil.FromCtx(ctx).Error("count tokens", "error", err)
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to count tokens")
+		return
+	}
+	if count >= maxTokensPerUser {
+		httputil.WriteProblem(w, http.StatusConflict, "maximum number of tokens reached (limit: 50)")
+		return
+	}
+
 	// Determine expiry
 	maxDays := s.app.Config().TokenMaxLifetimeDays
 	expiryDays := maxDays
@@ -181,6 +196,12 @@ func (s *Server) deleteToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Prevent deleting the token currently in use
+	if tokenID == ac.TokenID {
+		httputil.WriteProblem(w, http.StatusConflict, "cannot delete the token currently in use")
+		return
+	}
+
 	if err := s.app.DBClient().DeleteToken(ctx, tokenID); err != nil {
 		logutil.FromCtx(ctx).Error("delete token", "error", err)
 		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to delete token")
@@ -233,25 +254,17 @@ func (s *Server) rotateToken(w http.ResponseWriter, r *http.Request) {
 	// Determine expiry for new token: preserve remaining TTL from old token
 	// (intentional — rotation doesn't extend the original grant's lifetime).
 	// If old token had no expiry or was already expired, use max lifetime.
+	maxDays := s.app.Config().TokenMaxLifetimeDays
+	if maxDays <= 0 {
+		maxDays = 90
+	}
+	defaultExpiry := time.Now().Add(time.Duration(maxDays) * 24 * time.Hour)
+
 	var expiresAt time.Time
-	if oldToken.ExpiresAt != nil {
-		remaining := time.Until(*oldToken.ExpiresAt)
-		if remaining <= 0 {
-			// Old token was expired — use max lifetime for new one
-			maxDays := s.app.Config().TokenMaxLifetimeDays
-			if maxDays <= 0 {
-				maxDays = 90
-			}
-			expiresAt = time.Now().Add(time.Duration(maxDays) * 24 * time.Hour)
-		} else {
-			expiresAt = time.Now().Add(remaining)
-		}
+	if oldToken.ExpiresAt != nil && time.Until(*oldToken.ExpiresAt) > 0 {
+		expiresAt = time.Now().Add(time.Until(*oldToken.ExpiresAt))
 	} else {
-		maxDays := s.app.Config().TokenMaxLifetimeDays
-		if maxDays <= 0 {
-			maxDays = 90
-		}
-		expiresAt = time.Now().Add(time.Duration(maxDays) * 24 * time.Hour)
+		expiresAt = defaultExpiry
 	}
 
 	raw, hash, err := auth.GenerateToken()
@@ -261,18 +274,12 @@ func (s *Server) rotateToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create new token
-	newToken, err := s.app.DBClient().CreateToken(ctx, ac.UserID, hash, oldToken.Name, expiresAt)
+	// Atomic create + delete in a single transaction
+	newToken, err := s.app.DBClient().RotateToken(ctx, tokenID, ac.UserID, hash, oldToken.Name, expiresAt)
 	if err != nil {
-		logutil.FromCtx(ctx).Error("create rotated token", "error", err)
-		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to create new token")
+		logutil.FromCtx(ctx).Error("rotate token", "error", err)
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to rotate token")
 		return
-	}
-
-	// Delete old token (not atomic — acceptable per design doc)
-	if err := s.app.DBClient().DeleteToken(ctx, tokenID); err != nil {
-		logutil.FromCtx(ctx).Warn("failed to delete old token during rotation", "old_token_id", tokenID, "error", err)
-		// Continue — new token was created successfully
 	}
 
 	writeJSON(w, http.StatusOK, CreateTokenResponse{

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -205,4 +205,7 @@ type ServerConfig struct {
 	MultimodalEmbedEnabled  bool   `json:"multimodalEmbedEnabled"`
 	TextExtractorModel      string `json:"textExtractorModel"`
 	TextExtractorEnabled    bool   `json:"textExtractorEnabled"`
+
+	// Auth
+	OIDCEnabled bool `json:"oidcEnabled"`
 }

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -380,6 +380,20 @@ func (c *Client) do(ctx context.Context, method, path string, body, target any) 
 	return c.handleResponse(req, target)
 }
 
+// ServerConfig is the response from GET /api/v1/config.
+type ServerConfig struct {
+	OIDCEnabled bool `json:"oidcEnabled"`
+}
+
+// GetConfig fetches the server configuration (unauthenticated fields only).
+func (c *Client) GetConfig(ctx context.Context) (*ServerConfig, error) {
+	var cfg ServerConfig
+	if err := c.Get(ctx, "/api/v1/config", &cfg); err != nil {
+		return nil, fmt.Errorf("get config: %w", err)
+	}
+	return &cfg, nil
+}
+
 // AdminUser is the JSON representation of a user from the admin API.
 type AdminUser struct {
 	ID            string  `json:"id"`

--- a/internal/auth/audit.go
+++ b/internal/auth/audit.go
@@ -3,8 +3,6 @@ package auth
 import (
 	"context"
 	"log/slog"
-	"net/http"
-	"strings"
 
 	"github.com/raphi011/know/internal/logutil"
 )
@@ -53,16 +51,3 @@ func AuditLog(ctx context.Context, event AuditEvent, attrs ...slog.Attr) {
 	logutil.FromCtx(ctx).Info("audit", args...)
 }
 
-// clientIP extracts the client IP from an HTTP request,
-// preferring the first entry in X-Forwarded-For (for reverse proxy setups)
-// over RemoteAddr.
-func clientIP(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// XFF is "client, proxy1, proxy2" — take the first (client) IP.
-		if before, _, ok := strings.Cut(xff, ","); ok {
-			return strings.TrimSpace(before)
-		}
-		return xff
-	}
-	return r.RemoteAddr
-}

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -43,6 +43,8 @@ type AuthContext struct {
 	IsSystemAdmin bool
 	Vaults        []models.VaultPermission // vault permissions ("*" with RoleAdmin = all)
 	Provider      AuthProvider             // how the user was authenticated
+	TokenID       string                   // bare token ID (empty in no-auth mode)
+	TokenName     string                   // human-readable token name (empty in no-auth mode)
 }
 
 // WithAuth stores auth context in the request context.

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -12,6 +12,11 @@ import (
 	"github.com/raphi011/know/internal/metrics"
 )
 
+// MiddlewareConfig holds configuration for the auth middleware.
+type MiddlewareConfig struct {
+	TrustXForwardedFor bool
+}
+
 // NoAuthMiddleware injects an admin AuthContext with access to all vaults,
 // bypassing token validation entirely. Use only for local/Docker setups.
 func NoAuthMiddleware(next http.Handler) http.Handler {
@@ -30,15 +35,16 @@ func NoAuthMiddleware(next http.Handler) http.Handler {
 }
 
 // Middleware validates Bearer tokens and injects AuthContext.
-func Middleware(dbClient *db.Client, m *metrics.Metrics) func(http.Handler) http.Handler {
+func Middleware(dbClient *db.Client, m *metrics.Metrics, mwCfg MiddlewareConfig) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			header := r.Header.Get("Authorization")
+			ip := httputil.ClientIP(r, mwCfg.TrustXForwardedFor)
 			if !strings.HasPrefix(header, "Bearer ") {
 				event := AuditFailure
 				AuditLog(r.Context(), event,
 					slog.String("reason", "missing_header"),
-					slog.String("ip", clientIP(r)),
+					slog.String("ip", ip),
 				)
 				m.RecordAuthEvent(string(event), string(event.Result()))
 				httputil.WriteProblem(w, http.StatusUnauthorized, "missing authorization header")
@@ -56,7 +62,7 @@ func Middleware(dbClient *db.Client, m *metrics.Metrics) func(http.Handler) http
 				}
 				AuditLog(r.Context(), event,
 					slog.String("reason", reason),
-					slog.String("ip", clientIP(r)),
+					slog.String("ip", ip),
 				)
 				m.RecordAuthEvent(string(event), string(event.Result()))
 				httputil.WriteProblem(w, http.StatusUnauthorized, "invalid token")
@@ -66,13 +72,14 @@ func Middleware(dbClient *db.Client, m *metrics.Metrics) func(http.Handler) http
 			event := AuditSuccess
 			AuditLog(r.Context(), event,
 				slog.String("user_id", ac.UserID),
-				slog.String("ip", clientIP(r)),
+				slog.String("ip", ip),
 				slog.String("provider", string(ac.Provider)),
+				slog.String("token_name", ac.TokenName),
 			)
 			m.RecordAuthEvent(string(event), string(event.Result()))
 
 			ctx := WithAuth(r.Context(), ac)
-			logger := logutil.FromCtx(ctx).With("user_id", ac.UserID)
+			logger := logutil.FromCtx(ctx).With("user_id", ac.UserID, "token_name", ac.TokenName)
 			ctx = logutil.WithLogger(ctx, logger)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/models"
 )
 
@@ -217,7 +218,7 @@ func TestCheckVaultRole(t *testing.T) {
 }
 
 func TestMiddlewareMissingHeader(t *testing.T) {
-	handler := Middleware(nil, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := Middleware(nil, nil, MiddlewareConfig{})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("Handler should not be called without auth")
 	}))
 
@@ -303,29 +304,41 @@ func TestClientIP(t *testing.T) {
 		name       string
 		xff        string
 		remoteAddr string
+		trustXFF   bool
 		want       string
 	}{
 		{
 			name:       "no XFF header",
 			remoteAddr: "192.168.1.1:1234",
+			trustXFF:   true,
 			want:       "192.168.1.1:1234",
 		},
 		{
 			name:       "single IP in XFF",
 			xff:        "10.0.0.1",
 			remoteAddr: "192.168.1.1:1234",
+			trustXFF:   true,
 			want:       "10.0.0.1",
 		},
 		{
 			name:       "multiple IPs in XFF takes first",
 			xff:        "10.0.0.1, 172.16.0.1, 192.168.1.1",
 			remoteAddr: "127.0.0.1:1234",
+			trustXFF:   true,
 			want:       "10.0.0.1",
 		},
 		{
 			name:       "empty XFF falls back to RemoteAddr",
 			xff:        "",
 			remoteAddr: "192.168.1.1:1234",
+			trustXFF:   true,
+			want:       "192.168.1.1:1234",
+		},
+		{
+			name:       "XFF ignored when trust disabled",
+			xff:        "10.0.0.1",
+			remoteAddr: "192.168.1.1:1234",
+			trustXFF:   false,
 			want:       "192.168.1.1:1234",
 		},
 	}
@@ -337,8 +350,8 @@ func TestClientIP(t *testing.T) {
 			if tt.xff != "" {
 				r.Header.Set("X-Forwarded-For", tt.xff)
 			}
-			if got := clientIP(r); got != tt.want {
-				t.Errorf("clientIP() = %q, want %q", got, tt.want)
+			if got := httputil.ClientIP(r, tt.trustXFF); got != tt.want {
+				t.Errorf("ClientIP() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/auth/validate.go
+++ b/internal/auth/validate.go
@@ -51,6 +51,8 @@ func Authenticate(ctx context.Context, dbClient *db.Client, rawToken string, noA
 		IsSystemAdmin: info.IsSystemAdmin,
 		Vaults:        info.Vaults,
 		Provider:      ProviderToken,
+		TokenID:       info.TokenID,
+		TokenName:     info.TokenName,
 	}, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,7 +77,12 @@ type Config struct {
 	LogLevel slog.Level
 
 	// Auth settings
-	TokenMaxLifetimeDays int // KNOW_TOKEN_MAX_LIFETIME_DAYS (default: 90, 0 = no limit)
+	TokenMaxLifetimeDays int     // KNOW_TOKEN_MAX_LIFETIME_DAYS (default: 90, 0 = no limit)
+	TrustXForwardedFor   bool    // KNOW_TRUST_X_FORWARDED_FOR (default: false)
+	RateLimitAuthRPS     float64 // KNOW_RATE_LIMIT_AUTH_RPS (default: 5, 0 = disabled)
+	RateLimitAuthBurst   int     // KNOW_RATE_LIMIT_AUTH_BURST (default: 10)
+	RateLimitGlobalRPS   float64 // KNOW_RATE_LIMIT_GLOBAL_RPS (default: 100, 0 = disabled)
+	RateLimitGlobalBurst int     // KNOW_RATE_LIMIT_GLOBAL_BURST (default: 200)
 
 	// OIDC authentication
 	OIDCEnabled       bool   // KNOW_OIDC_ENABLED (default: false)
@@ -274,6 +279,11 @@ func Load() Config {
 
 		// Auth settings
 		TokenMaxLifetimeDays: getEnvInt("KNOW_TOKEN_MAX_LIFETIME_DAYS", 90),
+		TrustXForwardedFor:   getEnvBool("KNOW_TRUST_X_FORWARDED_FOR", false),
+		RateLimitAuthRPS:     getEnvFloat64("KNOW_RATE_LIMIT_AUTH_RPS", 5),
+		RateLimitAuthBurst:   getEnvInt("KNOW_RATE_LIMIT_AUTH_BURST", 10),
+		RateLimitGlobalRPS:   getEnvFloat64("KNOW_RATE_LIMIT_GLOBAL_RPS", 100),
+		RateLimitGlobalBurst: getEnvInt("KNOW_RATE_LIMIT_GLOBAL_BURST", 200),
 
 		// OIDC authentication
 		OIDCEnabled:       getEnvBool("KNOW_OIDC_ENABLED", false),
@@ -347,6 +357,18 @@ func getEnvInt(key string, defaultVal int) int {
 			return defaultVal
 		}
 		return i
+	}
+	return defaultVal
+}
+
+func getEnvFloat64(key string, defaultVal float64) float64 {
+	if val := os.Getenv(key); val != "" {
+		f, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			slog.Warn("invalid float env var, using default", "key", key, "value", val, "default", defaultVal, "error", err)
+			return defaultVal
+		}
+		return f
 	}
 	return defaultVal
 }

--- a/internal/db/queries_token.go
+++ b/internal/db/queries_token.go
@@ -71,7 +71,7 @@ func (c *Client) ListTokens(ctx context.Context, userID string) ([]models.APITok
 	defer c.logOp(ctx, "token.list", time.Now())
 	sql := `SELECT * FROM api_token WHERE user = type::record("user", $user_id) ORDER BY created_at DESC`
 	results, err := surrealdb.Query[[]models.APIToken](ctx, c.DB(), sql, map[string]any{
-		"user_id": userID,
+		"user_id": bareID("user", userID),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list tokens: %w", err)
@@ -82,8 +82,66 @@ func (c *Client) ListTokens(ctx context.Context, userID string) ([]models.APITok
 func (c *Client) DeleteToken(ctx context.Context, id string) error {
 	defer c.logOp(ctx, "token.delete", time.Now())
 	sql := `DELETE type::record("api_token", $id)`
-	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"id": id}); err != nil {
+	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{"id": bareID("api_token", id)}); err != nil {
 		return fmt.Errorf("delete token: %w", err)
 	}
 	return nil
+}
+
+// DeleteExpiredTokens removes all tokens whose expires_at has passed.
+func (c *Client) DeleteExpiredTokens(ctx context.Context) error {
+	defer c.logOp(ctx, "token.delete_expired", time.Now())
+	sql := `DELETE api_token WHERE expires_at != NONE AND expires_at < time::now()`
+	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, nil); err != nil {
+		return fmt.Errorf("delete expired tokens: %w", err)
+	}
+	return nil
+}
+
+// CountTokens returns the number of tokens owned by a user.
+func (c *Client) CountTokens(ctx context.Context, userID string) (int, error) {
+	defer c.logOp(ctx, "token.count", time.Now())
+	sql := `SELECT count() as count FROM api_token WHERE user = type::record("user", $user_id) GROUP ALL`
+	type countResult struct {
+		Count int `json:"count"`
+	}
+	results, err := surrealdb.Query[[]countResult](ctx, c.DB(), sql, map[string]any{
+		"user_id": bareID("user", userID),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("count tokens: %w", err)
+	}
+	r := firstResultOpt(results)
+	if r == nil {
+		return 0, nil
+	}
+	return r.Count, nil
+}
+
+// RotateToken atomically creates a new token and deletes the old one in a transaction.
+// Returns the newly created token. The fetch-after-commit is a separate query; if it
+// fails (extremely unlikely transient error), the rotation was still successful — the
+// caller should handle this gracefully.
+func (c *Client) RotateToken(ctx context.Context, oldTokenID, userID, newHash, name string, newExpiresAt time.Time) (*models.APIToken, error) {
+	defer c.logOp(ctx, "token.rotate", time.Now())
+	sql := `
+		BEGIN TRANSACTION;
+		CREATE api_token SET
+			user = type::record("user", $user_id),
+			token_hash = $new_hash,
+			name = $name,
+			expires_at = $expires_at;
+		DELETE type::record("api_token", $old_id);
+		COMMIT TRANSACTION;
+	`
+	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, map[string]any{
+		"user_id":    bareID("user", userID),
+		"new_hash":   newHash,
+		"name":       name,
+		"expires_at": newExpiresAt,
+		"old_id":     bareID("api_token", oldTokenID),
+	}); err != nil {
+		return nil, fmt.Errorf("rotate token: %w", err)
+	}
+	return c.GetTokenByHash(ctx, newHash)
 }

--- a/internal/db/queries_token_test.go
+++ b/internal/db/queries_token_test.go
@@ -145,6 +145,132 @@ func TestGetTokenByID(t *testing.T) {
 	}
 }
 
+func TestDeleteExpiredTokens(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+
+	// Create an expired token (expires_at in the past)
+	expiredHash := fmt.Sprintf("expired-hash-%d", time.Now().UnixNano())
+	pastExpiry := time.Now().Add(-1 * time.Hour)
+	_, err := testDB.CreateToken(ctx, userID, expiredHash, "expired-token", pastExpiry)
+	if err != nil {
+		t.Fatalf("CreateToken (expired) failed: %v", err)
+	}
+
+	// Create a valid token
+	validHash := fmt.Sprintf("valid-hash-%d", time.Now().UnixNano())
+	_, err = testDB.CreateToken(ctx, userID, validHash, "valid-token", testTokenExpiry)
+	if err != nil {
+		t.Fatalf("CreateToken (valid) failed: %v", err)
+	}
+
+	// Delete expired tokens
+	err = testDB.DeleteExpiredTokens(ctx)
+	if err != nil {
+		t.Fatalf("DeleteExpiredTokens failed: %v", err)
+	}
+
+	// Expired token should be gone
+	expired, err := testDB.GetTokenByHash(ctx, expiredHash)
+	if err != nil {
+		t.Fatalf("GetTokenByHash (expired) failed: %v", err)
+	}
+	if expired != nil {
+		t.Error("expired token should have been deleted")
+	}
+
+	// Valid token should still exist
+	valid, err := testDB.GetTokenByHash(ctx, validHash)
+	if err != nil {
+		t.Fatalf("GetTokenByHash (valid) failed: %v", err)
+	}
+	if valid == nil {
+		t.Error("valid token should still exist")
+	}
+}
+
+func TestCountTokens(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+
+	// Initially 0
+	count, err := testDB.CountTokens(ctx, userID)
+	if err != nil {
+		t.Fatalf("CountTokens failed: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 tokens, got %d", count)
+	}
+
+	// Create 3 tokens
+	for i := range 3 {
+		hash := fmt.Sprintf("count-hash-%d-%d", i, time.Now().UnixNano())
+		_, err := testDB.CreateToken(ctx, userID, hash, fmt.Sprintf("count-token-%d", i), testTokenExpiry)
+		if err != nil {
+			t.Fatalf("CreateToken %d failed: %v", i, err)
+		}
+	}
+
+	count, err = testDB.CountTokens(ctx, userID)
+	if err != nil {
+		t.Fatalf("CountTokens failed: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 tokens, got %d", count)
+	}
+}
+
+func TestRotateToken(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+
+	// Create original token
+	oldHash := fmt.Sprintf("rotate-old-hash-%d", time.Now().UnixNano())
+	oldToken, err := testDB.CreateToken(ctx, userID, oldHash, "rotate-me", testTokenExpiry)
+	if err != nil {
+		t.Fatalf("CreateToken failed: %v", err)
+	}
+	oldTokenID := models.MustRecordIDString(oldToken.ID)
+
+	// Rotate
+	newHash := fmt.Sprintf("rotate-new-hash-%d", time.Now().UnixNano())
+	newExpiry := time.Now().Add(30 * 24 * time.Hour)
+	newToken, err := testDB.RotateToken(ctx, oldTokenID, userID, newHash, "rotate-me", newExpiry)
+	if err != nil {
+		t.Fatalf("RotateToken failed: %v", err)
+	}
+	if newToken == nil {
+		t.Fatal("RotateToken returned nil")
+	}
+	if newToken.Name != "rotate-me" {
+		t.Errorf("expected name 'rotate-me', got %q", newToken.Name)
+	}
+	if newToken.TokenHash != newHash {
+		t.Errorf("expected new hash, got %q", newToken.TokenHash)
+	}
+
+	// Old token should be gone
+	old, err := testDB.GetTokenByHash(ctx, oldHash)
+	if err != nil {
+		t.Fatalf("GetTokenByHash (old) failed: %v", err)
+	}
+	if old != nil {
+		t.Error("old token should have been deleted")
+	}
+
+	// New token should exist
+	found, err := testDB.GetTokenByHash(ctx, newHash)
+	if err != nil {
+		t.Fatalf("GetTokenByHash (new) failed: %v", err)
+	}
+	if found == nil {
+		t.Error("new token should exist")
+	}
+}
+
 func TestDeleteToken(t *testing.T) {
 	ctx := context.Background()
 	user := createTestUser(t, ctx)

--- a/internal/httputil/ip.go
+++ b/internal/httputil/ip.go
@@ -1,0 +1,22 @@
+package httputil
+
+import (
+	"net/http"
+	"strings"
+)
+
+// ClientIP extracts the client IP from an HTTP request.
+// When trustXFF is true, the first entry in X-Forwarded-For is preferred
+// (for reverse proxy setups). Otherwise, RemoteAddr is always used.
+func ClientIP(r *http.Request, trustXFF bool) string {
+	if trustXFF {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			// XFF is "client, proxy1, proxy2" — take the first (client) IP.
+			if before, _, ok := strings.Cut(xff, ","); ok {
+				return strings.TrimSpace(before)
+			}
+			return xff
+		}
+	}
+	return r.RemoteAddr
+}

--- a/internal/httputil/problem.go
+++ b/internal/httputil/problem.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strconv"
 )
 
 // ProblemDetail is an RFC 9457 (Problem Details for HTTP APIs) response body.
@@ -32,4 +33,10 @@ func WriteProblem(w http.ResponseWriter, status int, detail string) {
 	if err := json.NewEncoder(w).Encode(p); err != nil {
 		slog.Warn("failed to encode problem detail", "error", err)
 	}
+}
+
+// WriteProblemWithRetry writes an RFC 9457 Problem Details response with a Retry-After header.
+func WriteProblemWithRetry(w http.ResponseWriter, status int, detail string, retryAfterSecs int) {
+	w.Header().Set("Retry-After", strconv.Itoa(retryAfterSecs))
+	WriteProblem(w, status, detail)
 }

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -11,15 +11,17 @@ import (
 // Metrics holds all Prometheus metrics for the application.
 // All methods are safe to call on a nil receiver (no-op).
 type Metrics struct {
-	dbDuration        *prometheus.HistogramVec
-	httpDuration      *prometheus.HistogramVec
-	httpRequestsTotal *prometheus.CounterVec
-	embedDuration     *prometheus.HistogramVec
-	llmDuration       *prometheus.HistogramVec
-	llmTokens         *prometheus.CounterVec
-	pipelineDuration  *prometheus.HistogramVec
-	pipelineTotal     *prometheus.CounterVec
-	authEventsTotal   *prometheus.CounterVec
+	dbDuration           *prometheus.HistogramVec
+	httpDuration         *prometheus.HistogramVec
+	httpRequestsTotal    *prometheus.CounterVec
+	embedDuration        *prometheus.HistogramVec
+	llmDuration          *prometheus.HistogramVec
+	llmTokens            *prometheus.CounterVec
+	pipelineDuration     *prometheus.HistogramVec
+	pipelineTotal        *prometheus.CounterVec
+	authEventsTotal      *prometheus.CounterVec
+	rateLimitRejectTotal *prometheus.CounterVec
+	cleanupFailuresTotal *prometheus.CounterVec
 }
 
 // NewMetrics creates and registers all Prometheus metrics.
@@ -74,6 +76,16 @@ func NewMetrics() *Metrics {
 			Name: "know_auth_events_total",
 			Help: "Total number of authentication events by event type and result.",
 		}, []string{"event", "result"}),
+
+		rateLimitRejectTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "know_rate_limit_rejected_total",
+			Help: "Total number of requests rejected by rate limiting.",
+		}, []string{"tier"}),
+
+		cleanupFailuresTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "know_cleanup_failures_total",
+			Help: "Total number of background cleanup task failures.",
+		}, []string{"task"}),
 	}
 
 	prometheus.MustRegister(
@@ -86,6 +98,8 @@ func NewMetrics() *Metrics {
 		m.pipelineDuration,
 		m.pipelineTotal,
 		m.authEventsTotal,
+		m.rateLimitRejectTotal,
+		m.cleanupFailuresTotal,
 	)
 
 	return m
@@ -134,6 +148,22 @@ func (m *Metrics) RecordAuthEvent(event, result string) {
 		return
 	}
 	m.authEventsTotal.WithLabelValues(event, result).Inc()
+}
+
+// RecordRateLimitRejection records a rate-limited request rejection.
+func (m *Metrics) RecordRateLimitRejection(tier string) {
+	if m == nil {
+		return
+	}
+	m.rateLimitRejectTotal.WithLabelValues(tier).Inc()
+}
+
+// RecordCleanupFailure records a background cleanup task failure.
+func (m *Metrics) RecordCleanupFailure(task string) {
+	if m == nil {
+		return
+	}
+	m.cleanupFailuresTotal.WithLabelValues(task).Inc()
 }
 
 // RecordPipelineJob records a pipeline job completion.

--- a/internal/oidc/device.go
+++ b/internal/oidc/device.go
@@ -1,11 +1,15 @@
 package oidc
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -50,6 +54,57 @@ func SignState(secret []byte, userCode string) string {
 	mac.Write([]byte(userCode))
 	sig := hex.EncodeToString(mac.Sum(nil))
 	return userCode + "." + sig
+}
+
+// gcmFromDeviceCode derives an AES-256-GCM cipher from the SHA256 of the device code.
+func gcmFromDeviceCode(deviceCode string) (cipher.AEAD, error) {
+	key := sha256.Sum256([]byte(deviceCode))
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, fmt.Errorf("create cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create gcm: %w", err)
+	}
+	return gcm, nil
+}
+
+// EncryptWithDeviceCode encrypts plaintext using AES-GCM with the SHA256 of the device code as key.
+// Only the holder of the device code can decrypt. Returns base64-encoded ciphertext.
+func EncryptWithDeviceCode(plaintext, deviceCode string) (string, error) {
+	gcm, err := gcmFromDeviceCode(deviceCode)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("generate nonce: %w", err)
+	}
+	ciphertext := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+	return base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+// DecryptWithDeviceCode decrypts base64-encoded ciphertext using AES-GCM with the SHA256 of the device code as key.
+func DecryptWithDeviceCode(encrypted, deviceCode string) (string, error) {
+	data, err := base64.StdEncoding.DecodeString(encrypted)
+	if err != nil {
+		return "", fmt.Errorf("decode base64: %w", err)
+	}
+	gcm, err := gcmFromDeviceCode(deviceCode)
+	if err != nil {
+		return "", err
+	}
+	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", fmt.Errorf("decrypt: %w", err)
+	}
+	return string(plaintext), nil
 }
 
 // VerifyState verifies an HMAC-signed state parameter and returns the user_code.

--- a/internal/oidc/device_test.go
+++ b/internal/oidc/device_test.go
@@ -56,6 +56,43 @@ func TestFormatUserCode(t *testing.T) {
 	}
 }
 
+func TestEncryptDecryptWithDeviceCode(t *testing.T) {
+	_, deviceCode, err := GenerateDeviceCode()
+	if err != nil {
+		t.Fatalf("GenerateDeviceCode failed: %v", err)
+	}
+
+	plaintext := "kh_abc123def456"
+	encrypted, err := EncryptWithDeviceCode(plaintext, deviceCode)
+	if err != nil {
+		t.Fatalf("EncryptWithDeviceCode failed: %v", err)
+	}
+
+	if encrypted == plaintext {
+		t.Error("encrypted should differ from plaintext")
+	}
+
+	decrypted, err := DecryptWithDeviceCode(encrypted, deviceCode)
+	if err != nil {
+		t.Fatalf("DecryptWithDeviceCode failed: %v", err)
+	}
+	if decrypted != plaintext {
+		t.Errorf("decrypted = %q, want %q", decrypted, plaintext)
+	}
+
+	// Wrong device code should fail
+	_, err = DecryptWithDeviceCode(encrypted, "wrong-device-code")
+	if err == nil {
+		t.Error("DecryptWithDeviceCode should fail with wrong device code")
+	}
+
+	// Tampered ciphertext should fail
+	_, err = DecryptWithDeviceCode(encrypted+"x", deviceCode)
+	if err == nil {
+		t.Error("DecryptWithDeviceCode should fail with tampered ciphertext")
+	}
+}
+
 func TestSignAndVerifyState(t *testing.T) {
 	secret := []byte("test-secret-key-32bytes!12345678")
 	userCode := "ABCDEFGH"

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -74,7 +74,8 @@ type ServerConfig struct {
 	TextExtractorEnabled    bool   `json:"textExtractorEnabled"`
 
 	// Auth
-	TokenMaxLifetimeDays int `json:"tokenMaxLifetimeDays"`
+	TokenMaxLifetimeDays int  `json:"tokenMaxLifetimeDays"`
+	OIDCEnabled          bool `json:"oidcEnabled"`
 }
 
 // App holds all application services and dependencies.
@@ -326,6 +327,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 			TextExtractorModel:      cfg.TextExtractorModel,
 			TextExtractorEnabled:    textExtractorOK,
 			TokenMaxLifetimeDays:    cfg.TokenMaxLifetimeDays,
+			OIDCEnabled:             cfg.OIDCEnabled,
 		},
 	}
 


### PR DESCRIPTION
Hardens the auth system with 10 improvements identified during an auth audit: rate limiting, token hygiene, encryption, and observability.

## New Features

- **Per-IP rate limiting** — Two configurable tiers: auth endpoints (5 rps default) and global (100 rps default). Uses token bucket algorithm via `golang.org/x/time/rate`. Set RPS to 0 to disable. Returns 429 with `Retry-After` header. Tracked via `know_rate_limit_rejected_total` Prometheus counter.
- **Expired token cleanup** — Background goroutine deletes expired API tokens every 5 min (decoupled from OIDC—always runs)
- **Max token count per user** — Limit of 50 tokens per user, returns 409 on overflow
- **Self-deletion guard** — Cannot delete the token you're currently using (409), rotation still allowed
- **Atomic token rotation** — `BEGIN TRANSACTION;...COMMIT TRANSACTION;` ensures no orphan tokens if delete fails
- **Device code token encryption** — Raw `kh_` tokens stored encrypted (AES-GCM, device_code as key) in the device_code table. Only the CLI holding the device_code can decrypt.
- **XFF trust configuration** — `KNOW_TRUST_X_FORWARDED_FOR` (default: true) controls whether `X-Forwarded-For` is trusted for client IP extraction
- **CLI OIDC pre-flight check** — `know auth login` checks server config before offering OIDC option; goes straight to token paste if OIDC disabled
- **Token name in audit logs** — `TokenID` and `TokenName` carried through `AuthContext` into audit logs and context logger
- **`oidcEnabled` in config API** — `GET /api/v1/config` now exposes OIDC availability

## Breaking Changes
- None