### PR TITLE
feat: harden security with SSRF prevention, security headers, and Helm validation

### DIFF
--- a/cmd/know/cmd_serve.go
+++ b/cmd/know/cmd_serve.go
@@ -96,6 +96,9 @@ func runServe(_ *cobra.Command, _ []string) error {
 		if serveNoAuth {
 			return fmt.Errorf("KNOW_NO_AUTH is not allowed in production mode (KNOW_ENVIRONMENT=production)")
 		}
+		if cfg.TLSSkipVerify {
+			return fmt.Errorf("KNOW_TLS_SKIP_VERIFY=true is not allowed in production mode (KNOW_ENVIRONMENT=production)")
+		}
 		if serveNFS {
 			slog.Warn("NFS server enabled in production mode — NFS has no per-user authentication, ensure network access is restricted")
 		}
@@ -251,7 +254,11 @@ func runServe(_ *cobra.Command, _ []string) error {
 	apiServer.Register(mux, authMw, app.AgentRunner())
 
 	// API documentation (Scalar UI at /, spec at /api/v1/openapi.yaml)
-	api.RegisterDocs(mux)
+	if cfg.DocsEnabled {
+		api.RegisterDocs(mux)
+	} else {
+		slog.Info("API docs disabled (KNOW_DOCS_ENABLED=false)")
+	}
 
 	// Document change events (SSE) — vault-scoped
 	// Uses the apiServer's vault scope middleware for consistent vault resolution.
@@ -397,7 +404,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 	})
 
 	// Global rate limiter (outermost middleware)
-	var handler http.Handler = api.RequestLogMiddleware(app.Metrics(), mux)
+	var handler http.Handler = api.SecurityHeadersMiddleware(api.RequestLogMiddleware(app.Metrics(), mux))
 	if cfg.RateLimitGlobalRPS > 0 {
 		globalRL := api.NewIPRateLimiter(cfg.RateLimitGlobalRPS, cfg.RateLimitGlobalBurst, "global", app.Metrics())
 		defer globalRL.Stop()

--- a/helm/know/templates/_helpers.tpl
+++ b/helm/know/templates/_helpers.tpl
@@ -49,6 +49,20 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Validate SurrealDB credentials are provided
+*/}}
+{{- define "know.validateSurrealDB" -}}
+{{- if not .Values.surrealdb.existingSecret }}
+{{- if not .Values.surrealdb.user }}
+{{- fail "surrealdb.user and surrealdb.password must both be set (or use surrealdb.existingSecret)" }}
+{{- end }}
+{{- if not .Values.surrealdb.password }}
+{{- fail "surrealdb.user and surrealdb.password must both be set (or use surrealdb.existingSecret)" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "know.serviceAccountName" -}}

--- a/helm/know/templates/deployment.yaml
+++ b/helm/know/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "know.validateSurrealDB" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -61,6 +62,8 @@ spec:
           env:
             - name: KNOW_ENVIRONMENT
               value: {{ .Values.environment | default "production" | quote }}
+            - name: KNOW_DOCS_ENABLED
+              value: {{ .Values.docsEnabled | default false | quote }}
             {{- if .Values.oidc.enabled }}
             - name: KNOW_OIDC_ENABLED
               value: "true"

--- a/helm/know/values.yaml
+++ b/helm/know/values.yaml
@@ -26,8 +26,8 @@ surrealdb:
   url: "ws://surrealdb:8000/rpc"
   namespace: "knowledge"
   database: "graph"
-  user: "root"
-  password: "root"
+  user: ""       # required — set via values or existingSecret
+  password: ""   # required — set via values or existingSecret
   # Authentication level: "root" or "database"
   authLevel: "root"
   # Use existing secret for credentials (optional)
@@ -73,6 +73,9 @@ ollama:
 pdf:
   textExtractorModel: ""  # model for PDF text extraction (default: gemini-2.0-flash)
   renderDpi: ""           # DPI for PDF rendering (default: 300)
+
+# API docs (Scalar UI at /, OpenAPI spec at /api/v1/openapi.yaml)
+docsEnabled: false  # disabled in production by default
 
 # MCP (Model Context Protocol) endpoint
 mcp:

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -43,6 +43,17 @@ func RequestLogMiddleware(m *metrics.Metrics, next http.Handler) http.Handler {
 	})
 }
 
+// SecurityHeadersMiddleware sets standard security response headers.
+func SecurityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+		next.ServeHTTP(w, r)
+	})
+}
+
 // statusRecorder wraps http.ResponseWriter to capture the status code.
 type statusRecorder struct {
 	http.ResponseWriter

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -61,3 +61,27 @@ func TestRequestLogMiddleware_capturesStatusCode(t *testing.T) {
 		t.Errorf("expected status=404 in log output, got: %s", output)
 	}
 }
+
+func TestSecurityHeadersMiddleware(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := SecurityHeadersMiddleware(inner)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	expected := map[string]string{
+		"X-Content-Type-Options": "nosniff",
+		"X-Frame-Options":        "DENY",
+		"Referrer-Policy":        "strict-origin-when-cross-origin",
+		"Permissions-Policy":     "camera=(), microphone=(), geolocation=()",
+	}
+	for header, want := range expected {
+		got := rec.Header().Get(header)
+		if got != want {
+			t.Errorf("header %s = %q, want %q", header, got, want)
+		}
+	}
+}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -421,6 +421,54 @@ components:
           description: Vault path where web-clipped documents are saved
           example: "/web"
 
+    ChangeEvent:
+      type: object
+      description: |
+        A change event delivered via SSE. Each event is sent as a
+        `data:` line containing a JSON-encoded ChangeEvent object.
+        For `job.created` events, `payload` is null.
+      required: [type, vaultId]
+      properties:
+        type:
+          type: string
+          description: Event type
+          enum:
+            - file.created
+            - file.updated
+            - file.deleted
+            - file.moved
+            - file.processed
+            - job.created
+        vaultId:
+          type: string
+          description: Vault record ID
+        payload:
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/DocumentPayload"
+
+    DocumentPayload:
+      type: object
+      description: Payload for document change events (file.* event types)
+      required: [docId, path, contentHash]
+      properties:
+        docId:
+          type: string
+          description: Document record ID
+          example: "file:abc123"
+        path:
+          type: string
+          description: Current vault path of the document
+          example: "/notes/hello.md"
+        oldPath:
+          type: string
+          description: Previous path (only present for `file.moved` events)
+          example: "/notes/old-name.md"
+        contentHash:
+          type: string
+          description: SHA-256 content hash of the document body
+          example: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
     Document:
       type: object
       description: A markdown document in a vault
@@ -2422,7 +2470,24 @@ paths:
       description: |
         Server-Sent Events stream for real-time document change notifications.
         Connect with `EventSource` or any SSE client. The connection stays open
-        until the client disconnects.
+        until the client disconnects. A `: ping` comment is sent every 30 seconds
+        as a keep-alive.
+
+        Each `data:` line contains a JSON-encoded `ChangeEvent` object:
+
+        ```
+        data: {"type":"file.updated","vaultId":"abc","payload":{"docId":"file:123","path":"/notes/hello.md","contentHash":"e3b0..."}}
+        ```
+
+        **Event types:**
+        | Type | Description |
+        |------|-------------|
+        | `file.created` | A new document was created |
+        | `file.updated` | An existing document's content changed |
+        | `file.deleted` | A document was deleted |
+        | `file.moved` | A document was renamed/moved (includes `oldPath`) |
+        | `file.processed` | A document finished pipeline processing (embedding, chunking) |
+        | `job.created` | A new pipeline job was queued |
       parameters:
         - $ref: "#/components/parameters/vault"
       responses:
@@ -2431,7 +2496,7 @@ paths:
           content:
             text/event-stream:
               schema:
-                type: string
+                $ref: "#/components/schemas/ChangeEvent"
 
   # ── Conversations ───────────────────────────────────────
   /conversations:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,7 @@ type Config struct {
 
 	// Server settings
 	Environment       string // KNOW_ENVIRONMENT ("development" or "production", default: "development")
+	DocsEnabled       bool   // KNOW_DOCS_ENABLED (default: true; Helm defaults to false)
 	IngestConcurrency int
 	NoAuth            bool   // bypass token auth (for local/Docker use)
 	MCPEnabled        bool   // serve MCP endpoint at /mcp (default: true)
@@ -306,6 +307,7 @@ func Load() Config {
 
 		// Server settings
 		Environment:       getEnv("KNOW_ENVIRONMENT", "development"),
+		DocsEnabled:       getEnvBool("KNOW_DOCS_ENABLED", true),
 		IngestConcurrency: getEnvInt("KNOW_INGEST_CONCURRENCY", 4),
 		NoAuth:            getEnvBool("KNOW_NO_AUTH", false),
 		MCPEnabled:        getEnvBool("KNOW_MCP_ENABLED", true),

--- a/internal/jina/reader.go
+++ b/internal/jina/reader.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -50,8 +52,46 @@ type responseData struct {
 	Content     string `json:"content"`
 }
 
+// validateURL checks that the target URL uses a safe scheme and does not
+// resolve to a private, loopback, or link-local address (SSRF prevention).
+//
+// Note: this is a best-effort client-side check. The actual HTTP request goes
+// to r.jina.ai, which performs its own fetch of the target URL. A DNS rebinding
+// attack (TOCTOU) is therefore mitigated by Jina being the intermediary.
+func validateURL(targetURL string) error {
+	u, err := url.Parse(targetURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("unsupported scheme %q: only http and https are allowed", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("URL has no host")
+	}
+	ips, err := net.LookupHost(host)
+	if err != nil {
+		return fmt.Errorf("resolve host %q: %w", host, err)
+	}
+	for _, ipStr := range ips {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			return fmt.Errorf("could not parse resolved IP %q for host %q", ipStr, host)
+		}
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+			return fmt.Errorf("URL resolves to non-public IP %s", ipStr)
+		}
+	}
+	return nil
+}
+
 // Read fetches a URL via Jina Reader and returns the markdown content with metadata.
 func (c *Client) Read(ctx context.Context, targetURL string) (*ReadResult, error) {
+	if err := validateURL(targetURL); err != nil {
+		return nil, fmt.Errorf("validate URL: %w", err)
+	}
+
 	reqURL := baseURL + "/" + targetURL
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)

--- a/internal/jina/reader_test.go
+++ b/internal/jina/reader_test.go
@@ -1,0 +1,40 @@
+package jina
+
+import (
+	"testing"
+)
+
+func TestValidateURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{name: "valid https", url: "https://example.com/page", wantErr: false},
+		{name: "valid http", url: "http://example.com/page", wantErr: false},
+		{name: "file scheme", url: "file:///etc/passwd", wantErr: true},
+		{name: "ftp scheme", url: "ftp://example.com/file", wantErr: true},
+		{name: "javascript scheme", url: "javascript:alert(1)", wantErr: true},
+		{name: "no scheme", url: "example.com", wantErr: true},
+		{name: "empty string", url: "", wantErr: true},
+		{name: "localhost", url: "http://localhost/secret", wantErr: true},
+		{name: "127.0.0.1", url: "http://127.0.0.1/secret", wantErr: true},
+		{name: "loopback ipv6", url: "http://[::1]/secret", wantErr: true},
+		{name: "private 10.x", url: "http://10.0.0.1/internal", wantErr: true},
+		{name: "private 172.16.x", url: "http://172.16.0.1/internal", wantErr: true},
+		{name: "private 192.168.x", url: "http://192.168.1.1/internal", wantErr: true},
+		{name: "link-local", url: "http://169.254.169.254/latest/meta-data/", wantErr: true},
+		// URL obfuscation bypass attempts
+		{name: "credentials in URL", url: "http://user@127.0.0.1/", wantErr: true},
+		{name: "expanded ipv6 loopback", url: "http://[0:0:0:0:0:0:0:1]/", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateURL(%q) error = %v, wantErr %v", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **SSRF prevention**: Add `validateURL` to Jina Reader — blocks private/loopback/link-local IPs, enforces http(s) scheme, fails closed on unparseable IPs. Includes defense-in-depth note about TOCTOU mitigation via Jina proxy.
- **Security headers**: Add `SecurityHeadersMiddleware` setting `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, and `Permissions-Policy` on all responses.
- **Production guards**: Block `KNOW_TLS_SKIP_VERIFY=true` in production mode (mirrors existing `KNOW_NO_AUTH` guard).
- **API docs toggle**: New `KNOW_DOCS_ENABLED` env var (default: true, Helm default: false) to conditionally serve Scalar UI. Logs when disabled.
- **Helm hardening**: Validate both `surrealdb.user` and `surrealdb.password` are set (or `existingSecret`). Remove insecure default credentials (`root`/`root`).
- **OpenAPI**: Document `ChangeEvent` and `DocumentPayload` schemas for SSE endpoint. Fix `payload` nullability for `job.created` events.

## Test plan

- [x] `just build` passes
- [x] `just test` passes — all existing + new tests green
- [x] `TestValidateURL` covers: valid URLs, blocked schemes, loopback (v4/v6), private ranges (10.x, 172.16.x, 192.168.x), link-local (169.254.x), URL obfuscation (credentials in URL, expanded IPv6)
- [x] `TestSecurityHeadersMiddleware` verifies all 4 headers
- [ ] Helm: verify `helm template` fails without `surrealdb.user`/`password`
- [ ] Manual: confirm `KNOW_DOCS_ENABLED=false` logs info line and returns 404 on `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)