### PR TITLE
feat: move MCP and OAuth endpoints to main API port

### DIFF
--- a/cmd/know/cmd_serve.go
+++ b/cmd/know/cmd_serve.go
@@ -217,6 +217,18 @@ func runServe(_ *cobra.Command, _ []string) error {
 		slog.Info("OIDC authentication enabled", "provider_type", cfg.OIDCProviderType, "provider_name", oidcProvider.ProviderName())
 	}
 
+	// OAuth AS facade for MCP auth (lets Claude Code authenticate via browser).
+	// Registered before auth middleware because OAuth endpoints are unauthenticated.
+	if cfg.OIDCEnabled && oidcHandler != nil {
+		oauthHandler := api.NewOAuthHandler(oidcHandler, oidcHandler.BaseURL())
+		if authRateLimiter != nil {
+			oauthHandler.RegisterRoutes(mux, authRateLimiter.Middleware(cfg.TrustXForwardedFor))
+		} else {
+			oauthHandler.RegisterRoutes(mux)
+		}
+		slog.Info("OAuth MCP auth enabled", "base_url", oidcHandler.BaseURL())
+	}
+
 	// Periodic cleanup: expired tokens (always) and device codes (when OIDC enabled)
 	go func() {
 		ticker := time.NewTicker(5 * time.Minute)
@@ -259,6 +271,28 @@ func runServe(_ *cobra.Command, _ []string) error {
 	apiServer := api.NewServer(app)
 	apiServer.Register(mux, authMw, app.AgentRunner())
 
+	// MCP endpoint for Model Context Protocol (on main port, behind auth)
+	if cfg.MCPEnabled {
+		mcpHandler := mcptools.NewHandler(
+			&tools.Executor{
+				DB:        app.DBClient(),
+				Search:    app.SearchService(),
+				FileSvc:   app.FileService(),
+				RenderSvc: app.RenderService(),
+				Jina:      app.JinaClient(),
+			},
+			app.DBClient(),
+			app.FileService(),
+			app.VaultService(),
+			app.RemoteService(),
+			app.MemoryService(),
+			app.ApifyClient(),
+			app.JinaClient(),
+		)
+		mux.Handle("/mcp", authMw(mcpHandler))
+		slog.Info("MCP endpoint enabled", "path", "/mcp")
+	}
+
 	// API documentation (Scalar UI at /, spec at /api/v1/openapi.yaml)
 	if cfg.DocsEnabled {
 		api.RegisterDocs(mux)
@@ -270,45 +304,11 @@ func runServe(_ *cobra.Command, _ []string) error {
 	// Uses the apiServer's vault scope middleware for consistent vault resolution.
 	mux.Handle("GET /api/v1/vaults/{vault}/events", authMw(apiServer.VaultScopeHandler(event.HandleEvents(app.EventBus()))))
 
-	// Protocol server (WebDAV + MCP) — separate port, own auth
+	// WebDAV server — separate port (editors connect directly)
 	var protoSrv *http.Server
 	{
 		protoMux := http.NewServeMux()
 
-		// MCP endpoint for Model Context Protocol
-		if cfg.MCPEnabled {
-			mcpHandler := mcptools.NewHandler(
-				&tools.Executor{
-					DB:        app.DBClient(),
-					Search:    app.SearchService(),
-					FileSvc:   app.FileService(),
-					RenderSvc: app.RenderService(),
-					Jina:      app.JinaClient(),
-				},
-				app.DBClient(),
-				app.FileService(),
-				app.VaultService(),
-				app.RemoteService(),
-				app.MemoryService(),
-				app.ApifyClient(),
-				app.JinaClient(),
-			)
-			protoMux.Handle("/mcp", authMw(mcpHandler))
-			slog.Info("MCP endpoint enabled", "port", cfg.ProtocolPort, "path", "/mcp")
-		}
-
-		// OAuth AS facade for MCP auth (lets Claude Code authenticate via browser)
-		if cfg.OIDCEnabled && oidcHandler != nil {
-			oauthHandler := api.NewOAuthHandler(oidcHandler, cfg.ProtocolBaseURL)
-			if authRateLimiter != nil {
-				oauthHandler.RegisterRoutes(protoMux, authRateLimiter.Middleware(cfg.TrustXForwardedFor))
-			} else {
-				oauthHandler.RegisterRoutes(protoMux)
-			}
-			slog.Info("OAuth MCP auth enabled", "base_url", cfg.ProtocolBaseURL)
-		}
-
-		// WebDAV endpoint for document editing with any editor
 		var davHandler http.Handler = knowdav.NewHandler(
 			serverCtx,
 			"/dav/",
@@ -351,7 +351,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 				slog.Error("protocol server error", "error", err)
 			}
 		}()
-		slog.Info("protocol server started (WebDAV + MCP)", "port", cfg.ProtocolPort)
+		slog.Info("WebDAV server started", "port", cfg.ProtocolPort)
 	}
 
 	// SSH/SFTP server (optional)
@@ -466,11 +466,11 @@ func runServe(_ *cobra.Command, _ []string) error {
 	slog.Info("cancelling background goroutines")
 	serverCancel()
 
-	// 3. Protocol server shutdown (WebDAV + MCP)
+	// 3. WebDAV server shutdown
 	if protoSrv != nil {
-		slog.Info("protocol: shutting down")
+		slog.Info("webdav: shutting down")
 		if err := protoSrv.Shutdown(shutdownCtx); err != nil {
-			slog.Error("protocol: shutdown error", "error", err)
+			slog.Error("webdav: shutdown error", "error", err)
 		}
 	}
 

--- a/docs/feature-auth.md
+++ b/docs/feature-auth.md
@@ -231,22 +231,22 @@ The CLI resolves tokens in this order:
 
 ### OAuth MCP Authentication
 
-When OIDC is enabled, Know exposes an OAuth 2.0 Authorization Server facade on the protocol port. This lets Claude Code and other MCP clients authenticate via browser login without manual token configuration.
+When OIDC is enabled, Know exposes an OAuth 2.0 Authorization Server facade on the main API port. This lets Claude Code and other MCP clients authenticate via browser login without manual token configuration.
 
-**Endpoints** (on protocol port, default 4002):
+**Endpoints** (on main port, default 8484):
 - `GET /.well-known/oauth-authorization-server` — OAuth metadata (RFC 8414)
 - `GET /oauth/authorize` — Starts the auth flow (redirects to OIDC provider)
 - `POST /oauth/token` — Exchanges authorization code for `kh_` token
 
 **Setup:**
 ```bash
-claude mcp add --transport http --client-id know-mcp know http://localhost:4002/mcp
+claude mcp add --transport http --client-id know-mcp know http://localhost:8484/mcp
 ```
 
 Then in Claude Code, run `/mcp` and select "Authenticate" — a browser window opens, you log in with your OIDC provider, and the token is issued and stored automatically by the MCP client.
 
 **Configuration:**
-- `KNOW_PROTOCOL_BASE_URL` — Public URL of the protocol port (required in production, e.g. `https://know.example.com:4002`)
+- The OAuth base URL is derived from the OIDC redirect URL — no separate configuration needed
 - Requires `KNOW_OIDC_ENABLED=true` and a configured OIDC provider
 
 ## Native App Login (PKCE)

--- a/docs/feature-mcp.md
+++ b/docs/feature-mcp.md
@@ -23,7 +23,7 @@ If the server has OIDC enabled, Claude Code can authenticate directly via browse
 
 ```bash
 # Add with OAuth support
-claude mcp add --transport http --client-id know-mcp know http://localhost:4002/mcp
+claude mcp add --transport http --client-id know-mcp know http://localhost:8484/mcp
 
 # Then authenticate via /mcp in Claude Code
 ```
@@ -32,7 +32,7 @@ This uses the OAuth 2.0 Authorization Code + PKCE flow. The server proxies authe
 
 For servers without OIDC, use bearer token authentication:
 ```bash
-claude mcp add --transport http know http://localhost:4002/mcp \
+claude mcp add --transport http know http://localhost:8484/mcp \
   --header "Authorization: Bearer ${KNOW_TOKEN}"
 ```
 

--- a/helm/know/Chart.yaml
+++ b/helm/know/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: know
 description: Know - Personal Knowledge RAG Database with REST API and WebDAV
 type: application
-version: 0.10.3
-appVersion: "0.13.1"
+version: 0.10.4
+appVersion: "0.14.0"
 keywords:
   - know
   - knowledge-graph

--- a/helm/know/templates/deployment.yaml
+++ b/helm/know/templates/deployment.yaml
@@ -217,12 +217,10 @@ spec:
             # MCP
             - name: KNOW_MCP_ENABLED
               value: {{ .Values.mcp.enabled | quote }}
-            # Protocol port (WebDAV + MCP)
+            # Protocol port (WebDAV)
             {{- if .Values.protocol.enabled }}
             - name: KNOW_PROTOCOL_PORT
               value: {{ .Values.protocol.port | default "4002" | quote }}
-            - name: KNOW_PROTOCOL_BASE_URL
-              value: {{ .Values.protocol.protocolBaseURL | default "" | quote }}
             {{- end }}
             # SSH/SFTP server
             {{- if .Values.ssh.enabled }}

--- a/helm/know/values.yaml
+++ b/helm/know/values.yaml
@@ -81,11 +81,10 @@ docsEnabled: false  # disabled in production by default
 mcp:
   enabled: true  # set to false to disable MCP endpoint at /mcp
 
-# Protocol port — separate port for WebDAV + MCP
+# Protocol port — separate port for WebDAV (editors connect directly)
 protocol:
   enabled: true
   port: "4002"
-  # protocolBaseURL: "" # Public URL for protocol port (required for OAuth in production)
 
 # SSH/SFTP server
 ssh:

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -54,6 +54,9 @@ func NewAuthHandler(provider oidc.Provider, dbClient *db.Client, selfSignup bool
 	}, nil
 }
 
+// BaseURL returns the scheme+host derived from the redirect URL (e.g. "https://know.example.com").
+func (h *AuthHandler) BaseURL() string { return h.baseURL }
+
 // RegisterRoutes registers unauthenticated OIDC auth routes.
 // If mw is non-nil, each route is wrapped with the middleware (e.g. rate limiting).
 func (h *AuthHandler) RegisterRoutes(mux *http.ServeMux, mw ...func(http.Handler) http.Handler) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,8 +101,7 @@ type Config struct {
 	IngestConcurrency int
 	NoAuth            bool   // bypass token auth (for local/Docker use)
 	MCPEnabled        bool   // serve MCP endpoint at /mcp (default: true)
-	ProtocolPort      string // KNOW_PROTOCOL_PORT — separate port for WebDAV + MCP (default: "4002")
-	ProtocolBaseURL   string // KNOW_PROTOCOL_BASE_URL (default: "http://localhost:{KNOW_PROTOCOL_PORT}")
+	ProtocolPort      string // KNOW_PROTOCOL_PORT — separate port for WebDAV (default: "4002")
 	MetricsPort       string // KNOW_METRICS_PORT — separate port for /metrics (default: "" = disabled)
 
 	// SSH/SFTP server
@@ -242,7 +241,6 @@ func Load() Config {
 	}
 
 	protocolPort := getEnv("KNOW_PROTOCOL_PORT", "4002")
-	protocolBaseURL := getEnv("KNOW_PROTOCOL_BASE_URL", "http://localhost:"+protocolPort)
 
 	return Config{
 		// SurrealDB
@@ -316,7 +314,6 @@ func Load() Config {
 		NoAuth:            getEnvBool("KNOW_NO_AUTH", false),
 		MCPEnabled:        getEnvBool("KNOW_MCP_ENABLED", true),
 		ProtocolPort:      protocolPort,
-		ProtocolBaseURL:   protocolBaseURL,
 		SSHEnabled:        getEnvBool("KNOW_SSH_ENABLED", false),
 		SSHPort:           getEnv("KNOW_SSH_PORT", "2222"),
 		SSHHostKeyPath:    getEnv("KNOW_SSH_HOST_KEY", ""),


### PR DESCRIPTION
## Summary

- Move MCP endpoint (`/mcp`) and OAuth AS facade from the separate protocol port (4002) to the main API port (8484), so MCP clients only need one URL
- Derive OAuth base URL from `oidcHandler.BaseURL()` (from OIDC redirect URL) instead of separate `KNOW_PROTOCOL_BASE_URL` env var
- Remove `KNOW_PROTOCOL_BASE_URL` from config, Helm chart, and docs — no longer needed
- Protocol port now serves WebDAV only (editors connect directly)

## Test plan

- [ ] `just build` compiles cleanly
- [ ] `just test` passes (excluding integration tests requiring Docker)
- [ ] MCP client (Claude Code) connects to `http://localhost:8484/mcp` with bearer token auth
- [ ] OAuth flow works: `claude mcp add --transport http --client-id know-mcp know http://localhost:8484/mcp` → browser login → token issued
- [ ] WebDAV still works on protocol port (4002)
- [ ] Helm deploy: verify `KNOW_PROTOCOL_BASE_URL` no longer set, MCP accessible on main port

🤖 Generated with [Claude Code](https://claude.com/claude-code)