### PR TITLE
feat: in-TUI document editing and browse UX improvements

### DIFF
--- a/cmd/know/cmd_browse.go
+++ b/cmd/know/cmd_browse.go
@@ -22,7 +22,6 @@ import (
 var (
 	browseAPI       *apiFlags
 	browseVaultID   *string
-	browseEdit      bool
 	browseViewer    string
 	browseLinks     bool
 	browseBookmarks bool
@@ -31,16 +30,15 @@ var (
 var browseCmd = &cobra.Command{
 	Use:   "browse [path]",
 	Short: "Browse, view, or edit vault documents",
-	Long: `Browse vault documents with fuzzy search, view them, or edit in $EDITOR.
+	Long: `Browse vault documents with fuzzy search and view them in a TUI.
 
 Without a path, launches a fuzzy finder to pick a file.
-With a path, opens the file directly.
+With a path, opens the file directly. Press 'e' in the viewer to edit in $EDITOR.
 
 Output adapts to context: interactive terminal shows a TUI viewer,
 piped output prints raw content to stdout.
 
 Flags:
-  -e, --edit      Open the selected file in $EDITOR and save changes
   --viewer CMD    Pipe content through a viewer command (e.g. bat, glow)
 
 Environment variables:
@@ -56,8 +54,6 @@ Examples:
   know browse | head                       # fuzzy pick → pipe content
   know browse | wc -l                      # fuzzy pick → count lines
   know browse --viewer bat /docs/readme.md # view with bat
-  know browse -e /docs/readme.md           # edit in $EDITOR
-  know browse -e                           # fuzzy pick → edit
   know browse --links                      # browse saved web clips`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runBrowse,
@@ -66,7 +62,6 @@ Examples:
 func init() {
 	browseAPI = addAPIFlags(browseCmd)
 	browseVaultID = addVaultFlag(browseCmd, browseAPI)
-	browseCmd.Flags().BoolVarP(&browseEdit, "edit", "e", false, "open in $EDITOR and save changes")
 	browseCmd.Flags().StringVar(&browseViewer, "viewer", os.Getenv("KNOW_VIEWER"), "viewer command (env: KNOW_VIEWER)")
 	browseCmd.Flags().BoolVarP(&browseLinks, "links", "l", false, "start on the Links tab (saved web clips)")
 	browseCmd.Flags().BoolVarP(&browseBookmarks, "bookmarks", "b", false, "start on the Bookmarks tab")
@@ -85,17 +80,6 @@ func runBrowse(_ *cobra.Command, args []string) error {
 
 // browseWithPath handles the case where a path is given as a positional argument.
 func browseWithPath(ctx context.Context, client *apiclient.Client, path string) error {
-	if browseEdit {
-		if !models.IsTextFile(path) {
-			return fmt.Errorf("browse: %s is not a text file — only .md and .txt files can be edited", path)
-		}
-		doc, err := client.GetDocument(ctx, *browseVaultID, path)
-		if err != nil {
-			return fmt.Errorf("browse: %w", err)
-		}
-		return editAndSave(ctx, client, *browseVaultID, path, doc.Content)
-	}
-
 	doc, err := client.GetDocument(ctx, *browseVaultID, path)
 	if err != nil {
 		return fmt.Errorf("browse: %w", err)
@@ -133,24 +117,11 @@ func browseWithPicker(ctx context.Context, client *apiclient.Client) error {
 		if f.IsDir {
 			continue
 		}
-		if browseEdit && !models.IsTextFile(f.Name) {
-			continue
-		}
 		docs = append(docs, f)
 	}
 
 	if len(docs) == 0 {
-		if browseEdit {
-			return fmt.Errorf("browse: no editable text files found in vault %q", *browseVaultID)
-		}
 		return fmt.Errorf("browse: no documents found in vault %q", *browseVaultID)
-	}
-
-	// --edit: pick → edit in $EDITOR
-	if browseEdit {
-		return pickAndDo(ctx, client, docs, func(path string, doc *apiclient.Document) error {
-			return editAndSave(ctx, client, *browseVaultID, path, doc.Content)
-		})
 	}
 
 	// --viewer: pick → pipe through viewer
@@ -199,30 +170,6 @@ func pickAndDo(ctx context.Context, client *apiclient.Client, docs []models.File
 		return fmt.Errorf("browse: %w", err)
 	}
 	return action(selected, doc)
-}
-
-// editAndSave opens content in $EDITOR and saves changes back to the server.
-func editAndSave(ctx context.Context, client *apiclient.Client, vaultID, path, content string) error {
-	updated, err := openInEditor(content, filepath.Ext(path))
-	if err != nil {
-		return err
-	}
-
-	if updated == content {
-		fmt.Println("no changes")
-		return nil
-	}
-
-	if _, err := client.EditDocument(ctx, apiclient.EditDocumentRequest{
-		VaultName: vaultID,
-		Path:      path,
-		Content:   updated,
-	}); err != nil {
-		return fmt.Errorf("save: %w", err)
-	}
-
-	fmt.Println("saved")
-	return nil
 }
 
 // viewWithCommand pipes content through an external viewer command.

--- a/cmd/know/cmd_note.go
+++ b/cmd/know/cmd_note.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -206,6 +207,27 @@ func streamToStdout(events <-chan tui.StreamEvent) error {
 		}
 	}
 	return fmt.Errorf("agent: stream ended unexpectedly")
+}
+
+// editAndSave opens content in $EDITOR and saves changes back to the server.
+func editAndSave(ctx context.Context, client *apiclient.Client, vaultID, path, content string) error {
+	updated, err := openInEditor(content, filepath.Ext(path))
+	if err != nil {
+		return err
+	}
+	if updated == content {
+		fmt.Println("no changes")
+		return nil
+	}
+	if _, err := client.EditDocument(ctx, apiclient.EditDocumentRequest{
+		VaultName: vaultID,
+		Path:      path,
+		Content:   updated,
+	}); err != nil {
+		return fmt.Errorf("save: %w", err)
+	}
+	fmt.Println("saved")
+	return nil
 }
 
 // openInEditor writes content to a temp file, opens $EDITOR, and returns the edited content.

--- a/internal/tui/browse/browser.go
+++ b/internal/tui/browse/browser.go
@@ -103,7 +103,7 @@ func NewModelWithDocument(doc *apiclient.Document, client *apiclient.Client, vau
 		noFinder:     true,
 		glamourStyle: glamourStyle,
 		renderer:     r,
-		viewer:       newViewer(doc.Path, renderContent(r, doc), 80, 24),
+		viewer:       newViewer(doc.Path, doc.Content, renderContent(r, doc), 80, 24),
 	}
 }
 
@@ -121,9 +121,14 @@ func renderContent(r *glamour.TermRenderer, doc *apiclient.Document) string {
 }
 
 func (m Model) Init() tea.Cmd {
-	cmds := []tea.Cmd{m.finder.Init()}
-	// Start loading links and bookmarks immediately so they're ready when user switches tabs
-	cmds = append(cmds, m.links.loadLinks(), m.bookmarks.loadBookmarks())
+	cmds := []tea.Cmd{m.links.loadLinks(), m.bookmarks.loadBookmarks()}
+	// Focus the input for the initial tab.
+	switch m.activeTab {
+	case TabAllFiles:
+		cmds = append(cmds, m.finder.Init())
+	case TabLinks:
+		cmds = append(cmds, m.links.input.Focus())
+	}
 	return tea.Batch(cmds...)
 }
 
@@ -136,6 +141,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.finder.picker.SetSize(msg.Width, contentHeight)
 		m.links.width = msg.Width
 		m.links.height = contentHeight
+		m.links.input.SetWidth(msg.Width - len(m.links.input.Prompt))
 		m.bookmarks.width = msg.Width
 		m.bookmarks.height = contentHeight
 		m.updateRenderer()
@@ -157,25 +163,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 
-		// Tab switching with 1/2 keys (only in finding state, and only when
+		// Tab switching with 1/2/3 or Tab key (only in finding state, and only when
 		// the links model isn't in a confirmation mode)
 		if m.state == stateFinding && !m.links.confirmDelete {
+			var newTab Tab = -1
 			switch msg.String() {
+			case "tab":
+				newTab = (m.activeTab + 1) % 3
+			case "shift+tab":
+				newTab = (m.activeTab + 2) % 3
 			case "1":
-				if m.activeTab != TabAllFiles {
-					m.activeTab = TabAllFiles
-					return m, m.finder.picker.Input.Focus()
-				}
-				return m, nil
+				newTab = TabAllFiles
 			case "2":
-				if m.activeTab != TabLinks {
-					m.activeTab = TabLinks
-				}
-				return m, nil
+				newTab = TabLinks
 			case "3":
-				if m.activeTab != TabBookmarks {
-					m.activeTab = TabBookmarks
-				}
+				newTab = TabBookmarks
+			}
+			if newTab >= 0 && newTab != m.activeTab {
+				m.activeTab = newTab
+				return m, m.focusActiveTab()
+			} else if newTab >= 0 {
 				return m, nil
 			}
 		}
@@ -206,7 +213,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.fetchAudio(msg.doc)
 		}
 
-		m.viewer = newViewer(msg.doc.Path, renderContent(m.renderer, msg.doc), m.width, m.height)
+		m.viewer = newViewer(msg.doc.Path, msg.doc.Content, renderContent(m.renderer, msg.doc), m.width, m.height)
 		// Initialize bookmark state from loaded bookmarks.
 		for _, bm := range m.bookmarks.items {
 			if bm.Path == msg.doc.Path {
@@ -224,7 +231,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.transcript != "" {
 				content := "**Audio playback unavailable:** " + msg.err.Error() + "\n\n---\n\n" + msg.transcript
 				doc := &apiclient.Document{Content: content}
-				m.viewer = newViewer(msg.path, renderContent(m.renderer, doc), m.width, m.height)
+				m.viewer = newViewer(msg.path, content, renderContent(m.renderer, doc), m.width, m.height)
 				m.state = stateViewing
 				return m, nil
 			}
@@ -248,10 +255,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 		m.state = stateFinding
-		if m.activeTab == TabAllFiles {
-			return m, m.finder.picker.Input.Focus()
-		}
-		return m, nil
+		return m, m.focusActiveTab()
 
 	case bookmarkToggledMsg:
 		var cmd tea.Cmd
@@ -262,6 +266,28 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.viewer.bookmarked = false
 		}
 		return m, cmd
+
+	case editorFinishedMsg:
+		if msg.err != nil {
+			slog.Warn("editor failed", "path", msg.path, "error", msg.err)
+			m.viewer.statusMsg = fmt.Sprintf("Edit failed: %v", msg.err)
+			return m, nil
+		}
+		if !msg.changed {
+			m.viewer.statusMsg = "No changes"
+			return m, nil
+		}
+		// Re-render with updated content.
+		m.viewer = newViewer(msg.path, msg.content, renderContent(m.renderer, &apiclient.Document{Content: msg.content}), m.width, m.height)
+		m.viewer.statusMsg = "Saved"
+		// Restore bookmark state.
+		for _, bm := range m.bookmarks.items {
+			if bm.Path == msg.path {
+				m.viewer.bookmarked = true
+				break
+			}
+		}
+		return m, nil
 	}
 
 	// Async messages must always reach their model regardless of active tab.
@@ -294,9 +320,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 	case stateViewing:
-		// Handle bookmark toggle in viewer
-		if keyMsg, ok := msg.(tea.KeyPressMsg); ok && keyMsg.String() == "b" {
-			return m, m.bookmarks.toggleBookmark(m.viewer.path, !m.viewer.bookmarked)
+		if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+			switch keyMsg.String() {
+			case "b":
+				return m, m.bookmarks.toggleBookmark(m.viewer.path, !m.viewer.bookmarked)
+			case "e":
+				if m.viewer.audioPlayer != nil || !models.IsTextFile(m.viewer.path) {
+					break
+				}
+				return m, m.editDocument()
+			}
 		}
 		var cmd tea.Cmd
 		m.viewer, cmd = m.viewer.Update(msg)
@@ -327,6 +360,25 @@ func (m Model) View() tea.View {
 	v := tea.NewView(content)
 	v.AltScreen = true
 	return v
+}
+
+// editDocument opens the current document in $EDITOR.
+func (m *Model) editDocument() tea.Cmd {
+	return openInEditor(m.viewer.path, m.viewer.rawContent, m.client, m.vaultID)
+}
+
+// focusActiveTab blurs all inputs then focuses the active tab's input.
+func (m *Model) focusActiveTab() tea.Cmd {
+	m.finder.picker.Input.Blur()
+	m.links.input.Blur()
+	switch m.activeTab {
+	case TabAllFiles:
+		return m.finder.picker.Input.Focus()
+	case TabLinks:
+		return m.links.input.Focus()
+	default:
+		return nil
+	}
 }
 
 func (m *Model) fetchDocument(path string) tea.Cmd {

--- a/internal/tui/browse/editor.go
+++ b/internal/tui/browse/editor.go
@@ -1,0 +1,89 @@
+package browse
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/raphi011/know/internal/apiclient"
+)
+
+// editorFinishedMsg is sent after the editor process exits.
+type editorFinishedMsg struct {
+	path    string
+	content string // updated content
+	changed bool   // true if content was modified and saved
+	err     error
+}
+
+// editorErr returns a Cmd that sends an editorFinishedMsg with an error.
+func editorErr(path string, err error) tea.Cmd {
+	return func() tea.Msg {
+		return editorFinishedMsg{path: path, err: err}
+	}
+}
+
+// openInEditor launches $EDITOR with the document content and returns an
+// ExecProcess command that suspends the TUI while the editor runs.
+func openInEditor(path, content string, client *apiclient.Client, vaultID string) tea.Cmd {
+	ext := filepath.Ext(path)
+	tmpFile, err := os.CreateTemp("", "know-*"+ext)
+	if err != nil {
+		return editorErr(path, fmt.Errorf("create temp file: %w", err))
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+
+	if err := os.WriteFile(tmpPath, []byte(content), 0600); err != nil {
+		os.Remove(tmpPath)
+		return editorErr(path, fmt.Errorf("write temp file: %w", err))
+	}
+
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "vi"
+	}
+	if _, err := exec.LookPath(editor); err != nil {
+		os.Remove(tmpPath)
+		return editorErr(path, fmt.Errorf("editor %q not found: set $EDITOR", editor))
+	}
+
+	c := exec.Command(editor, tmpPath)
+	return tea.ExecProcess(c, func(err error) tea.Msg {
+		defer func() {
+			if removeErr := os.Remove(tmpPath); removeErr != nil {
+				slog.Warn("failed to remove temp file", "path", tmpPath, "error", removeErr)
+			}
+		}()
+
+		if err != nil {
+			return editorFinishedMsg{path: path, err: fmt.Errorf("run editor: %w", err)}
+		}
+
+		data, err := os.ReadFile(tmpPath)
+		if err != nil {
+			return editorFinishedMsg{path: path, err: fmt.Errorf("read edited file: %w", err)}
+		}
+
+		updated := string(data)
+		if updated == content {
+			return editorFinishedMsg{path: path}
+		}
+
+		// Save changes back to the server. context.Background is required
+		// because tea.ExecProcess callbacks don't receive a context.
+		if _, err := client.EditDocument(context.Background(), apiclient.EditDocumentRequest{
+			VaultName: vaultID,
+			Path:      path,
+			Content:   updated,
+		}); err != nil {
+			return editorFinishedMsg{path: path, err: fmt.Errorf("save: %w", err)}
+		}
+
+		return editorFinishedMsg{path: path, content: updated, changed: true}
+	})
+}

--- a/internal/tui/browse/links.go
+++ b/internal/tui/browse/links.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 
+	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
 	"github.com/raphi011/know/internal/apiclient"
@@ -67,7 +68,7 @@ type linksModel struct {
 	width    int
 	height   int
 
-	query     string
+	input     textinput.Model
 	view      linksView
 	loaded    bool
 	statusErr string
@@ -80,7 +81,18 @@ type linksModel struct {
 }
 
 func newLinksModel(client *apiclient.Client, vaultID string) linksModel {
+	ti := textinput.New()
+	ti.Placeholder = "Search links..."
+	ti.CharLimit = 256
+	ti.Prompt = "/ "
+
+	styles := ti.Styles()
+	styles.Cursor.Blink = false
+	styles.Focused.Prompt = pick.PromptStyle
+	ti.SetStyles(styles)
+
 	return linksModel{
+		input:   ti,
 		client:  client,
 		vaultID: vaultID,
 		view:    linksViewInbox,
@@ -113,13 +125,14 @@ func (l *linksModel) applyFilter() {
 }
 
 func (l *linksModel) refilter() {
-	if l.query == "" {
+	query := l.input.Value()
+	if query == "" {
 		l.matches = make([]fuzzy.Match, len(l.filtered))
 		for i := range l.filtered {
 			l.matches[i] = fuzzy.Match{Index: i}
 		}
 	} else {
-		l.matches = fuzzy.FindFrom(l.query, linkSource(l.filtered))
+		l.matches = fuzzy.FindFrom(query, linkSource(l.filtered))
 	}
 
 	if l.cursor >= len(l.matches) {
@@ -238,7 +251,7 @@ func (l linksModel) Update(msg tea.Msg) (linksModel, tea.Cmd) {
 				l.confirmDelete = true
 			}
 			return l, nil
-		case "tab":
+		case "v":
 			if l.view == linksViewInbox {
 				l.view = linksViewArchived
 			} else {
@@ -270,23 +283,17 @@ func (l linksModel) Update(msg tea.Msg) (linksModel, tea.Cmd) {
 			l.cursor = min(l.cursor+l.visibleRows(), max(len(l.matches)-1, 0))
 			l.ensureCursorVisible()
 			return l, nil
-		case "backspace":
-			if len(l.query) > 0 {
-				l.query = l.query[:len(l.query)-1]
-				l.refilter()
-			}
-			return l, nil
-		default:
-			// Single printable characters go to search
-			if len(msg.String()) == 1 && msg.String() >= " " {
-				l.query += msg.String()
-				l.refilter()
-				return l, nil
-			}
 		}
 	}
 
-	return l, nil
+	// Delegate remaining keys to text input for search.
+	prev := l.input.Value()
+	var cmd tea.Cmd
+	l.input, cmd = l.input.Update(msg)
+	if l.input.Value() != prev {
+		l.refilter()
+	}
+	return l, cmd
 }
 
 func (l linksModel) toggleArchive(entry *models.FileEntry) tea.Cmd {
@@ -344,9 +351,8 @@ func (l linksModel) View() string {
 		return b.String()
 	}
 
-	// Search query display
-	b.WriteString(pick.PromptStyle.Render("/ "))
-	b.WriteString(l.query)
+	// Search input
+	b.WriteString(l.input.View())
 	b.WriteString("\n")
 
 	// View indicator + count
@@ -405,7 +411,7 @@ func (l linksModel) View() string {
 	} else if l.statusOK != "" {
 		b.WriteString(pick.CountStyle.Render("  " + l.statusOK))
 	} else {
-		b.WriteString(pick.CountStyle.Render("  enter: view  o: open  a: archive  d: delete  tab: inbox/archived  esc: quit"))
+		b.WriteString(pick.CountStyle.Render("  enter: view  o: open  a: archive  d: delete  v: inbox/archived  esc: quit"))
 	}
 
 	return b.String()

--- a/internal/tui/browse/viewer.go
+++ b/internal/tui/browse/viewer.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
+	"github.com/raphi011/know/internal/models"
 	"github.com/raphi011/know/internal/record"
 )
 
@@ -16,20 +17,23 @@ type viewerModel struct {
 	viewport    viewport.Model
 	audioPlayer *audioPlayerModel
 	path        string
+	rawContent  string // original content for editing
 	width       int
 	height      int
 	bookmarked  bool
+	statusMsg   string
 }
 
-func newViewer(path, renderedContent string, width, height int) viewerModel {
+func newViewer(path, rawContent, renderedContent string, width, height int) viewerModel {
 	vp := viewport.New(viewport.WithWidth(width), viewport.WithHeight(max(height-2, 1)))
 	vp.SetContent(renderedContent)
 
 	return viewerModel{
-		viewport: vp,
-		path:     path,
-		width:    width,
-		height:   height,
+		viewport:   vp,
+		path:       path,
+		rawContent: rawContent,
+		width:      width,
+		height:     height,
 	}
 }
 
@@ -86,7 +90,15 @@ func (v viewerModel) View() string {
 		if v.bookmarked {
 			bookmarkHint = "b: unbookmark"
 		}
-		footer := footerBarStyle.Render(fmt.Sprintf("  %.0f%%  %s  esc: back  q: quit", pct*100, bookmarkHint))
+		editHint := "  e: edit"
+		if v.audioPlayer != nil || !models.IsTextFile(v.path) {
+			editHint = ""
+		}
+		parts := fmt.Sprintf("%.0f%%%s  %s  esc: back  q: quit", pct*100, editHint, bookmarkHint)
+		if v.statusMsg != "" {
+			parts = v.statusMsg + "  —  " + parts
+		}
+		footer := footerBarStyle.Render("  " + parts)
 		b.WriteString(footer)
 	}
 


### PR DESCRIPTION
Move document editing from the CLI `--edit` flag into the TUI viewer. Pressing `e` in the viewer opens `$EDITOR` via `tea.ExecProcess`, saves changes back to the server, and re-renders the document. Also improves tab navigation and links search UX.

## New Features
- **In-viewer editing**: press `e` to edit text documents in `$EDITOR` (with text-file guard to prevent binary corruption)
- **Tab/Shift+Tab navigation**: cycle between All Files, Links, and Bookmarks tabs
- **Links search input**: replaced manual character handling with bubbletea `textinput` component (cursor, selection, proper key handling)
- **Viewer footer**: shows contextual hints (`e: edit` only for text files) and status messages after edit operations
- **Keybind change**: links inbox/archived toggle moved from `tab` to `v` (tab now switches between browse tabs)

## Breaking Changes
- Removed `--edit`/`-e` flag from `know browse` command (editing is now inside the TUI viewer)
- Links view: `tab` no longer toggles inbox/archived — use `v` instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)