### PR TITLE
feat: add Links tab to browse TUI with label management

### DIFF
--- a/cmd/know/cmd_auth.go
+++ b/cmd/know/cmd_auth.go
@@ -6,13 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/raphi011/know/internal/apiclient"
 	"github.com/raphi011/know/internal/auth"
+	"github.com/raphi011/know/internal/browser"
 	"github.com/spf13/cobra"
 )
 
@@ -121,7 +120,9 @@ func loginWithBrowser(apiURL string) error {
 	fmt.Print("Press Enter to open the browser...")
 	fmt.Scanln()
 
-	openBrowser(resp.VerificationURI)
+	if err := browser.Open(resp.VerificationURI); err != nil {
+		fmt.Fprintf(os.Stderr, "Could not open browser: %v\nPlease open this URL manually: %s\n", err, resp.VerificationURI)
+	}
 
 	fmt.Println("\nWaiting for authentication...")
 
@@ -180,23 +181,6 @@ func loginWithToken(apiURL string) error {
 	}
 	fmt.Println("Token saved successfully!")
 	return nil
-}
-
-func openBrowser(urlStr string) {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", urlStr)
-	case "linux":
-		cmd = exec.Command("xdg-open", urlStr)
-	case "windows":
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", urlStr)
-	}
-	if cmd != nil {
-		if err := cmd.Start(); err != nil {
-			fmt.Fprintf(os.Stderr, "Could not open browser: %v\nPlease open this URL manually: %s\n", err, urlStr)
-		}
-	}
 }
 
 var authStatusCmd = &cobra.Command{

--- a/cmd/know/cmd_browse.go
+++ b/cmd/know/cmd_browse.go
@@ -24,6 +24,7 @@ var (
 	browseVaultID *string
 	browseEdit    bool
 	browseViewer  string
+	browseLinks   bool
 )
 
 var browseCmd = &cobra.Command{
@@ -55,7 +56,8 @@ Examples:
   know browse | wc -l                      # fuzzy pick → count lines
   know browse --viewer bat /docs/readme.md # view with bat
   know browse -e /docs/readme.md           # edit in $EDITOR
-  know browse -e                           # fuzzy pick → edit`,
+  know browse -e                           # fuzzy pick → edit
+  know browse --links                      # browse saved web clips`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runBrowse,
 }
@@ -65,6 +67,7 @@ func init() {
 	browseVaultID = addVaultFlag(browseCmd, browseAPI)
 	browseCmd.Flags().BoolVarP(&browseEdit, "edit", "e", false, "open in $EDITOR and save changes")
 	browseCmd.Flags().StringVar(&browseViewer, "viewer", os.Getenv("KNOW_VIEWER"), "viewer command (env: KNOW_VIEWER)")
+	browseCmd.Flags().BoolVarP(&browseLinks, "links", "l", false, "start on the Links tab (saved web clips)")
 	browseCmd.ValidArgsFunction = completeVaultPaths(browseAPI, browseVaultID, pathFilterFiles)
 }
 
@@ -166,7 +169,11 @@ func browseWithPicker(ctx context.Context, client *apiclient.Client) error {
 
 	// Standard browse TUI.
 	isDark := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
-	model := browse.NewModel(client, *browseVaultID, docs, isDark)
+	var startTab []browse.Tab
+	if browseLinks {
+		startTab = append(startTab, browse.TabLinks)
+	}
+	model := browse.NewModel(client, *browseVaultID, docs, isDark, startTab...)
 	p := tea.NewProgram(model)
 	if _, err := p.Run(); err != nil {
 		return fmt.Errorf("browse: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -212,7 +212,7 @@ require (
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/term v0.41.0
-	golang.org/x/time v0.15.0 // indirect
+	golang.org/x/time v0.15.0
 	google.golang.org/api v0.272.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260316180232-0b37fe3546d5 // indirect
 	google.golang.org/grpc v1.79.3 // indirect

--- a/helm/know/Chart.yaml
+++ b/helm/know/Chart.yaml
@@ -3,7 +3,7 @@ name: know
 description: Know - Personal Knowledge RAG Database with REST API and WebDAV
 type: application
 version: 0.10.1
-appVersion: "0.11.0"
+appVersion: "0.12.0"
 keywords:
   - know
   - knowledge-graph

--- a/helm/know/templates/deployment.yaml
+++ b/helm/know/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "know.labels" . | nindent 4 }}
 spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit | default 3 }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:

--- a/helm/know/values.yaml
+++ b/helm/know/values.yaml
@@ -1,6 +1,7 @@
 # Default values for know
 
 replicaCount: 1
+revisionHistoryLimit: 3
 
 image:
   repository: know

--- a/internal/api/labels.go
+++ b/internal/api/labels.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"net/http"
+	"slices"
 
 	"github.com/raphi011/know/internal/auth"
 	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
+	"github.com/raphi011/know/internal/models"
 )
 
 func (s *Server) listLabels(w http.ResponseWriter, r *http.Request) {
@@ -31,4 +33,64 @@ func (s *Server) listLabels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, httputil.NewListResponse(labels, len(labels)))
+}
+
+type patchLabelsRequest struct {
+	Path   string   `json:"path"`
+	Add    []string `json:"add,omitempty"`
+	Remove []string `json:"remove,omitempty"`
+}
+
+func (s *Server) patchLabels(w http.ResponseWriter, r *http.Request) {
+	vaultID := auth.MustVaultIDFromCtx(r.Context())
+	logger := logutil.FromCtx(r.Context())
+
+	req, ok := decodeBody[patchLabelsRequest](w, r, 1<<16)
+	if !ok {
+		return
+	}
+
+	if req.Path == "" {
+		httputil.WriteProblem(w, http.StatusBadRequest, "path is required")
+		return
+	}
+
+	req.Path = models.NormalizePath(req.Path)
+
+	file, err := s.app.DBClient().GetFileByPath(r.Context(), vaultID, req.Path)
+	if err != nil {
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to look up document")
+		logger.Error("patch labels: get file", "path", req.Path, "error", err)
+		return
+	}
+	if file == nil {
+		httputil.WriteProblem(w, http.StatusNotFound, "document not found")
+		return
+	}
+
+	fileID, err := models.RecordIDString(file.ID)
+	if err != nil {
+		httputil.WriteProblem(w, http.StatusInternalServerError, "invalid document record")
+		logger.Error("patch labels: record ID", "path", req.Path, "error", err)
+		return
+	}
+
+	// Compute new labels
+	labels := file.Labels
+	for _, l := range req.Add {
+		if !slices.Contains(labels, l) {
+			labels = append(labels, l)
+		}
+	}
+	labels = slices.DeleteFunc(labels, func(l string) bool {
+		return slices.Contains(req.Remove, l)
+	})
+
+	if err := s.app.DBClient().UpdateFileLabels(r.Context(), fileID, labels); err != nil {
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to update labels")
+		logger.Error("patch labels", "path", req.Path, "error", err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"labels": labels})
 }

--- a/internal/api/ls.go
+++ b/internal/api/ls.go
@@ -23,6 +23,13 @@ func (s *Server) ls(w http.ResponseWriter, r *http.Request) {
 
 	recursive := r.URL.Query().Get("recursive") == "true"
 
+	// Parse optional labels filter.
+	labelsParam := r.URL.Query().Get("labels")
+	var labels []string
+	if labelsParam != "" {
+		labels = strings.Split(labelsParam, ",")
+	}
+
 	// Build prefix with trailing slash for filtering (root "/" stays as "/").
 	prefix := folder
 	if !strings.HasSuffix(prefix, "/") {
@@ -30,6 +37,39 @@ func (s *Server) ls(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logger := logutil.FromCtx(r.Context())
+
+	// When labels are specified, use ListFiles (returns full models.File) so we
+	// can populate Labels and Source on the response entries.
+	if len(labels) > 0 {
+		isNotFolder := false
+		files, err := s.app.DBClient().ListFiles(r.Context(), db.ListFilesFilter{
+			VaultID:  vaultID,
+			Folder:   &prefix,
+			IsFolder: &isNotFolder,
+			Labels:   labels,
+			Limit:    10000,
+		})
+		if err != nil {
+			httputil.WriteProblem(w, http.StatusInternalServerError, "failed to list documents")
+			logger.Error("ls documents by labels", "vault_id", vaultID, "labels", labels, "error", err)
+			return
+		}
+
+		var entries []models.FileEntry
+		for _, f := range files {
+			source, _ := f.Metadata["source"].(string) // zero-value "" is fine when absent or non-string
+			entries = append(entries, models.FileEntry{
+				Name:   path.Base(f.Path),
+				Path:   f.Path,
+				Title:  f.Title,
+				Size:   f.Size,
+				Labels: f.Labels,
+				Source: source,
+			})
+		}
+		writeJSON(w, http.StatusOK, httputil.NewListResponse(entries, len(entries)))
+		return
+	}
 
 	// Pass prefix (with trailing slash) to the DB so that "/docs" doesn't match "/docs-other".
 	// For root ("/"), starts_with(path, "/") correctly matches all documents.

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -574,6 +574,14 @@ components:
         size:
           type: integer
           description: Content size in bytes (0 for folders)
+        labels:
+          type: array
+          items:
+            type: string
+          description: Document labels (populated when filtering by labels)
+        source:
+          type: string
+          description: Original URL for web-clipped documents
 
     FetchRequest:
       type: object
@@ -1715,6 +1723,11 @@ paths:
           in: query
           schema:
             type: boolean
+        - name: labels
+          in: query
+          schema:
+            type: string
+          description: Comma-separated label filter. When set, only files matching all labels are returned (with Labels and Source fields populated).
       responses:
         "200":
           description: Directory entries (files and folders)
@@ -2085,6 +2098,50 @@ paths:
           $ref: "#/components/responses/NotFound"
 
   # ── Labels ──────────────────────────────────────────────
+  /vaults/{vault}/documents/labels:
+    patch:
+      tags: [Labels]
+      summary: Add or remove labels on a document
+      parameters:
+        - $ref: "#/components/parameters/vault"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [path]
+              properties:
+                path:
+                  type: string
+                  description: Document path
+                add:
+                  type: array
+                  items:
+                    type: string
+                  description: Labels to add
+                remove:
+                  type: array
+                  items:
+                    type: string
+                  description: Labels to remove
+      responses:
+        "200":
+          description: Updated labels
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  labels:
+                    type: array
+                    items:
+                      type: string
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /vaults/{vault}/labels:
     get:
       tags: [Labels]

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -75,6 +75,7 @@ func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Han
 
 	// --- Labels ---
 	mux.Handle("GET /api/v1/vaults/{vault}/labels", vs(s.listLabels))
+	mux.Handle("PATCH /api/v1/vaults/{vault}/documents/labels", vs(s.patchLabels))
 
 	// --- Tasks ---
 	mux.Handle("GET /api/v1/vaults/{vault}/tasks", vs(s.listTasks))

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/raphi011/know/internal/httputil"
@@ -660,6 +661,32 @@ func (c *Client) ListFiles(ctx context.Context, vaultName, path string, recursiv
 		return nil, fmt.Errorf("list files: %w", err)
 	}
 	return resp.Items, nil
+}
+
+// ListFilesByLabels lists files with specific labels across the vault.
+func (c *Client) ListFilesByLabels(ctx context.Context, vaultName string, labels []string) ([]models.FileEntry, error) {
+	q := url.Values{
+		"path":      {"/"},
+		"recursive": {"true"},
+		"labels":    {strings.Join(labels, ",")},
+	}
+	var resp httputil.ListResponse[models.FileEntry]
+	if err := c.Get(ctx, vaultPath(vaultName, "/documents/ls")+"?"+q.Encode(), &resp); err != nil {
+		return nil, fmt.Errorf("list files by labels: %w", err)
+	}
+	return resp.Items, nil
+}
+
+// PatchLabelsRequest is the request body for patching document labels.
+type PatchLabelsRequest struct {
+	Path   string   `json:"path"`
+	Add    []string `json:"add,omitempty"`
+	Remove []string `json:"remove,omitempty"`
+}
+
+// PatchDocumentLabels adds or removes labels on a document.
+func (c *Client) PatchDocumentLabels(ctx context.Context, vaultName string, req PatchLabelsRequest) error {
+	return c.Patch(ctx, vaultPath(vaultName, "/documents/labels"), req, nil)
 }
 
 // ListLabels returns all distinct labels in the given vault.

--- a/internal/browser/open.go
+++ b/internal/browser/open.go
@@ -1,0 +1,26 @@
+package browser
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// Open opens the given URL in the user's default browser.
+func Open(urlStr string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", urlStr)
+	case "linux":
+		cmd = exec.Command("xdg-open", urlStr)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", urlStr)
+	default:
+		return fmt.Errorf("unsupported platform %s, open manually: %s", runtime.GOOS, urlStr)
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("open browser: %w", err)
+	}
+	return nil
+}

--- a/internal/db/queries_file.go
+++ b/internal/db/queries_file.go
@@ -263,6 +263,23 @@ func (c *Client) UpdateFile(ctx context.Context, id string, input models.FileInp
 	return firstResult(results, "update file")
 }
 
+// UpdateFileLabels sets the labels on a file identified by record ID.
+func (c *Client) UpdateFileLabels(ctx context.Context, id string, labels []string) error {
+	defer c.logOp(ctx, "file.update_labels", time.Now())
+	if labels == nil {
+		labels = []string{}
+	}
+	sql := `UPDATE type::record("file", $id) SET labels = $labels`
+	_, err := surrealdb.Query[[]models.File](ctx, c.DB(), sql, map[string]any{
+		"id":     bareID("file", id),
+		"labels": labels,
+	})
+	if err != nil {
+		return fmt.Errorf("update file labels: %w", err)
+	}
+	return nil
+}
+
 // updateFileByPath updates a file identified by vault+path instead of record ID.
 // Used as a fallback when the unique index reports a conflict but GetFileByPath
 // cannot find the record (e.g. SurrealDB index/data inconsistency).

--- a/internal/db/queries_file_test.go
+++ b/internal/db/queries_file_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1574,5 +1575,66 @@ func TestListFiles_UpdatedSinceFilter(t *testing.T) {
 	}
 	if len(allDocs) != 2 {
 		t.Errorf("expected 2 docs total, got %d", len(allDocs))
+	}
+}
+
+func TestUpdateFileLabels(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	doc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID,
+		Path:    "/labels-test.md",
+		Title:   "Labels Test",
+		Content: "content",
+		Labels:  []string{"web-clip"},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+
+	fileID := models.MustRecordIDString(doc.ID)
+
+	// Add archived label
+	if err := testDB.UpdateFileLabels(ctx, fileID, []string{"web-clip", "archived"}); err != nil {
+		t.Fatalf("UpdateFileLabels failed: %v", err)
+	}
+
+	// Verify
+	updated, err := testDB.GetFileByPath(ctx, vaultID, "/labels-test.md")
+	if err != nil {
+		t.Fatalf("GetFileByPath failed: %v", err)
+	}
+	if !slices.Equal(updated.Labels, []string{"web-clip", "archived"}) {
+		t.Errorf("Expected [web-clip archived], got %v", updated.Labels)
+	}
+
+	// Remove archived label
+	if err := testDB.UpdateFileLabels(ctx, fileID, []string{"web-clip"}); err != nil {
+		t.Fatalf("UpdateFileLabels (remove) failed: %v", err)
+	}
+
+	updated, err = testDB.GetFileByPath(ctx, vaultID, "/labels-test.md")
+	if err != nil {
+		t.Fatalf("GetFileByPath failed: %v", err)
+	}
+	if len(updated.Labels) != 1 || updated.Labels[0] != "web-clip" {
+		t.Errorf("Expected [web-clip], got %v", updated.Labels)
+	}
+
+	// Set labels to nil (should normalize to empty slice)
+	if err := testDB.UpdateFileLabels(ctx, fileID, nil); err != nil {
+		t.Fatalf("UpdateFileLabels (nil) failed: %v", err)
+	}
+
+	updated, err = testDB.GetFileByPath(ctx, vaultID, "/labels-test.md")
+	if err != nil {
+		t.Fatalf("GetFileByPath failed: %v", err)
+	}
+	if len(updated.Labels) != 0 {
+		t.Errorf("Expected empty labels, got %v", updated.Labels)
 	}
 }

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -65,7 +65,9 @@ func SchemaSQL(dimension int) string {
     DEFINE FIELD IF NOT EXISTS created_at     ON file TYPE datetime DEFAULT time::now();
     DEFINE FIELD IF NOT EXISTS updated_at     ON file TYPE datetime VALUE time::now();
     DEFINE FIELD IF NOT EXISTS stem           ON file TYPE string DEFAULT "";
-    DEFINE FIELD IF NOT EXISTS no_embed       ON file TYPE bool DEFAULT false;
+    DEFINE FIELD no_embed ON file TYPE bool DEFAULT false;
+    -- Backfill: existing records may have NONE from an older schema.
+    UPDATE file SET no_embed = false WHERE no_embed = NONE;
 
     DEFINE INDEX IF NOT EXISTS idx_file_vault_path    ON file FIELDS vault, path UNIQUE;
     DEFINE INDEX IF NOT EXISTS idx_file_labels        ON file FIELDS labels;

--- a/internal/models/file.go
+++ b/internal/models/file.go
@@ -106,9 +106,11 @@ type FileTombstone struct {
 
 // FileEntry is a lightweight entry for directory listings (ls endpoint).
 type FileEntry struct {
-	Name  string `json:"name"`
-	Path  string `json:"path"`
-	Title string `json:"title,omitempty"`
-	IsDir bool   `json:"isDir"`
-	Size  int    `json:"size,omitempty"`
+	Name   string   `json:"name"`
+	Path   string   `json:"path"`
+	Title  string   `json:"title,omitempty"`
+	IsDir  bool     `json:"isDir"`
+	Size   int      `json:"size,omitempty"`
+	Labels []string `json:"labels,omitempty"`
+	Source string   `json:"source,omitempty"`
 }

--- a/internal/tui/browse/browser.go
+++ b/internal/tui/browse/browser.go
@@ -26,16 +26,18 @@ type documentFetchedMsg struct {
 	err error
 }
 
-// Model is the root browser model composing a finder and viewer.
+// Model is the root browser model composing a finder, links list, and viewer.
 type Model struct {
-	state    viewState
-	finder   finderModel
-	viewer   viewerModel
-	client   *apiclient.Client
-	vaultID  string
-	noFinder bool // true when opened with a direct path (skip finder on Escape)
-	width    int
-	height   int
+	state     viewState
+	activeTab Tab
+	finder    finderModel
+	links     linksModel
+	viewer    viewerModel
+	client    *apiclient.Client
+	vaultID   string
+	noFinder  bool // true when opened with a direct path (skip finder on Escape)
+	width     int
+	height    int
 
 	glamourStyle string
 	renderer     *glamour.TermRenderer
@@ -59,11 +61,18 @@ func initGlamour(isDark bool) (string, *glamour.TermRenderer) {
 
 // NewModel creates a browser with a pre-fetched file list.
 // isDark should be detected before bubbletea starts.
-func NewModel(client *apiclient.Client, vaultID string, files []models.FileEntry, isDark bool) Model {
+// startTab selects which tab to show initially.
+func NewModel(client *apiclient.Client, vaultID string, files []models.FileEntry, isDark bool, startTab ...Tab) Model {
 	glamourStyle, r := initGlamour(isDark)
+	initial := TabAllFiles
+	if len(startTab) > 0 {
+		initial = startTab[0]
+	}
 	return Model{
 		state:        stateFinding,
+		activeTab:    initial,
 		finder:       newFinder(files),
+		links:        newLinksModel(client, vaultID),
 		client:       client,
 		vaultID:      vaultID,
 		glamourStyle: glamourStyle,
@@ -100,7 +109,10 @@ func renderContent(r *glamour.TermRenderer, doc *apiclient.Document) string {
 }
 
 func (m Model) Init() tea.Cmd {
-	return m.finder.Init()
+	cmds := []tea.Cmd{m.finder.Init()}
+	// Start loading links immediately so they're ready when user switches tabs
+	cmds = append(cmds, m.links.loadLinks())
+	return tea.Batch(cmds...)
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -108,7 +120,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		m.finder.picker.SetSize(msg.Width, msg.Height)
+		contentHeight := msg.Height - 1 // reserve 1 line for tab bar
+		m.finder.picker.SetSize(msg.Width, contentHeight)
+		m.links.width = msg.Width
+		m.links.height = contentHeight
 		m.updateRenderer()
 		if m.state == stateViewing {
 			m.viewer.width = msg.Width
@@ -123,16 +138,39 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 
+		// Tab switching with 1/2 keys (only in finding state, and only when
+		// the links model isn't in a confirmation mode)
+		if m.state == stateFinding && !m.links.confirmDelete {
+			switch msg.String() {
+			case "1":
+				if m.activeTab != TabAllFiles {
+					m.activeTab = TabAllFiles
+					return m, m.finder.picker.Input.Focus()
+				}
+				return m, nil
+			case "2":
+				if m.activeTab != TabLinks {
+					m.activeTab = TabLinks
+				}
+				return m, nil
+			}
+		}
+
 	case fileSelectedMsg:
 		return m, m.fetchDocument(msg.path)
 
 	case documentFetchedMsg:
 		if msg.err != nil {
 			slog.Warn("document fetch failed", "error", msg.err)
-			m.finder.statusErr = fmt.Sprintf("Failed to open: %v", msg.err)
+			if m.activeTab == TabAllFiles {
+				m.finder.statusErr = fmt.Sprintf("Failed to open: %v", msg.err)
+			} else {
+				m.links.statusErr = fmt.Sprintf("Failed to open: %v", msg.err)
+			}
 			return m, nil
 		}
 		m.finder.statusErr = ""
+		m.links.statusErr = ""
 		m.viewer = newViewer(msg.doc.Path, renderContent(m.renderer, msg.doc), m.width, m.height)
 		m.state = stateViewing
 		return m, nil
@@ -142,14 +180,31 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 		m.state = stateFinding
-		return m, m.finder.picker.Input.Focus()
+		if m.activeTab == TabAllFiles {
+			return m, m.finder.picker.Input.Focus()
+		}
+		return m, nil
+	}
+
+	// Links-specific messages must always reach the links model,
+	// regardless of which tab is active (e.g. async load results).
+	switch msg.(type) {
+	case linksLoadedMsg, linkArchivedMsg, linkDeletedMsg:
+		var cmd tea.Cmd
+		m.links, cmd = m.links.Update(msg)
+		return m, cmd
 	}
 
 	// Route to active sub-model
 	switch m.state {
 	case stateFinding:
+		if m.activeTab == TabAllFiles {
+			var cmd tea.Cmd
+			m.finder, cmd = m.finder.Update(msg)
+			return m, cmd
+		}
 		var cmd tea.Cmd
-		m.finder, cmd = m.finder.Update(msg)
+		m.links, cmd = m.links.Update(msg)
 		return m, cmd
 	case stateViewing:
 		var cmd tea.Cmd
@@ -165,7 +220,12 @@ func (m Model) View() tea.View {
 
 	switch m.state {
 	case stateFinding:
-		content = m.finder.View()
+		tabBar := renderTabs(m.activeTab, len(m.links.allLinks))
+		if m.activeTab == TabAllFiles {
+			content = tabBar + "\n" + m.finder.View()
+		} else {
+			content = tabBar + "\n" + m.links.View()
+		}
 	case stateViewing:
 		content = m.viewer.View()
 	}
@@ -195,7 +255,7 @@ func (m *Model) updateRenderer() {
 		glamour.WithWordWrap(wrapWidth),
 	)
 	if err != nil {
-		slog.Warn("glamour renderer re-creation failed on resize", "width", wrapWidth, "error", err)
+		slog.Warn("glamour renderer re-creation failed on resize", "error", err)
 	} else {
 		m.renderer = r
 	}

--- a/internal/tui/browse/links.go
+++ b/internal/tui/browse/links.go
@@ -1,0 +1,412 @@
+package browse
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
+	"github.com/raphi011/know/internal/apiclient"
+	"github.com/raphi011/know/internal/browser"
+	"github.com/raphi011/know/internal/models"
+	"github.com/raphi011/know/internal/tui/pick"
+	"github.com/sahilm/fuzzy"
+)
+
+// linkSource implements fuzzy.Source for matching against link title + source URL.
+type linkSource []models.FileEntry
+
+func (s linkSource) String(i int) string {
+	e := s[i]
+	parts := e.Title
+	if e.Source != "" {
+		parts += " " + e.Source
+	}
+	if parts == "" {
+		parts = e.Path
+	}
+	return parts
+}
+
+func (s linkSource) Len() int { return len(s) }
+
+// linksLoadedMsg is sent when the links list has been fetched from the API.
+type linksLoadedMsg struct {
+	links []models.FileEntry
+	err   error
+}
+
+// linkArchivedMsg is sent after a label patch completes.
+type linkArchivedMsg struct {
+	path   string
+	labels []string
+	err    error
+}
+
+// linkDeletedMsg is sent after a delete completes.
+type linkDeletedMsg struct {
+	path string
+	err  error
+}
+
+type linksView int
+
+const (
+	linksViewInbox linksView = iota
+	linksViewArchived
+)
+
+type linksModel struct {
+	allLinks []models.FileEntry // all web clips
+	filtered []models.FileEntry // filtered by view (inbox/archived)
+	matches  []fuzzy.Match
+	cursor   int
+	offset   int
+	width    int
+	height   int
+
+	query     string
+	view      linksView
+	loaded    bool
+	statusErr string
+	statusOK  string
+
+	confirmDelete bool // true when waiting for y/n confirmation
+
+	client  *apiclient.Client
+	vaultID string
+}
+
+func newLinksModel(client *apiclient.Client, vaultID string) linksModel {
+	return linksModel{
+		client:  client,
+		vaultID: vaultID,
+		view:    linksViewInbox,
+	}
+}
+
+func (l linksModel) loadLinks() tea.Cmd {
+	client := l.client
+	vaultID := l.vaultID
+	return func() tea.Msg {
+		links, err := client.ListFilesByLabels(context.Background(), vaultID, []string{"web-clip"})
+		if err != nil {
+			return linksLoadedMsg{err: fmt.Errorf("load links: %w", err)}
+		}
+		return linksLoadedMsg{links: links}
+	}
+}
+
+func (l *linksModel) applyFilter() {
+	l.filtered = nil
+	for _, link := range l.allLinks {
+		isArchived := slices.Contains(link.Labels, "archived")
+		if l.view == linksViewInbox && !isArchived {
+			l.filtered = append(l.filtered, link)
+		} else if l.view == linksViewArchived && isArchived {
+			l.filtered = append(l.filtered, link)
+		}
+	}
+	l.refilter()
+}
+
+func (l *linksModel) refilter() {
+	if l.query == "" {
+		l.matches = make([]fuzzy.Match, len(l.filtered))
+		for i := range l.filtered {
+			l.matches[i] = fuzzy.Match{Index: i}
+		}
+	} else {
+		l.matches = fuzzy.FindFrom(l.query, linkSource(l.filtered))
+	}
+
+	if l.cursor >= len(l.matches) {
+		l.cursor = max(0, len(l.matches)-1)
+	}
+	l.ensureCursorVisible()
+}
+
+func (l *linksModel) ensureCursorVisible() {
+	visible := l.visibleRows()
+	if l.cursor < l.offset {
+		l.offset = l.cursor
+	}
+	if l.cursor >= l.offset+visible {
+		l.offset = l.cursor - visible + 1
+	}
+}
+
+func (l linksModel) visibleRows() int {
+	// tab bar (1) + search hint (1) + count line (1) + footer (1) = 4 lines overhead
+	return max(l.height-4, 1)
+}
+
+func (l linksModel) selectedEntry() *models.FileEntry {
+	if len(l.matches) == 0 || l.cursor >= len(l.matches) {
+		return nil
+	}
+	return &l.filtered[l.matches[l.cursor].Index]
+}
+
+func (l linksModel) Update(msg tea.Msg) (linksModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case linksLoadedMsg:
+		l.loaded = true
+		if msg.err != nil {
+			l.statusErr = msg.err.Error()
+			return l, nil
+		}
+		l.allLinks = msg.links
+		l.applyFilter()
+		return l, nil
+
+	case linkArchivedMsg:
+		if msg.err != nil {
+			l.statusErr = fmt.Sprintf("Archive failed: %v", msg.err)
+			return l, nil
+		}
+		// Update the local entry's labels
+		for i := range l.allLinks {
+			if l.allLinks[i].Path == msg.path {
+				l.allLinks[i].Labels = msg.labels
+				break
+			}
+		}
+		l.statusOK = "Updated"
+		l.applyFilter()
+		return l, nil
+
+	case linkDeletedMsg:
+		if msg.err != nil {
+			l.statusErr = fmt.Sprintf("Delete failed: %v", msg.err)
+			return l, nil
+		}
+		l.allLinks = slices.DeleteFunc(l.allLinks, func(e models.FileEntry) bool {
+			return e.Path == msg.path
+		})
+		l.statusOK = "Deleted"
+		l.applyFilter()
+		return l, nil
+
+	case tea.KeyPressMsg:
+		l.statusErr = ""
+		l.statusOK = ""
+
+		// Delete confirmation mode
+		if l.confirmDelete {
+			switch msg.String() {
+			case "y":
+				l.confirmDelete = false
+				entry := l.selectedEntry()
+				if entry == nil {
+					return l, nil
+				}
+				return l, l.deleteLink(entry.Path)
+			default:
+				l.confirmDelete = false
+				return l, nil
+			}
+		}
+
+		switch msg.String() {
+		case "enter":
+			entry := l.selectedEntry()
+			if entry != nil {
+				return l, func() tea.Msg {
+					return fileSelectedMsg{path: entry.Path}
+				}
+			}
+			return l, nil
+		case "o":
+			entry := l.selectedEntry()
+			if entry != nil && entry.Source != "" {
+				if err := browser.Open(entry.Source); err != nil {
+					l.statusErr = fmt.Sprintf("Could not open browser: %v", err)
+				}
+			}
+			return l, nil
+		case "a":
+			entry := l.selectedEntry()
+			if entry == nil {
+				return l, nil
+			}
+			return l, l.toggleArchive(entry)
+		case "d":
+			if l.selectedEntry() != nil {
+				l.confirmDelete = true
+			}
+			return l, nil
+		case "tab":
+			if l.view == linksViewInbox {
+				l.view = linksViewArchived
+			} else {
+				l.view = linksViewInbox
+			}
+			l.cursor = 0
+			l.offset = 0
+			l.applyFilter()
+			return l, nil
+		case "esc":
+			return l, tea.Quit
+		case "up":
+			if l.cursor > 0 {
+				l.cursor--
+				l.ensureCursorVisible()
+			}
+			return l, nil
+		case "down":
+			if l.cursor < len(l.matches)-1 {
+				l.cursor++
+				l.ensureCursorVisible()
+			}
+			return l, nil
+		case "pgup":
+			l.cursor = max(l.cursor-l.visibleRows(), 0)
+			l.ensureCursorVisible()
+			return l, nil
+		case "pgdown":
+			l.cursor = min(l.cursor+l.visibleRows(), max(len(l.matches)-1, 0))
+			l.ensureCursorVisible()
+			return l, nil
+		case "backspace":
+			if len(l.query) > 0 {
+				l.query = l.query[:len(l.query)-1]
+				l.refilter()
+			}
+			return l, nil
+		default:
+			// Single printable characters go to search
+			if len(msg.String()) == 1 && msg.String() >= " " {
+				l.query += msg.String()
+				l.refilter()
+				return l, nil
+			}
+		}
+	}
+
+	return l, nil
+}
+
+func (l linksModel) toggleArchive(entry *models.FileEntry) tea.Cmd {
+	client := l.client
+	vaultID := l.vaultID
+	path := entry.Path
+	isArchived := slices.Contains(entry.Labels, "archived")
+
+	return func() tea.Msg {
+		var req apiclient.PatchLabelsRequest
+		req.Path = path
+		if isArchived {
+			req.Remove = []string{"archived"}
+		} else {
+			req.Add = []string{"archived"}
+		}
+		if err := client.PatchDocumentLabels(context.Background(), vaultID, req); err != nil {
+			return linkArchivedMsg{path: path, err: err}
+		}
+
+		// Compute resulting labels locally
+		labels := make([]string, len(entry.Labels))
+		copy(labels, entry.Labels)
+		if isArchived {
+			labels = slices.DeleteFunc(labels, func(l string) bool { return l == "archived" })
+		} else {
+			labels = append(labels, "archived")
+		}
+		return linkArchivedMsg{path: path, labels: labels}
+	}
+}
+
+func (l linksModel) deleteLink(path string) tea.Cmd {
+	client := l.client
+	vaultID := l.vaultID
+	return func() tea.Msg {
+		_, err := client.DeleteDocuments(context.Background(), vaultID, path, false, false)
+		if err != nil {
+			return linkDeletedMsg{path: path, err: err}
+		}
+		return linkDeletedMsg{path: path}
+	}
+}
+
+var (
+	sourceStyle   = lipgloss.NewStyle().Foreground(pick.MutedColor)
+	archivedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B"))
+)
+
+func (l linksModel) View() string {
+	var b strings.Builder
+
+	if !l.loaded {
+		b.WriteString("  Loading links...")
+		return b.String()
+	}
+
+	// Search query display
+	b.WriteString(pick.PromptStyle.Render("/ "))
+	b.WriteString(l.query)
+	b.WriteString("\n")
+
+	// View indicator + count
+	viewLabel := "Inbox"
+	if l.view == linksViewArchived {
+		viewLabel = "Archived"
+	}
+	b.WriteString(pick.CountStyle.Render(fmt.Sprintf("  %s — %d/%d links", viewLabel, len(l.matches), len(l.filtered))))
+	b.WriteString("\n")
+
+	visible := l.visibleRows()
+	end := min(l.offset+visible, len(l.matches))
+
+	for i := l.offset; i < end; i++ {
+		m := l.matches[i]
+		entry := l.filtered[m.Index]
+
+		prefix := "  "
+		style := pick.NormalStyle
+		if i == l.cursor {
+			prefix = "> "
+			style = pick.SelectedStyle
+		}
+
+		// Title or path
+		title := entry.Title
+		if title == "" {
+			title = entry.Path
+		}
+		line := style.Render(title)
+
+		// Source URL (dimmed)
+		if entry.Source != "" {
+			line += " " + sourceStyle.Render(entry.Source)
+		}
+
+		// Archived badge
+		if slices.Contains(entry.Labels, "archived") {
+			line += " " + archivedStyle.Render("[archived]")
+		}
+
+		b.WriteString(prefix + line + "\n")
+	}
+
+	// Pad remaining space
+	rendered := end - l.offset
+	for i := rendered; i < visible; i++ {
+		b.WriteString("\n")
+	}
+
+	// Status messages
+	if l.confirmDelete {
+		b.WriteString(errStyle.Render("  Delete this link? y/n"))
+	} else if l.statusErr != "" {
+		b.WriteString(errStyle.Render("  " + l.statusErr))
+	} else if l.statusOK != "" {
+		b.WriteString(pick.CountStyle.Render("  " + l.statusOK))
+	} else {
+		b.WriteString(pick.CountStyle.Render("  enter: view  o: open  a: archive  d: delete  tab: inbox/archived  esc: quit"))
+	}
+
+	return b.String()
+}

--- a/internal/tui/browse/tabs.go
+++ b/internal/tui/browse/tabs.go
@@ -1,0 +1,40 @@
+package browse
+
+import (
+	"fmt"
+
+	lipgloss "charm.land/lipgloss/v2"
+	"github.com/raphi011/know/internal/tui/pick"
+)
+
+// Tab identifies a browse tab.
+type Tab int
+
+const (
+	// TabAllFiles is the default tab showing all vault documents.
+	TabAllFiles Tab = iota
+	// TabLinks shows saved web clips.
+	TabLinks
+)
+
+var (
+	activeTabStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#FFFFFF")).
+			Background(pick.PrimaryColor).
+			Bold(true).
+			Padding(0, 1)
+
+	inactiveTabStyle = lipgloss.NewStyle().
+				Foreground(pick.MutedColor).
+				Padding(0, 1)
+)
+
+func renderTabs(active Tab, linkCount int) string {
+	allFiles := "All Files"
+	links := fmt.Sprintf("Links (%d)", linkCount)
+
+	if active == TabAllFiles {
+		return activeTabStyle.Render(allFiles) + " " + inactiveTabStyle.Render(links)
+	}
+	return inactiveTabStyle.Render(allFiles) + " " + activeTabStyle.Render(links)
+}


### PR DESCRIPTION
Add a tabbed interface to `know browse` for managing saved web clips (documents with the `web-clip` label). Includes inbox/archive workflow, delete with confirmation, fuzzy search, and open-in-browser.

## New Features
- **Links tab** in `know browse` — press `2` to switch, or `know browse --links` to start there
- **Inbox/Archive workflow** — `a` to archive/unarchive, `tab` to switch views, `d` to delete with confirmation
- **Open in browser** — `o` opens the source URL in the default browser
- **Fuzzy search** — type to filter links by title or source URL
- **PATCH /documents/labels** — add/remove labels on documents via API
- **Labels filter on ls** — `?labels=web-clip` query param filters documents by label
- **Labels + Source on FileEntry** — enriched directory listing response

## Breaking Changes
- None

## Other Changes
- Extract `browser.Open` to shared `internal/browser` package (was inline in cmd_auth.go)
- `browser.Open` now returns error (callers handle it with user-facing messages)
- Fix `patchLabels` handler: distinguish DB errors (500) from not-found (404), use `RecordIDString` instead of `MustRecordIDString`
- Fix `no_embed` schema: force `bool` type (was `option<bool>` on old records) with backfill
- Helm: `revisionHistoryLimit: 3`, `appVersion: 0.12.0`
- OpenAPI spec updated for all new endpoints and fields
- Integration test for `UpdateFileLabels` with exact label assertions and nil-to-empty case