### PR TITLE
feat: enable CGO in Docker and split audio into build-tagged files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.26-alpine AS go-builder
 
 WORKDIR /app
 
-RUN apk add --no-cache git
+RUN apk add --no-cache git build-base alsa-lib-dev
 
 # Download Go modules first (cache layer)
 COPY go.mod go.sum ./
@@ -17,14 +17,14 @@ COPY internal/ ./internal/
 ARG VERSION=dev
 ARG COMMIT=none
 
-RUN CGO_ENABLED=0 GOOS=linux go build \
+RUN CGO_ENABLED=1 GOOS=linux go build \
     -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \
     -o /know ./cmd/know
 
 # Runtime
 FROM alpine:3.21
 
-RUN apk add --no-cache ca-certificates tzdata ffmpeg poppler-utils \
+RUN apk add --no-cache ca-certificates tzdata ffmpeg poppler-utils alsa-lib \
     && addgroup -S -g 1000 know \
     && adduser -S -u 1000 -G know know
 

--- a/helm/know/Chart.yaml
+++ b/helm/know/Chart.yaml
@@ -3,7 +3,7 @@ name: know
 description: Know - Personal Knowledge RAG Database with REST API and WebDAV
 type: application
 version: 0.10.2
-appVersion: "0.12.0"
+appVersion: "0.13.0"
 keywords:
   - know
   - knowledge-graph

--- a/internal/record/errors_nocgo.go
+++ b/internal/record/errors_nocgo.go
@@ -1,0 +1,7 @@
+//go:build !cgo
+
+package record
+
+import "errors"
+
+var errNoCGO = errors.New("audio support requires CGO (rebuild with CGO_ENABLED=1)")

--- a/internal/record/player_cgo.go
+++ b/internal/record/player_cgo.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package record
 
 import (

--- a/internal/record/player_nocgo.go
+++ b/internal/record/player_nocgo.go
@@ -1,0 +1,39 @@
+//go:build !cgo
+
+package record
+
+import (
+	"io"
+	"time"
+)
+
+// PlayerState represents the current state of the audio player.
+type PlayerState int
+
+const (
+	_ PlayerState = iota // reserved
+	PlayerPlaying
+	PlayerPaused
+	PlayerStopped
+)
+
+// Player manages WAV playback. This is a stub for non-CGO builds.
+type Player struct{}
+
+// NewPlayer returns an error in non-CGO builds because malgo requires CGO.
+func NewPlayer(r io.ReadCloser) (*Player, error) {
+	_ = r.Close() // best-effort; errNoCGO is the primary error to report
+	return nil, errNoCGO
+}
+
+func (p *Player) Play() error             { return errNoCGO }
+func (p *Player) Pause() error            { return errNoCGO }
+func (p *Player) PlayPause() error        { return errNoCGO }
+func (p *Player) Seek(time.Duration)      {}
+func (p *Player) Position() time.Duration { return 0 }
+func (p *Player) Duration() time.Duration { return 0 }
+func (p *Player) Volume() float64         { return 0 }
+func (p *Player) SetVolume(float64)       {}
+func (p *Player) State() PlayerState      { return PlayerStopped }
+func (p *Player) PCMData() []byte         { return nil }
+func (p *Player) Close()                  {}

--- a/internal/record/recorder_cgo.go
+++ b/internal/record/recorder_cgo.go
@@ -1,16 +1,13 @@
+//go:build cgo
+
 package record
 
 import (
+	"fmt"
 	"log/slog"
 	"sync"
 
 	"github.com/gen2brain/malgo"
-)
-
-const (
-	sampleRate    = 44100
-	channels      = 1
-	bitsPerSample = 16
 )
 
 // Recorder captures audio from the default input device via malgo.
@@ -32,7 +29,7 @@ type Recorder struct {
 func NewRecorder() (*Recorder, error) {
 	ctx, err := malgo.InitContext(nil, malgo.ContextConfig{}, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init audio context: %w", err)
 	}
 	return &Recorder{ctx: ctx}, nil
 }
@@ -66,11 +63,14 @@ func (r *Recorder) Start() error {
 
 	device, err := malgo.InitDevice(r.ctx.Context, deviceConfig, callbacks)
 	if err != nil {
-		return err
+		return fmt.Errorf("init capture device: %w", err)
 	}
 	r.device = device
 
-	return r.device.Start()
+	if err := r.device.Start(); err != nil {
+		return fmt.Errorf("start capture: %w", err)
+	}
+	return nil
 }
 
 // DrainAmplitudes returns and clears the buffered amplitudes from the audio

--- a/internal/record/recorder_nocgo.go
+++ b/internal/record/recorder_nocgo.go
@@ -1,0 +1,17 @@
+//go:build !cgo
+
+package record
+
+// Recorder captures audio. This is a stub for non-CGO builds.
+type Recorder struct{}
+
+// NewRecorder returns an error in non-CGO builds because malgo requires CGO.
+func NewRecorder() (*Recorder, error) {
+	return nil, errNoCGO
+}
+
+func (r *Recorder) Start() error               { return errNoCGO }
+func (r *Recorder) DrainAmplitudes() []float64 { return nil }
+func (r *Recorder) Stop()                      {}
+func (r *Recorder) PCMData() []byte            { return nil }
+func (r *Recorder) Close()                     {}

--- a/internal/record/wav.go
+++ b/internal/record/wav.go
@@ -7,6 +7,13 @@ import (
 	"time"
 )
 
+// Default recording format: 44.1 kHz, mono, 16-bit signed PCM.
+const (
+	sampleRate    = 44100
+	channels      = 1
+	bitsPerSample = 16
+)
+
 // WAVHeader contains parsed WAV file metadata and PCM data.
 type WAVHeader struct {
 	SampleRate    uint32


### PR DESCRIPTION
## Summary

- Enable `CGO_ENABLED=1` in Dockerfile with `build-base` + `alsa-lib-dev` build deps and `alsa-lib` runtime dep (required by malgo audio library)
- Split `player.go` and `recorder.go` into `_cgo.go` (full malgo implementation) and `_nocgo.go` (graceful error stubs) using Go build tags
- Add shared `errors_nocgo.go` for the `errNoCGO` sentinel error
- Move shared audio constants (`sampleRate`, `channels`, `bitsPerSample`) to `wav.go` so both build variants can access them
- Add error wrapping context to `recorder_cgo.go` (`NewRecorder`, `Start`) per project conventions
- Bump appVersion to 0.13.0

## Test plan

- [x] `just build` succeeds with CGO enabled
- [x] `just test` passes
- [ ] Verify Docker image builds successfully
- [ ] Verify audio recording works in CGO-enabled container

🤖 Generated with [Claude Code](https://claude.com/claude-code)