### PR TITLE
feat: inject VAULT.md instructions into agent system prompt

### DIFF
--- a/docs/feature-agent.md
+++ b/docs/feature-agent.md
@@ -89,6 +89,47 @@ Example prompts:
 "Reorganize the docs folder — split the README into separate guides"
 ```
 
+## Vault Instructions (VAULT.md)
+
+Create a `/VAULT.md` document at the root of your vault to customize agent behavior. The content is injected into the agent's system prompt on every request — similar to how `CLAUDE.md` works for Claude Code.
+
+### Creating VAULT.md
+
+```
+# Via agent chat
+"Create /VAULT.md with the following instructions: Always respond in German."
+
+# Via CLI import
+echo "Always respond in German." > vault-instructions.md
+know import vault-instructions.md /VAULT.md --vault default
+
+# Via WebDAV, NFS, or any editor that connects to the vault
+```
+
+### Updating via the agent
+
+Ask the agent to remember preferences and it will update `/VAULT.md`:
+
+```
+"Remember that I prefer bullet lists over prose."
+"Add to VAULT.md: always cite sources with document paths."
+```
+
+### Example VAULT.md
+
+```markdown
+# Vault Instructions
+
+- Always respond in German
+- Prefer bullet lists over prose
+- When summarizing documents, include the document path as a citation
+- Use the "meeting-notes" template for any meeting-related requests
+```
+
+### Size limit
+
+VAULT.md content is capped at 32 KB. Content beyond this limit is truncated with a warning.
+
 ## Reference
 
 ### REST API Endpoints

--- a/internal/agent/middleware.go
+++ b/internal/agent/middleware.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/components/tool"
@@ -70,11 +71,28 @@ func (m *contextInjectionMiddleware) BeforeAgent(ctx context.Context, runCtx *ad
 		}
 	}
 
+	var vaultInstructions string
+	vaultMDFile, err := m.db.GetFileByPath(ctx, m.vaultID, "/VAULT.md")
+	if err != nil {
+		logger.Warn("failed to load VAULT.md", "vault_id", m.vaultID, "error", err)
+	} else if vaultMDFile != nil {
+		content, contentErr := m.fileSvc.ReadFileContent(ctx, vaultMDFile)
+		if contentErr != nil {
+			logger.Warn("failed to read VAULT.md content", "vault_id", m.vaultID, "error", contentErr)
+		} else {
+			vaultInstructions = formatVaultInstructions(content)
+			if len(content) > maxVaultInstructionsBytes {
+				logger.Warn("VAULT.md truncated", "vault_id", m.vaultID, "size_bytes", len(content), "max_bytes", maxVaultInstructionsBytes)
+			}
+		}
+	}
+
 	vals := map[string]any{
-		"FolderTree":  folderTree,
-		"Labels":      labels,
-		"Templates":   templates,
-		"CurrentDate": time.Now().Format("2006-01-02"),
+		"FolderTree":        folderTree,
+		"Labels":            labels,
+		"Templates":         templates,
+		"CurrentDate":       time.Now().Format("2006-01-02"),
+		"VaultInstructions": vaultInstructions,
 	}
 	adk.AddSessionValues(ctx, vals)
 
@@ -141,6 +159,31 @@ func formatTemplates(docs []models.File) string {
 			fmt.Fprintf(&sb, "- %s\n", escaped)
 		}
 	}
+	return sb.String()
+}
+
+const maxVaultInstructionsBytes = 32 * 1024
+
+// formatVaultInstructions wraps VAULT.md content in a labeled section for the
+// system prompt, or returns "" if content is empty. Escapes curly braces to
+// prevent FString interpolation and truncates at 32 KB.
+func formatVaultInstructions(content string) string {
+	if content == "" {
+		return ""
+	}
+	if len(content) > maxVaultInstructionsBytes {
+		// Truncate at a valid UTF-8 boundary to avoid garbled trailing runes.
+		trunc := content[:maxVaultInstructionsBytes]
+		for !utf8.ValidString(trunc) {
+			trunc = trunc[:len(trunc)-1]
+		}
+		content = trunc + "\n\n(truncated — VAULT.md exceeds 32 KB limit)"
+	}
+	esc := strings.NewReplacer("{", "{{", "}", "}}")
+	var sb strings.Builder
+	sb.WriteString("\n\n## Vault Instructions (/VAULT.md)\nYou can update this file using edit_document when the user asks you to remember preferences or conventions.\n\n<vault-instructions>\n")
+	sb.WriteString(esc.Replace(content))
+	sb.WriteString("\n</vault-instructions>")
 	return sb.String()
 }
 

--- a/internal/agent/middleware_test.go
+++ b/internal/agent/middleware_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/raphi011/know/internal/models"
@@ -47,6 +48,60 @@ func TestFormatTemplates(t *testing.T) {
 			got := formatTemplates(tt.docs)
 			if got != tt.want {
 				t.Errorf("formatTemplates() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatVaultInstructions(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "normal content",
+			in:   "Always respond in German",
+			want: "\n\n## Vault Instructions (/VAULT.md)\nYou can update this file using edit_document when the user asks you to remember preferences or conventions.\n\n<vault-instructions>\nAlways respond in German\n</vault-instructions>",
+		},
+		{
+			name: "curly braces escaped",
+			in:   "Use {name} template",
+			want: "\n\n## Vault Instructions (/VAULT.md)\nYou can update this file using edit_document when the user asks you to remember preferences or conventions.\n\n<vault-instructions>\nUse {{name}} template\n</vault-instructions>",
+		},
+		{
+			name: "XML-like tags passed through",
+			in:   "<foo>bar</foo>",
+			want: "\n\n## Vault Instructions (/VAULT.md)\nYou can update this file using edit_document when the user asks you to remember preferences or conventions.\n\n<vault-instructions>\n<foo>bar</foo>\n</vault-instructions>",
+		},
+		{
+			name: "exact boundary not truncated",
+			in:   strings.Repeat("x", maxVaultInstructionsBytes),
+			want: "\n\n## Vault Instructions (/VAULT.md)\nYou can update this file using edit_document when the user asks you to remember preferences or conventions.\n\n<vault-instructions>\n" + strings.Repeat("x", maxVaultInstructionsBytes) + "\n</vault-instructions>",
+		},
+		{
+			name: "oversized content truncated",
+			in:   strings.Repeat("x", maxVaultInstructionsBytes+100),
+			want: "\n\n## Vault Instructions (/VAULT.md)\nYou can update this file using edit_document when the user asks you to remember preferences or conventions.\n\n<vault-instructions>\n" + strings.Repeat("x", maxVaultInstructionsBytes) + "\n\n(truncated — VAULT.md exceeds 32 KB limit)\n</vault-instructions>",
+		},
+		{
+			name: "multi-byte char at boundary truncated cleanly",
+			// 'ä' is 2 bytes in UTF-8; place it so second byte falls past the limit
+			in:   strings.Repeat("a", maxVaultInstructionsBytes-1) + "ä",
+			want: "\n\n## Vault Instructions (/VAULT.md)\nYou can update this file using edit_document when the user asks you to remember preferences or conventions.\n\n<vault-instructions>\n" + strings.Repeat("a", maxVaultInstructionsBytes-1) + "\n\n(truncated — VAULT.md exceeds 32 KB limit)\n</vault-instructions>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatVaultInstructions(tt.in)
+			if got != tt.want {
+				t.Errorf("formatVaultInstructions() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -107,7 +107,7 @@ Today's date is {CurrentDate}.
 - Do not include a sources section at the end of your response — sources are shown separately in the UI
 - You can access multiple vaults including remote ones. Read tools (search, read_document, etc.) automatically query all accessible vaults. Results from remote vaults are prefixed with [namespace].
 - For write tools (create_document, edit_document, etc.), you can target a specific vault by setting the "vault" field. Use "remote-name/vault-name" format for remote vaults. If omitted, the first local vault is used.
-- When asked to use a template, read it with read_document and structure your output accordingly{FolderTree}{Labels}{Templates}`
+- When asked to use a template, read it with read_document and structure your output accordingly{FolderTree}{Labels}{Templates}{VaultInstructions}`
 
 // buildMessages converts DB messages to eino schema messages.
 func buildMessages(ctx context.Context, dbMsgs []models.Message) []*schema.Message {


### PR DESCRIPTION
Users can create a `/VAULT.md` document at the vault root to customize agent behavior. The content is loaded on every request and injected into the system prompt — similar to how `CLAUDE.md` works for Claude Code.

## New Features
- VAULT.md loading in `contextInjectionMiddleware.BeforeAgent` with graceful degradation on errors
- `formatVaultInstructions` — wraps content with FString brace escaping and rune-safe 32 KB truncation
- Server-side `logger.Warn` when truncation occurs
- Agent is instructed to update VAULT.md via `edit_document` when users ask to remember preferences
- Documentation in `docs/feature-agent.md`

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)