### PR TITLE
refactor: extract constants, deduplicate patterns, and flatten nesting

### DIFF
--- a/cmd/know/cmd_serve.go
+++ b/cmd/know/cmd_serve.go
@@ -188,6 +188,14 @@ func runServe(_ *cobra.Command, _ []string) error {
 		slog.Info("auth rate limiting enabled", "rps", cfg.RateLimitAuthRPS, "burst", cfg.RateLimitAuthBurst)
 	}
 
+	registerAuthRoutes := func(register func(*http.ServeMux, ...func(http.Handler) http.Handler)) {
+		if authRateLimiter != nil {
+			register(mux, authRateLimiter.Middleware(cfg.TrustXForwardedFor))
+		} else {
+			register(mux)
+		}
+	}
+
 	// OIDC auth routes (unauthenticated — must be registered before auth middleware)
 	var oidcHandler *api.AuthHandler
 	if cfg.OIDCEnabled {
@@ -209,11 +217,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 		if oidcErr != nil {
 			return fmt.Errorf("init oidc handler: %w", oidcErr)
 		}
-		if authRateLimiter != nil {
-			oidcHandler.RegisterRoutes(mux, authRateLimiter.Middleware(cfg.TrustXForwardedFor))
-		} else {
-			oidcHandler.RegisterRoutes(mux)
-		}
+		registerAuthRoutes(oidcHandler.RegisterRoutes)
 		slog.Info("OIDC authentication enabled", "provider_type", cfg.OIDCProviderType, "provider_name", oidcProvider.ProviderName())
 	}
 
@@ -221,13 +225,9 @@ func runServe(_ *cobra.Command, _ []string) error {
 	// Registered before auth middleware because OAuth endpoints are unauthenticated.
 	var resourceMetadataURL string
 	if cfg.OIDCEnabled && oidcHandler != nil {
-		oauthHandler := api.NewOAuthHandler(oidcHandler, app.DBClient(), oidcHandler.BaseURL())
+		oauthHandler := api.NewOAuthHandler(oidcHandler, app.DBClient())
 		resourceMetadataURL = oauthHandler.ResourceMetadataURL()
-		if authRateLimiter != nil {
-			oauthHandler.RegisterRoutes(mux, authRateLimiter.Middleware(cfg.TrustXForwardedFor))
-		} else {
-			oauthHandler.RegisterRoutes(mux)
-		}
+		registerAuthRoutes(oauthHandler.RegisterRoutes)
 		slog.Info("OAuth MCP auth enabled", "base_url", oidcHandler.BaseURL())
 	}
 

--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -1,0 +1,65 @@
+# Code Cleanup Backlog
+
+Remaining simplification opportunities identified by code review. Items are ordered by impact.
+
+## Medium Priority
+
+### 1. `NewAuthHandler` has 5 parameters
+**File:** `internal/api/auth.go:38`
+
+```go
+func NewAuthHandler(provider oidc.Provider, dbClient *db.Client, selfSignup bool, redirectURL string, tokenMaxLifetimeDays int) (*AuthHandler, error)
+```
+
+Consolidate into an `AuthHandlerConfig` struct. Single call site in `cmd/know/cmd_serve.go`.
+
+### 2. `file.NewService` has 7 parameters
+**File:** `internal/file/service.go:237`
+
+```go
+func NewService(db *db.Client, blobStore blob.Store, embedder *llm.Embedder, chunkConfig parser.ChunkConfig, versionConfig VersionConfig, bus *event.Bus, embedMaxInputChars int)
+```
+
+Group into a `ServiceConfig` struct. Single call site in `internal/server/bootstrap.go`.
+
+### 3. Bookmark handlers repeat auth extraction
+**File:** `internal/api/bookmarks.go`
+
+All three handlers (`listBookmarks`, `addBookmark`, `removeBookmark`) repeat:
+```go
+ac, err := auth.FromContext(ctx)
+if err != nil {
+    httputil.WriteProblem(w, http.StatusUnauthorized, "unauthorized")
+    return
+}
+userID := ac.UserID
+```
+
+Could extract to a `requireUserID(w, r) (string, bool)` helper in the api package, or use middleware.
+
+## Lower Priority
+
+### 4. `config.Load()` is ~137 lines
+**File:** `internal/config/config.go:228`
+
+Massive function reading env vars. Could split by category (DB, LLM, Auth, SSH, etc.) into private helpers like `loadDBConfig()`, `loadAuthConfig()`.
+
+### 5. Multi-vault tool error log duplication
+**File:** `internal/tools/multivault.go`
+
+Identical `logger.Warn("multi-vault tool failed", ...)` in 3 methods (`runConcat`, `runFirstHit`, `runDedupCSV`). Extract to a private `logToolError` method.
+
+### 6. Image MIME type validation inline
+**File:** `internal/agent/handler.go:88-96`
+
+Switch on `"image/png", "image/jpeg", "image/gif", "image/webp"` could use a `models.IsValidImageMIME()` helper from `internal/models/mime.go`.
+
+### 7. Deep nesting in attachment validation
+**File:** `internal/agent/handler.go:79-97`
+
+Attachment validation loop has nested if/switch. Could extract to `validateAttachment()` helper.
+
+### 8. Gemini MIME support duplication
+**Files:** `internal/llm/gemini_multimodal_embedder.go:114`, `internal/llm/gemini_text_extractor.go:96`
+
+Near-identical `SupportsMIME()` methods. Acceptable since they're in different subsystems with potentially different future needs, but could share a base set.

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -181,13 +181,13 @@ func (rn *Runner) HandleEvents() http.HandlerFunc {
 
 			switch *conv.BgStatus {
 			case "completed":
-				writeSSE(w, flusher, StreamEvent{Type: "msg_end"})
+				writeSSE(w, flusher, StreamEvent{Type: EventMsgEnd})
 			case "failed":
 				errMsg := "agent failed"
 				if conv.BgError != nil {
 					errMsg = *conv.BgError
 				}
-				writeSSE(w, flusher, StreamEvent{Type: "error", Content: errMsg})
+				writeSSE(w, flusher, StreamEvent{Type: EventError, Content: errMsg})
 			default:
 				// "running" but not in tasks map — race condition or server restart
 				httputil.WriteProblem(w, http.StatusNotFound, "task not available")

--- a/internal/agent/middleware.go
+++ b/internal/agent/middleware.go
@@ -21,6 +21,9 @@ import (
 	"github.com/raphi011/know/internal/tools"
 )
 
+// fstringEscaper escapes curly braces to prevent FString interpolation of user-controlled content.
+var fstringEscaper = strings.NewReplacer("{", "{{", "}", "}}")
+
 // --- contextInjectionMiddleware: inject doc refs + text attachments + session values ---
 
 type contextInjectionMiddleware struct {
@@ -71,28 +74,12 @@ func (m *contextInjectionMiddleware) BeforeAgent(ctx context.Context, runCtx *ad
 		}
 	}
 
-	var vaultInstructions string
-	vaultMDFile, err := m.db.GetFileByPath(ctx, m.vaultID, "/VAULT.md")
-	if err != nil {
-		logger.Warn("failed to load VAULT.md", "vault_id", m.vaultID, "error", err)
-	} else if vaultMDFile != nil {
-		content, contentErr := m.fileSvc.ReadFileContent(ctx, vaultMDFile)
-		if contentErr != nil {
-			logger.Warn("failed to read VAULT.md content", "vault_id", m.vaultID, "error", contentErr)
-		} else {
-			vaultInstructions = formatVaultInstructions(content)
-			if len(content) > maxVaultInstructionsBytes {
-				logger.Warn("VAULT.md truncated", "vault_id", m.vaultID, "size_bytes", len(content), "max_bytes", maxVaultInstructionsBytes)
-			}
-		}
-	}
-
 	vals := map[string]any{
 		"FolderTree":        folderTree,
 		"Labels":            labels,
 		"Templates":         templates,
 		"CurrentDate":       time.Now().Format("2006-01-02"),
-		"VaultInstructions": vaultInstructions,
+		"VaultInstructions": m.loadVaultInstructions(ctx),
 	}
 	adk.AddSessionValues(ctx, vals)
 
@@ -103,6 +90,29 @@ func (m *contextInjectionMiddleware) BeforeAgent(ctx context.Context, runCtx *ad
 	}
 
 	return ctx, runCtx, nil
+}
+
+// loadVaultInstructions reads /VAULT.md from the vault and returns formatted instructions
+// for the system prompt. Returns "" if the file doesn't exist or can't be read.
+func (m *contextInjectionMiddleware) loadVaultInstructions(ctx context.Context) string {
+	logger := logutil.FromCtx(ctx)
+	f, err := m.db.GetFileByPath(ctx, m.vaultID, "/VAULT.md")
+	if err != nil {
+		logger.Warn("failed to load VAULT.md", "vault_id", m.vaultID, "error", err)
+		return ""
+	}
+	if f == nil {
+		return ""
+	}
+	content, err := m.fileSvc.ReadFileContent(ctx, f)
+	if err != nil {
+		logger.Warn("failed to read VAULT.md content", "vault_id", m.vaultID, "error", err)
+		return ""
+	}
+	if len(content) > maxVaultInstructionsBytes {
+		logger.Warn("VAULT.md truncated", "vault_id", m.vaultID, "size_bytes", len(content), "max_bytes", maxVaultInstructionsBytes)
+	}
+	return formatVaultInstructions(content)
 }
 
 // formatFolderTree renders a vault's folder structure as a code block, or "" if empty.
@@ -117,8 +127,7 @@ func formatFolderTree(folders []models.File) string {
 		indent := strings.Repeat("  ", depth)
 		sb.WriteString(indent)
 		sb.WriteString("├── ")
-		// Escape curly braces to prevent FString interpolation of user-controlled folder names.
-		sb.WriteString(strings.NewReplacer("{", "{{", "}", "}}").Replace(path.Base(f.Path)))
+		sb.WriteString(fstringEscaper.Replace(path.Base(f.Path)))
 		sb.WriteString("/\n")
 	}
 	sb.WriteString("```")
@@ -133,8 +142,7 @@ func formatLabels(labelCounts []models.LabelCount) string {
 	var sb strings.Builder
 	sb.WriteString("\n\nVault labels:\n")
 	for _, lc := range labelCounts {
-		// Escape curly braces to prevent FString interpolation of user-controlled label names.
-		escaped := strings.NewReplacer("{", "{{", "}", "}}").Replace(lc.Label)
+		escaped := fstringEscaper.Replace(lc.Label)
 		fmt.Fprintf(&sb, "- %s (%d)\n", escaped, lc.Count)
 	}
 	return sb.String()
@@ -147,12 +155,11 @@ func formatTemplates(docs []models.File) string {
 	if len(docs) == 0 {
 		return ""
 	}
-	esc := strings.NewReplacer("{", "{{", "}", "}}")
 	var sb strings.Builder
 	sb.WriteString("\n\nAvailable templates (read with read_document to use):\n")
 	for _, doc := range docs {
-		escaped := esc.Replace(doc.Path)
-		title := esc.Replace(doc.Title)
+		escaped := fstringEscaper.Replace(doc.Path)
+		title := fstringEscaper.Replace(doc.Title)
 		if title != "" {
 			fmt.Fprintf(&sb, "- %s — %s\n", escaped, title)
 		} else {
@@ -179,10 +186,9 @@ func formatVaultInstructions(content string) string {
 		}
 		content = trunc + "\n\n(truncated — VAULT.md exceeds 32 KB limit)"
 	}
-	esc := strings.NewReplacer("{", "{{", "}", "}}")
 	var sb strings.Builder
 	sb.WriteString("\n\n## Vault Instructions (/VAULT.md)\nYou can update this file using edit_document when the user asks you to remember preferences or conventions.\n\n<vault-instructions>\n")
-	sb.WriteString(esc.Replace(content))
+	sb.WriteString(fstringEscaper.Replace(content))
 	sb.WriteString("\n</vault-instructions>")
 	return sb.String()
 }
@@ -201,14 +207,14 @@ func (m *contextInjectionMiddleware) BeforeModelRewriteState(ctx context.Context
 			doc, docErr := m.db.GetFileByPath(ctx, m.vaultID, ref)
 			if docErr != nil {
 				logutil.FromCtx(ctx).Warn("failed to read referenced doc", "path", ref, "error", docErr)
-				m.emit(StreamEvent{Type: "error", Content: fmt.Sprintf("could not read referenced document: %s", ref)})
+				m.emit(StreamEvent{Type: EventError, Content: fmt.Sprintf("could not read referenced document: %s", ref)})
 				continue
 			}
 			if doc != nil {
 				content, contentErr := m.fileSvc.ReadFileContent(ctx, doc)
 				if contentErr != nil {
 					logutil.FromCtx(ctx).Warn("failed to read doc content", "path", ref, "error", contentErr)
-					m.emit(StreamEvent{Type: "error", Content: fmt.Sprintf("could not read document content: %s", ref)})
+					m.emit(StreamEvent{Type: EventError, Content: fmt.Sprintf("could not read document content: %s", ref)})
 					continue
 				}
 				fmt.Fprintf(&refContext, "\n--- Document: %s ---\n%s\n", doc.Path, content)

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -124,7 +124,7 @@ func (r *Runner) runTask(bgCtx context.Context, convID, userID string, logger *s
 		logger.Warn("failed to set bg_status running", "error", err)
 	}
 
-	buf.Push(StreamEvent{Type: "conv_id", ConvID: convID})
+	buf.Push(StreamEvent{Type: EventConvID, ConvID: convID})
 
 	go func() {
 		defer close(done)
@@ -139,7 +139,7 @@ func (r *Runner) runTask(bgCtx context.Context, convID, userID string, logger *s
 
 		if taskErr != nil {
 			logger.Error("agent task error", "error", taskErr)
-			buf.Push(StreamEvent{Type: "error", Content: "Failed to process request. Please try again."})
+			buf.Push(StreamEvent{Type: EventError, Content: "Failed to process request. Please try again."})
 			if dbErr := r.db.SetConversationBgFailed(context.Background(), convID, taskErr.Error()); dbErr != nil {
 				logger.Warn("failed to set bg_status failed", "error", dbErr)
 			}

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -25,9 +25,20 @@ import (
 	"github.com/raphi011/know/internal/tools"
 )
 
+// Stream event types.
+const (
+	EventText        = "text"
+	EventToolStart   = "tool_start"
+	EventToolEnd     = "tool_end"
+	EventInterrupted = "interrupted"
+	EventMsgEnd      = "msg_end"
+	EventConvID      = "conv_id"
+	EventError       = "error"
+)
+
 // StreamEvent is sent to the client via SSE.
 type StreamEvent struct {
-	Type              string                `json:"type"` // "text" | "tool_start" | "tool_end" | "interrupted" | "msg_start" | "msg_end" | "conv_id" | "error"
+	Type              string                `json:"type"` // Event* constants
 	Content           string                `json:"content,omitempty"`
 	ConvID            string                `json:"convId,omitempty"`
 	MsgID             string                `json:"msgId,omitempty"`
@@ -168,7 +179,7 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest, emit func(StreamEve
 			return fmt.Errorf("extract conversation ID: %w", err)
 		}
 		req.ConversationID = convID
-		emit(StreamEvent{Type: "conv_id", ConvID: convID})
+		emit(StreamEvent{Type: EventConvID, ConvID: convID})
 	}
 
 	// 2. Store user message
@@ -239,7 +250,7 @@ func (s *Service) finalizeRun(ctx context.Context, convID string, model *llm.Mod
 
 	if err != nil {
 		logutil.FromCtx(ctx).Error("failed to persist agent results", "conversation_id", convID, "error", err)
-		emit(StreamEvent{Type: "error", Content: "warning: response may not be saved to conversation history"})
+		emit(StreamEvent{Type: EventError, Content: "warning: response may not be saved to conversation history"})
 	}
 
 	// If interrupted, skip msg_end — it will be emitted after resume completes
@@ -248,7 +259,7 @@ func (s *Service) finalizeRun(ctx context.Context, convID string, model *llm.Mod
 	}
 
 	emit(StreamEvent{
-		Type:              "msg_end",
+		Type:              EventMsgEnd,
 		MsgID:             assistantMsgID,
 		InputTokens:       result.TokenUsage.InputTokens,
 		OutputTokens:      result.TokenUsage.OutputTokens,
@@ -346,7 +357,7 @@ func consumeAgentEvents(ctx context.Context, iter *adk.AsyncIterator[*adk.AgentE
 		// Error event — stop processing messages but keep draining for RunCompleteEvent
 		if event.Err != nil {
 			logger.Error("agent error", "error", event.Err)
-			emit(StreamEvent{Type: "error", Content: fmt.Sprintf("generation failed: %v", event.Err)})
+			emit(StreamEvent{Type: EventError, Content: fmt.Sprintf("generation failed: %v", event.Err)})
 			hitError = true
 			continue
 		}
@@ -358,7 +369,7 @@ func consumeAgentEvents(ctx context.Context, iter *adk.AsyncIterator[*adk.AgentE
 				if ictx.IsRootCause {
 					if req, ok := ictx.Info.(*ApprovalRequest); ok {
 						emit(StreamEvent{
-							Type:        "interrupted",
+							Type:        EventInterrupted,
 							InterruptID: ictx.ID,
 							CallID:      req.CallID,
 							Tool:        req.Tool,
@@ -382,15 +393,15 @@ func consumeAgentEvents(ctx context.Context, iter *adk.AsyncIterator[*adk.AgentE
 			switch e := event.Output.CustomizedOutput.(type) {
 			case *ToolStartEvent:
 				if !hitError {
-					emit(StreamEvent{Type: "tool_start", CallID: e.CallID, Tool: e.Tool, Input: e.Input})
+					emit(StreamEvent{Type: EventToolStart, CallID: e.CallID, Tool: e.Tool, Input: e.Input})
 				}
 
 			case *ToolEndEvent:
 				if !hitError {
 					if e.Error != "" {
-						emit(StreamEvent{Type: "tool_end", CallID: e.CallID, Tool: e.Tool, Content: e.Error})
+						emit(StreamEvent{Type: EventToolEnd, CallID: e.CallID, Tool: e.Tool, Content: e.Error})
 					} else {
-						emit(StreamEvent{Type: "tool_end", CallID: e.CallID, Tool: e.Tool, Meta: e.Meta})
+						emit(StreamEvent{Type: EventToolEnd, CallID: e.CallID, Tool: e.Tool, Meta: e.Meta})
 					}
 				}
 
@@ -427,18 +438,18 @@ func consumeAgentEvents(ctx context.Context, iter *adk.AsyncIterator[*adk.AgentE
 					}
 					if recvErr != nil {
 						logger.Error("stream recv error", "error", recvErr)
-						emit(StreamEvent{Type: "error", Content: fmt.Sprintf("response was truncated: %v", recvErr)})
+						emit(StreamEvent{Type: EventError, Content: fmt.Sprintf("response was truncated: %v", recvErr)})
 						hitError = true
 						break
 					}
 					if chunk.Content != "" {
 						answer.WriteString(chunk.Content)
-						emit(StreamEvent{Type: "text", Content: chunk.Content})
+						emit(StreamEvent{Type: EventText, Content: chunk.Content})
 					}
 				}
 			} else if mv.Message != nil && mv.Message.Content != "" {
 				answer.WriteString(mv.Message.Content)
-				emit(StreamEvent{Type: "text", Content: mv.Message.Content})
+				emit(StreamEvent{Type: EventText, Content: mv.Message.Content})
 			}
 		}
 	}
@@ -547,15 +558,15 @@ func splitAttachments(attachments []models.ChatAttachment, emit func(StreamEvent
 		case models.AttachmentTypeImage:
 			imageAtts = append(imageAtts, att)
 		default:
-			emit(StreamEvent{Type: "error", Content: fmt.Sprintf("unsupported attachment type %q for %s, skipping", att.Type, att.Path)})
+			emit(StreamEvent{Type: EventError, Content: fmt.Sprintf("unsupported attachment type %q for %s, skipping", att.Type, att.Path)})
 		}
 	}
 	return imageAtts
 }
 
-// isWriteTool returns true for tools that modify documents.
+// isWriteTool returns true for tools that require write approval.
 func isWriteTool(name string) bool {
-	return name == "create_document" || name == "edit_document" || name == "edit_document_section" || name == "create_memory"
+	return tools.IsWriteTool(name)
 }
 
 // buildApprovalRequest computes the diff for a write tool call.
@@ -585,7 +596,7 @@ func (s *Service) buildApprovalRequest(ctx context.Context, vaultID string, call
 	}
 
 	// Section edits require an existing document
-	if call.Function.Name == "edit_document_section" && doc == nil {
+	if call.Function.Name == tools.ToolEditDocumentSection && doc == nil {
 		return nil, fmt.Errorf("document not found: %s", args.Path)
 	}
 
@@ -605,7 +616,7 @@ func (s *Service) buildApprovalRequest(ctx context.Context, vaultID string, call
 		}
 	}
 
-	if call.Function.Name == "edit_document_section" && doc != nil {
+	if call.Function.Name == tools.ToolEditDocumentSection && doc != nil {
 		edit := parser.BuildSectionEdit(parser.SectionEditArgs{
 			Operation:  args.Operation,
 			Heading:    args.Heading,

--- a/internal/agent/websearch_tool.go
+++ b/internal/agent/websearch_tool.go
@@ -18,7 +18,7 @@ type WebSearchTool struct {
 
 func (t *WebSearchTool) Info(_ context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
-		Name: "web_search",
+		Name: tools.ToolWebSearch,
 		Desc: "Search the web for information not found in the knowledge base. Only call this after the user explicitly asks to search the web.",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"query": {

--- a/internal/api/bookmarks.go
+++ b/internal/api/bookmarks.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 	"path"
 
@@ -58,9 +57,8 @@ func (s *Server) addBookmark(w http.ResponseWriter, r *http.Request) {
 	userID := ac.UserID
 	logger := logutil.FromCtx(ctx)
 
-	var req bookmarkRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httputil.WriteProblem(w, http.StatusBadRequest, "invalid request body")
+	req, ok := decodeBody[bookmarkRequest](w, r, 1024)
+	if !ok {
 		return
 	}
 	if req.Path == "" {
@@ -106,9 +104,8 @@ func (s *Server) removeBookmark(w http.ResponseWriter, r *http.Request) {
 	userID := ac.UserID
 	logger := logutil.FromCtx(ctx)
 
-	var req bookmarkRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httputil.WriteProblem(w, http.StatusBadRequest, "invalid request body")
+	req, ok := decodeBody[bookmarkRequest](w, r, 1024)
+	if !ok {
 		return
 	}
 	if req.Path == "" {

--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -28,11 +28,11 @@ type OAuthHandler struct {
 	baseURL string
 }
 
-func NewOAuthHandler(authHandler *AuthHandler, dbClient *db.Client, baseURL string) *OAuthHandler {
+func NewOAuthHandler(authHandler *AuthHandler, dbClient *db.Client) *OAuthHandler {
 	return &OAuthHandler{
 		auth:    authHandler,
 		db:      dbClient,
-		baseURL: strings.TrimRight(baseURL, "/"),
+		baseURL: strings.TrimRight(authHandler.BaseURL(), "/"),
 	}
 }
 

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -51,7 +51,7 @@ func (t *mcpTools) register(server *mcp.Server) {
 	}
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "search_documents",
+		Name:        tools.ToolSearchDocuments,
 		Description: "Search documents using full-text and semantic search. Returns titles, paths, scores, and matching snippets. Use list_labels first to discover labels for filtering.",
 		Annotations: readOnly,
 	}, t.searchDocuments)
@@ -63,25 +63,25 @@ func (t *mcpTools) register(server *mcp.Server) {
 	}, t.getDocument)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "list_labels",
+		Name:        tools.ToolListLabels,
 		Description: "List all labels used across documents. Useful for discovering available categories before searching.",
 		Annotations: readOnly,
 	}, t.listLabels)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "list_folders",
+		Name:        tools.ToolListFolders,
 		Description: "List the folder structure. Use to browse and understand vault organization before searching.",
 		Annotations: readOnly,
 	}, t.listFolders)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "list_folder_contents",
+		Name:        tools.ToolListFolderContents,
 		Description: "List documents and subfolders in a specific folder. Returns immediate children only. Use list_folders first to discover available folders.",
 		Annotations: readOnly,
 	}, t.listFolderContents)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "get_document_versions",
+		Name:        tools.ToolGetDocumentVersions,
 		Description: "Get version history for a document by path. Returns previous versions with timestamps, sources, and titles.",
 		Annotations: readOnly,
 	}, t.getDocumentVersions)
@@ -92,7 +92,7 @@ func (t *mcpTools) register(server *mcp.Server) {
 	}
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "create_memory",
+		Name:        tools.ToolCreateMemory,
 		Description: "Create a memory, optionally scoped to a project. Automatically labels with 'memory' (and 'project/{project}' if project is set). For project memories, use a stable identifier (git remote URL or repo folder name). For global memories (e.g. Go patterns, Docker tips), omit project and add descriptive labels for categorization. Always call list_labels first to discover existing labels and reuse them for consistency.",
 		Annotations: writeNonDestructive,
 	}, t.createMemory)
@@ -110,31 +110,31 @@ func (t *mcpTools) register(server *mcp.Server) {
 	}, t.deleteMemory)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "create_document",
+		Name:        tools.ToolCreateDocument,
 		Description: "Create a new document in the knowledge base. Content should be markdown. Fails if a document already exists at the path.",
 		Annotations: writeNonDestructive,
 	}, t.createDocument)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "edit_document",
+		Name:        tools.ToolEditDocument,
 		Description: "Edit an existing document by replacing its full content. Read the document first with get_document, then pass the complete new content. Optionally pass expected_hash (from get_document) to prevent overwriting concurrent changes.",
 		Annotations: writeIdempotent,
 	}, t.editDocument)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "edit_document_section",
+		Name:        tools.ToolEditDocumentSection,
 		Description: "Edit a specific section of a document by heading, without sending the full content. Use get_document with sections=true to see available sections. Supports replace, insert_after, insert_before, delete, and append operations. Optionally pass expected_hash to prevent overwriting concurrent changes.",
 		Annotations: writeIdempotent,
 	}, t.editDocumentSection)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "list_tasks",
+		Name:        tools.ToolListTasks,
 		Description: "List tasks (markdown checkboxes) extracted from documents. Returns tasks grouped by document with status, labels, and due dates. Use list_labels to discover available labels for filtering.",
 		Annotations: readOnly,
 	}, t.listTasks)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "toggle_task",
+		Name:        tools.ToolToggleTask,
 		Description: "Toggle a task's status between open and done. Modifies the source markdown document (changes `- [ ]` to `- [x]` or vice versa). Use list_tasks to find task IDs.",
 		Annotations: writeNonDestructive,
 	}, t.toggleTask)
@@ -157,7 +157,7 @@ func (t *mcpTools) register(server *mcp.Server) {
 		OpenWorldHint:   new(true),
 	}
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "fetch_webpage",
+		Name:        tools.ToolFetchWebpage,
 		Description: "Fetch a web page and convert it to markdown. Set save=true to persist the page to the vault's web clip folder with proper frontmatter (title, source URL, fetched_at, web-clip label). Without save, returns markdown content only.",
 		Annotations: openWorldWrite,
 	}, t.fetchWebpage)
@@ -197,7 +197,7 @@ func (t *mcpTools) searchDocuments(ctx context.Context, req *mcp.CallToolRequest
 	var sb strings.Builder
 	var failedVaults int
 	for _, ref := range refs {
-		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "search", string(argsJSON))
+		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, tools.ToolSearch, string(argsJSON))
 		if execErr != nil {
 			logutil.FromCtx(ctx).Warn("search failed", "vault", ref.VaultID, "namespace", ref.Namespace, "error", execErr)
 			failedVaults++
@@ -241,7 +241,7 @@ func (t *mcpTools) getDocument(ctx context.Context, req *mcp.CallToolRequest, in
 	}
 
 	for _, ref := range refs {
-		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "read_document", string(argsJSON))
+		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, tools.ToolReadDocument, string(argsJSON))
 		if execErr != nil {
 			if isToolLevelError(execErr) {
 				continue // not found in this vault, try next
@@ -270,7 +270,7 @@ func (t *mcpTools) listLabels(ctx context.Context, req *mcp.CallToolRequest, inp
 	for _, ref := range refs {
 		cacheKey := "list_labels:" + ref.Namespace + ":" + ref.VaultID
 		result, err := t.cache.GetOrFetch(cacheKey, func() (string, error) {
-			r, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "list_labels", "{}")
+			r, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, tools.ToolListLabels, "{}")
 			return r, execErr
 		})
 		if err != nil {
@@ -308,7 +308,7 @@ func (t *mcpTools) listFolders(ctx context.Context, req *mcp.CallToolRequest, in
 	for _, ref := range refs {
 		cacheKey := "list_folders:" + ref.Namespace + ":" + ref.VaultID
 		result, err := t.cache.GetOrFetch(cacheKey, func() (string, error) {
-			r, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "list_folders", "{}")
+			r, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, tools.ToolListFolders, "{}")
 			return r, execErr
 		})
 		if err != nil {
@@ -350,7 +350,7 @@ func (t *mcpTools) listFolderContents(ctx context.Context, req *mcp.CallToolRequ
 
 	var sb strings.Builder
 	for _, ref := range refs {
-		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "list_folder_contents", string(argsJSON))
+		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, tools.ToolListFolderContents, string(argsJSON))
 		if execErr != nil {
 			logutil.FromCtx(ctx).Warn("list folder contents failed", "vault", ref.VaultID, "namespace", ref.Namespace, "error", execErr)
 			continue
@@ -396,7 +396,7 @@ func (t *mcpTools) getDocumentVersions(ctx context.Context, req *mcp.CallToolReq
 	}
 
 	for _, ref := range refs {
-		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "get_document_versions", string(argsJSON))
+		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, tools.ToolGetDocumentVersions, string(argsJSON))
 		if execErr != nil {
 			if isToolLevelError(execErr) {
 				continue // not found in this vault, try next
@@ -457,7 +457,7 @@ func (t *mcpTools) createMemory(ctx context.Context, req *mcp.CallToolRequest, i
 	if strings.TrimSpace(input.Content) == "" {
 		return errorResult("content is required"), nil, nil
 	}
-	return t.executeWriteTool(ctx, "create_memory", input.Vault, input)
+	return t.executeWriteTool(ctx, tools.ToolCreateMemory, input.Vault, input)
 }
 
 type retrieveMemoriesInput struct {
@@ -556,7 +556,7 @@ func (t *mcpTools) createDocument(ctx context.Context, req *mcp.CallToolRequest,
 	if strings.TrimSpace(input.Content) == "" {
 		return errorResult("content is required"), nil, nil
 	}
-	return t.executeWriteTool(ctx, "create_document", input.Vault, input)
+	return t.executeWriteTool(ctx, tools.ToolCreateDocument, input.Vault, input)
 }
 
 type editDocumentInput struct {
@@ -573,7 +573,7 @@ func (t *mcpTools) editDocument(ctx context.Context, req *mcp.CallToolRequest, i
 	if strings.TrimSpace(input.Content) == "" {
 		return errorResult("content is required"), nil, nil
 	}
-	return t.executeWriteTool(ctx, "edit_document", input.Vault, input)
+	return t.executeWriteTool(ctx, tools.ToolEditDocument, input.Vault, input)
 }
 
 type editDocumentSectionInput struct {
@@ -600,7 +600,7 @@ func (t *mcpTools) editDocumentSection(ctx context.Context, req *mcp.CallToolReq
 	if !slices.Contains(validOps, op) {
 		return errorResult(fmt.Sprintf("unknown operation: %q. Valid operations: %s", op, strings.Join(validOps, ", "))), nil, nil
 	}
-	return t.executeWriteTool(ctx, "edit_document_section", input.Vault, input)
+	return t.executeWriteTool(ctx, tools.ToolEditDocumentSection, input.Vault, input)
 }
 
 // ---------- Task tool handlers ----------
@@ -630,7 +630,7 @@ func (t *mcpTools) listTasks(ctx context.Context, req *mcp.CallToolRequest, inpu
 	var sb strings.Builder
 	var failedVaults int
 	for _, ref := range refs {
-		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, "list_tasks", string(argsJSON))
+		result, _, execErr := ref.Executor.ExecuteTool(ctx, ref.VaultID, tools.ToolListTasks, string(argsJSON))
 		if execErr != nil {
 			logutil.FromCtx(ctx).Warn("list tasks failed", "vault", ref.VaultID, "namespace", ref.Namespace, "error", execErr)
 			failedVaults++
@@ -667,7 +667,7 @@ func (t *mcpTools) toggleTask(ctx context.Context, req *mcp.CallToolRequest, inp
 	if strings.TrimSpace(input.TaskID) == "" {
 		return errorResult("task_id is required"), nil, nil
 	}
-	return t.executeWriteTool(ctx, "toggle_task", input.Vault, input)
+	return t.executeWriteTool(ctx, tools.ToolToggleTask, input.Vault, input)
 }
 
 // ---------- YouTube transcript handler ----------
@@ -715,7 +715,7 @@ func (t *mcpTools) fetchWebpage(ctx context.Context, req *mcp.CallToolRequest, i
 	}
 
 	// Save mode — delegate to the Tier 1 tool via the executor.
-	return t.executeWriteTool(ctx, "fetch_webpage", "", input)
+	return t.executeWriteTool(ctx, tools.ToolFetchWebpage, "", input)
 }
 
 // ---------- helpers ----------

--- a/internal/remote/executor.go
+++ b/internal/remote/executor.go
@@ -29,27 +29,27 @@ func NewExecutor(client *apiclient.Client, remoteName string) *Executor {
 // ExecuteTool routes a tool call to the appropriate REST API method on the remote server.
 func (e *Executor) ExecuteTool(ctx context.Context, vaultID, toolName, arguments string) (string, *tools.ToolResultMeta, error) {
 	switch toolName {
-	case "search":
+	case tools.ToolSearch:
 		return e.execSearch(ctx, vaultID, arguments)
-	case "read_document":
+	case tools.ToolReadDocument:
 		return e.execReadDocument(ctx, vaultID, arguments)
-	case "list_labels":
+	case tools.ToolListLabels:
 		return e.execListLabels(ctx, vaultID)
-	case "list_folders":
+	case tools.ToolListFolders:
 		return e.execListFolders(ctx, vaultID, arguments)
-	case "list_folder_contents":
+	case tools.ToolListFolderContents:
 		return e.execListFolderContents(ctx, vaultID, arguments)
-	case "create_document":
+	case tools.ToolCreateDocument:
 		return e.execCreateDocument(ctx, vaultID, arguments)
-	case "edit_document":
+	case tools.ToolEditDocument:
 		return e.execEditDocument(ctx, vaultID, arguments)
-	case "edit_document_section":
+	case tools.ToolEditDocumentSection:
 		return "", nil, &tools.ToolError{
 			Message: "edit_document_section is not supported on remote vaults. Use get_document to read the full content, edit locally, then use edit_document to save.",
 		}
-	case "create_memory":
+	case tools.ToolCreateMemory:
 		return e.execCreateMemory(ctx, vaultID, arguments)
-	case "get_document_versions":
+	case tools.ToolGetDocumentVersions:
 		return e.execGetDocumentVersions(ctx, vaultID, arguments)
 	default:
 		return "", nil, fmt.Errorf("unknown tool: %s", toolName)

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -16,6 +16,38 @@ import (
 	"github.com/raphi011/know/internal/search"
 )
 
+// Canonical tool names. Use these constants instead of string literals.
+const (
+	ToolSearch              = "search"
+	ToolReadDocument        = "read_document"
+	ToolCreateDocument      = "create_document"
+	ToolEditDocument        = "edit_document"
+	ToolEditDocumentSection = "edit_document_section"
+	ToolCreateMemory        = "create_memory"
+	ToolListLabels          = "list_labels"
+	ToolListFolders         = "list_folders"
+	ToolListFolderContents  = "list_folder_contents"
+	ToolGetDocumentVersions = "get_document_versions"
+	ToolListTasks           = "list_tasks"
+	ToolToggleTask          = "toggle_task"
+	ToolFetchWebpage        = "fetch_webpage"
+	ToolSearchDocuments     = "search_documents"
+	ToolWebSearch           = "web_search"
+)
+
+// writeTools is the set of tools that require write approval.
+var writeTools = map[string]bool{
+	ToolCreateDocument:      true,
+	ToolEditDocument:        true,
+	ToolEditDocumentSection: true,
+	ToolCreateMemory:        true,
+}
+
+// IsWriteTool reports whether the named tool requires write approval.
+func IsWriteTool(name string) bool {
+	return writeTools[name]
+}
+
 // ToolExecutor defines the interface for executing tools against a vault.
 // Both the local Executor and the remote proxy implement this.
 type ToolExecutor interface {
@@ -42,24 +74,24 @@ type Executor struct {
 func (e *Executor) initRegistry() {
 	e.once.Do(func() {
 		e.registry = map[string]tool.InvokableTool{
-			"search":                &SearchTool{search: e.Search},
-			"read_document":         &ReadDocumentTool{db: e.DB, fileSvc: e.FileSvc, renderSvc: e.RenderSvc},
-			"list_labels":           &ListLabelsTool{db: e.DB},
-			"list_folders":          &ListFoldersTool{db: e.DB},
-			"list_folder_contents":  &ListFolderContentsTool{db: e.DB},
-			"get_document_versions": &GetDocumentVersionsTool{db: e.DB},
-			"list_tasks":            &ListTasksTool{db: e.DB},
+			ToolSearch:              &SearchTool{search: e.Search},
+			ToolReadDocument:        &ReadDocumentTool{db: e.DB, fileSvc: e.FileSvc, renderSvc: e.RenderSvc},
+			ToolListLabels:          &ListLabelsTool{db: e.DB},
+			ToolListFolders:         &ListFoldersTool{db: e.DB},
+			ToolListFolderContents:  &ListFolderContentsTool{db: e.DB},
+			ToolGetDocumentVersions: &GetDocumentVersionsTool{db: e.DB},
+			ToolListTasks:           &ListTasksTool{db: e.DB},
 		}
 
 		if e.FileSvc != nil {
-			e.registry["create_document"] = &CreateDocumentTool{db: e.DB, docService: e.FileSvc}
-			e.registry["edit_document"] = &EditDocumentTool{db: e.DB, docService: e.FileSvc}
-			e.registry["edit_document_section"] = &EditDocumentSectionTool{db: e.DB, docService: e.FileSvc}
-			e.registry["create_memory"] = &CreateMemoryTool{db: e.DB, docService: e.FileSvc}
-			e.registry["toggle_task"] = &ToggleTaskTool{docService: e.FileSvc}
+			e.registry[ToolCreateDocument] = &CreateDocumentTool{db: e.DB, docService: e.FileSvc}
+			e.registry[ToolEditDocument] = &EditDocumentTool{db: e.DB, docService: e.FileSvc}
+			e.registry[ToolEditDocumentSection] = &EditDocumentSectionTool{db: e.DB, docService: e.FileSvc}
+			e.registry[ToolCreateMemory] = &CreateMemoryTool{db: e.DB, docService: e.FileSvc}
+			e.registry[ToolToggleTask] = &ToggleTaskTool{docService: e.FileSvc}
 		}
 
-		e.registry["fetch_webpage"] = &FetchWebpageTool{jina: e.Jina, db: e.DB, fileSvc: e.FileSvc, model: e.Model}
+		e.registry[ToolFetchWebpage] = &FetchWebpageTool{jina: e.Jina, db: e.DB, fileSvc: e.FileSvc, model: e.Model}
 	})
 }
 

--- a/internal/tools/multivault.go
+++ b/internal/tools/multivault.go
@@ -193,7 +193,7 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 	}{
 		{
 			info: &schema.ToolInfo{
-				Name: "search",
+				Name: ToolSearch,
 				Desc: "Search documents using full-text and semantic search. Returns titles, paths, scores, and matching snippets. Use list_labels first to discover labels for filtering.",
 				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 					"query":    {Type: schema.String, Desc: "Search query text", Required: true},
@@ -207,7 +207,7 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 		},
 		{
 			info: &schema.ToolInfo{
-				Name: "read_document",
+				Name: ToolReadDocument,
 				Desc: "Read the full content of a specific document by its path. Set sections=true to include a section outline for use with edit_document_section.",
 				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 					"path":     {Type: schema.String, Desc: "The document path (e.g. /folder/document-name)", Required: true},
@@ -218,7 +218,7 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 		},
 		{
 			info: &schema.ToolInfo{
-				Name:        "list_labels",
+				Name:        ToolListLabels,
 				Desc:        "List all labels/categories used across documents in all vaults",
 				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{}),
 			},
@@ -226,7 +226,7 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 		},
 		{
 			info: &schema.ToolInfo{
-				Name: "list_folders",
+				Name: ToolListFolders,
 				Desc: "List the folder structure across all vaults",
 				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 					"parent": {Type: schema.String, Desc: "Parent folder path to list children of (e.g. /guides/). Lists all folders if omitted."},
@@ -236,7 +236,7 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 		},
 		{
 			info: &schema.ToolInfo{
-				Name: "list_folder_contents",
+				Name: ToolListFolderContents,
 				Desc: "List documents and subfolders in a specific folder. Returns immediate children only.",
 				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 					"folder": {Type: schema.String, Desc: "Folder path (e.g. /guides/)", Required: true},
@@ -246,7 +246,7 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 		},
 		{
 			info: &schema.ToolInfo{
-				Name: "get_document_versions",
+				Name: ToolGetDocumentVersions,
 				Desc: "Get version history for a document by path. Returns previous versions with timestamps, sources, and titles.",
 				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 					"path":  {Type: schema.String, Desc: "Document path", Required: true},
@@ -257,7 +257,7 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 		},
 		{
 			info: &schema.ToolInfo{
-				Name: "list_tasks",
+				Name: ToolListTasks,
 				Desc: "List tasks (markdown checkboxes) extracted from documents. Returns tasks grouped by document with status, labels, and due dates.",
 				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 					"status":     {Type: schema.String, Desc: "Filter by status: 'open' or 'done'"},
@@ -276,7 +276,7 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 
 	writeTools := []*schema.ToolInfo{
 		{
-			Name: "create_document",
+			Name: ToolCreateDocument,
 			Desc: "Create a new document in the knowledge base. The content should be markdown. Fails if a document already exists at the given path.",
 			ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 				"path":    {Type: schema.String, Desc: "Document path (e.g. /guides/new-guide.md)", Required: true},
@@ -285,7 +285,7 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 			}),
 		},
 		{
-			Name: "edit_document",
+			Name: ToolEditDocument,
 			Desc: "Edit an existing document by replacing its full content. Read the document first to get the current content, then modify and pass the complete new content.",
 			ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 				"path":          {Type: schema.String, Desc: "Document path of the existing document", Required: true},
@@ -295,7 +295,7 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 			}),
 		},
 		{
-			Name: "edit_document_section",
+			Name: ToolEditDocumentSection,
 			Desc: "Edit a specific section of a document by heading, without sending the full content. Use get_document with sections=true to see available sections. Supports replace, insert_after, insert_before, delete, and append operations.",
 			ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 				"path":          {Type: schema.String, Desc: "Document path", Required: true},
@@ -310,7 +310,7 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 			}),
 		},
 		{
-			Name: "create_memory",
+			Name: ToolCreateMemory,
 			Desc: "Create a memory, optionally scoped to a project. For project memories, use a stable identifier (git remote URL or repo folder name). For global memories, omit project and add descriptive labels. Call list_labels first to reuse existing labels.",
 			ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 				"title":   {Type: schema.String, Desc: "Memory title (used for filename)", Required: true},
@@ -321,7 +321,7 @@ func NewMultiVaultTools(resolver VaultResolver, writeResolver WriteVaultResolver
 			}),
 		},
 		{
-			Name: "toggle_task",
+			Name: ToolToggleTask,
 			Desc: "Toggle a task's status between open and done. Modifies the source markdown document. Use list_tasks to find task IDs.",
 			ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 				"task_id": {Type: schema.String, Desc: "The task ID to toggle (from list_tasks output)", Required: true},

--- a/internal/tools/tool_create_document.go
+++ b/internal/tools/tool_create_document.go
@@ -20,7 +20,7 @@ type CreateDocumentTool struct {
 
 func (t *CreateDocumentTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
-		Name: "create_document",
+		Name: ToolCreateDocument,
 		Desc: "Create a new document in the knowledge base. The content should be markdown. Fails if a document already exists at the given path.",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"path": {
@@ -43,7 +43,7 @@ func (t *CreateDocumentTool) InvokableRun(ctx context.Context, argumentsInJSON s
 	args, err := parseInput[struct {
 		Path    string `json:"path"`
 		Content string `json:"content"`
-	}](argumentsInJSON, "create_document")
+	}](argumentsInJSON, ToolCreateDocument)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/tool_create_memory.go
+++ b/internal/tools/tool_create_memory.go
@@ -22,7 +22,7 @@ type CreateMemoryTool struct {
 
 func (t *CreateMemoryTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
-		Name: "create_memory",
+		Name: ToolCreateMemory,
 		Desc: "Create a memory, optionally scoped to a project. For project memories, use a stable identifier (git remote URL or repo folder name). For global memories (e.g. Go patterns, Docker tips), omit project and add descriptive labels. Call list_labels first to reuse existing labels.",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"title": {
@@ -58,7 +58,7 @@ func (t *CreateMemoryTool) InvokableRun(ctx context.Context, argumentsInJSON str
 		Content string   `json:"content"`
 		Project string   `json:"project"`
 		Labels  []string `json:"labels"`
-	}](argumentsInJSON, "create_memory")
+	}](argumentsInJSON, ToolCreateMemory)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/tool_edit_document.go
+++ b/internal/tools/tool_edit_document.go
@@ -20,7 +20,7 @@ type EditDocumentTool struct {
 
 func (t *EditDocumentTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
-		Name: "edit_document",
+		Name: ToolEditDocument,
 		Desc: "Edit an existing document by replacing its full content. Read the document first to get the current content, then modify and pass the complete new content.",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"path": {
@@ -48,7 +48,7 @@ func (t *EditDocumentTool) InvokableRun(ctx context.Context, argumentsInJSON str
 		Path         string  `json:"path"`
 		Content      string  `json:"content"`
 		ExpectedHash *string `json:"expected_hash"`
-	}](argumentsInJSON, "edit_document")
+	}](argumentsInJSON, ToolEditDocument)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/tool_edit_document_section.go
+++ b/internal/tools/tool_edit_document_section.go
@@ -21,7 +21,7 @@ type EditDocumentSectionTool struct {
 
 func (t *EditDocumentSectionTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
-		Name: "edit_document_section",
+		Name: ToolEditDocumentSection,
 		Desc: "Edit a specific section of a document by heading, without sending the full content. Use get_document with sections=true first to see the section outline. Operations: replace (update existing section content), insert_after/insert_before (add new section relative to target, requires new_heading), delete (remove a section), append (add new section at end, requires new_heading).",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"path": {
@@ -74,7 +74,7 @@ func (t *EditDocumentSectionTool) InvokableRun(ctx context.Context, argumentsInJ
 		NewHeading   *string `json:"new_heading"`
 		NewLevel     *int    `json:"new_level"`
 		ExpectedHash *string `json:"expected_hash"`
-	}](argumentsInJSON, "edit_document_section")
+	}](argumentsInJSON, ToolEditDocumentSection)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/tool_fetch_webpage.go
+++ b/internal/tools/tool_fetch_webpage.go
@@ -25,7 +25,7 @@ type FetchWebpageTool struct {
 
 func (t *FetchWebpageTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
-		Name: "fetch_webpage",
+		Name: ToolFetchWebpage,
 		Desc: "Fetch a web page and convert it to markdown. Set save=true to persist the page to the vault's web clip folder with proper frontmatter. Without save, returns the markdown content only.",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"url": {
@@ -57,7 +57,7 @@ func (t *FetchWebpageTool) InvokableRun(ctx context.Context, argumentsInJSON str
 		Save  bool    `json:"save"`
 		Path  *string `json:"path"`
 		Clean bool    `json:"clean"`
-	}](argumentsInJSON, "fetch_webpage")
+	}](argumentsInJSON, ToolFetchWebpage)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/tool_get_document_versions.go
+++ b/internal/tools/tool_get_document_versions.go
@@ -19,7 +19,7 @@ type GetDocumentVersionsTool struct {
 
 func (t *GetDocumentVersionsTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
-		Name: "get_document_versions",
+		Name: ToolGetDocumentVersions,
 		Desc: "Get version history for a document by path. Returns previous versions with timestamps, sources, and titles.",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"path": {
@@ -41,7 +41,7 @@ func (t *GetDocumentVersionsTool) InvokableRun(ctx context.Context, argumentsInJ
 	input, err := parseInput[struct {
 		Path  string `json:"path"`
 		Limit *int   `json:"limit"`
-	}](argumentsInJSON, "get_document_versions")
+	}](argumentsInJSON, ToolGetDocumentVersions)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/tool_list_folder_contents.go
+++ b/internal/tools/tool_list_folder_contents.go
@@ -20,7 +20,7 @@ type ListFolderContentsTool struct {
 
 func (t *ListFolderContentsTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
-		Name: "list_folder_contents",
+		Name: ToolListFolderContents,
 		Desc: "List documents and subfolders in a specific folder. Returns immediate children only.",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"folder": {
@@ -37,7 +37,7 @@ func (t *ListFolderContentsTool) InvokableRun(ctx context.Context, argumentsInJS
 
 	input, err := parseInput[struct {
 		Folder string `json:"folder"`
-	}](argumentsInJSON, "list_folder_contents")
+	}](argumentsInJSON, ToolListFolderContents)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/tool_list_folders.go
+++ b/internal/tools/tool_list_folders.go
@@ -21,7 +21,7 @@ type ListFoldersTool struct {
 
 func (t *ListFoldersTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
-		Name: "list_folders",
+		Name: ToolListFolders,
 		Desc: "List the folder structure of the knowledge base. Optionally filter to immediate children of a parent folder.",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"parent": {
@@ -37,7 +37,7 @@ func (t *ListFoldersTool) InvokableRun(ctx context.Context, argumentsInJSON stri
 
 	input, err := parseInput[struct {
 		Parent *string `json:"parent"`
-	}](argumentsInJSON, "list_folders")
+	}](argumentsInJSON, ToolListFolders)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/tool_list_labels.go
+++ b/internal/tools/tool_list_labels.go
@@ -18,7 +18,7 @@ type ListLabelsTool struct {
 
 func (t *ListLabelsTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
-		Name:        "list_labels",
+		Name:        ToolListLabels,
 		Desc:        "List all labels/categories used across documents in the knowledge base",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{}),
 	}, nil

--- a/internal/tools/tool_list_tasks.go
+++ b/internal/tools/tool_list_tasks.go
@@ -19,7 +19,7 @@ type ListTasksTool struct {
 
 func (t *ListTasksTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
-		Name: "list_tasks",
+		Name: ToolListTasks,
 		Desc: "List tasks (markdown checkboxes) extracted from documents. Returns tasks grouped by document with status, labels, and due dates. Use list_labels to discover available labels for filtering.",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"status": {
@@ -71,7 +71,7 @@ func (t *ListTasksTool) InvokableRun(ctx context.Context, argumentsInJSON string
 		Path      *string  `json:"path"`
 		Limit     *int     `json:"limit"`
 		Offset    *int     `json:"offset"`
-	}](argumentsInJSON, "list_tasks")
+	}](argumentsInJSON, ToolListTasks)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/tool_read_document.go
+++ b/internal/tools/tool_read_document.go
@@ -24,7 +24,7 @@ type ReadDocumentTool struct {
 
 func (t *ReadDocumentTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
-		Name: "read_document",
+		Name: ToolReadDocument,
 		Desc: "Read the full content of a specific document by its path. Set sections=true to include a section outline for use with edit_document_section.",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"path": {
@@ -46,7 +46,7 @@ func (t *ReadDocumentTool) InvokableRun(ctx context.Context, argumentsInJSON str
 	input, err := parseInput[struct {
 		Path     string `json:"path"`
 		Sections bool   `json:"sections"`
-	}](argumentsInJSON, "read_document")
+	}](argumentsInJSON, ToolReadDocument)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/tool_search.go
+++ b/internal/tools/tool_search.go
@@ -18,7 +18,7 @@ type SearchTool struct {
 
 func (t *SearchTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
-		Name: "search",
+		Name: ToolSearch,
 		Desc: "Search documents using full-text and semantic search. Returns titles, paths, scores, and matching snippets.",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"query": {Type: schema.String, Desc: "Search query text", Required: true},
@@ -31,7 +31,7 @@ func (t *SearchTool) InvokableRun(ctx context.Context, argumentsInJSON string, o
 
 	input, err := parseInput[struct {
 		Query string `json:"query"`
-	}](argumentsInJSON, "search")
+	}](argumentsInJSON, ToolSearch)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/tool_toggle_task.go
+++ b/internal/tools/tool_toggle_task.go
@@ -18,7 +18,7 @@ type ToggleTaskTool struct {
 
 func (t *ToggleTaskTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	return &schema.ToolInfo{
-		Name: "toggle_task",
+		Name: ToolToggleTask,
 		Desc: "Toggle a task's status between open and done. This modifies the source markdown document (changes `- [ ]` to `- [x]` or vice versa). Use list_tasks to find task IDs.",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"task_id": {
@@ -33,7 +33,7 @@ func (t *ToggleTaskTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
 func (t *ToggleTaskTool) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
 	input, err := parseInput[struct {
 		TaskID string `json:"task_id"`
-	}](argumentsInJSON, "toggle_task")
+	}](argumentsInJSON, ToolToggleTask)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -13,6 +13,7 @@ import (
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/glamour"
+	"github.com/raphi011/know/internal/agent"
 	"github.com/raphi011/know/internal/api"
 	"github.com/raphi011/know/internal/models"
 	"github.com/raphi011/know/internal/tools"
@@ -425,7 +426,7 @@ func (m *Model) sendMessage() tea.Cmd {
 	startStreamCmd := func() tea.Msg {
 		ch, err := client.Chat(ctx, convID, vaultID, content, attachments, false)
 		if err != nil {
-			return streamEventMsg{event: StreamEvent{Type: "error", Content: err.Error()}, done: true}
+			return streamEventMsg{event: StreamEvent{Type: agent.EventError, Content: err.Error()}, done: true}
 		}
 
 		event, ok := <-ch
@@ -561,7 +562,7 @@ func (m *Model) resubscribeAfterApproval() tea.Cmd {
 	return func() tea.Msg {
 		ch, err := client.SubscribeEvents(ctx, convID)
 		if err != nil {
-			return streamEventMsg{event: StreamEvent{Type: "error", Content: fmt.Sprintf("resubscribe failed: %v", err)}, done: true}
+			return streamEventMsg{event: StreamEvent{Type: agent.EventError, Content: fmt.Sprintf("resubscribe failed: %v", err)}, done: true}
 		}
 
 		event, ok := <-ch
@@ -575,7 +576,7 @@ func (m *Model) resubscribeAfterApproval() tea.Cmd {
 func (m Model) handleStreamEvent(msg streamEventMsg) (tea.Model, tea.Cmd) {
 	// Handle error events before checking done — when Chat() fails,
 	// the message has both an error and done=true.
-	if msg.event.Type == "error" {
+	if msg.event.Type == agent.EventError {
 		slog.Warn("stream error", "conversationID", m.conversationID, "error", msg.event.Content)
 	}
 
@@ -591,9 +592,9 @@ func (m Model) handleStreamEvent(msg streamEventMsg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg.event.Type {
-	case "text":
+	case agent.EventText:
 		m.appendText(msg.event.Content)
-	case "tool_start":
+	case agent.EventToolStart:
 		// Reuse existing part if this tool was already started before approval.
 		if existing := m.findToolPart(msg.event.CallID); existing != nil {
 			existing.Status = ToolRunning
@@ -607,9 +608,9 @@ func (m Model) handleStreamEvent(msg streamEventMsg) (tea.Model, tea.Cmd) {
 				Status:   ToolRunning,
 			})
 		}
-	case "tool_end":
+	case agent.EventToolEnd:
 		m.updateToolStatus(msg.event.CallID, msg.event.Tool, ToolComplete, msg.event.Meta)
-	case "interrupted":
+	case agent.EventInterrupted:
 		pa := pendingApproval{event: msg.event}
 		if m.dialog == nil {
 			dialogHeight := max(m.height/2, 10)
@@ -622,16 +623,16 @@ func (m Model) handleStreamEvent(msg streamEventMsg) (tea.Model, tea.Cmd) {
 		} else {
 			m.dialog.approvals = append(m.dialog.approvals, pa)
 		}
-	case "conv_id":
+	case agent.EventConvID:
 		m.conversationID = msg.event.ConvID
-	case "error":
+	case agent.EventError:
 		m.streamParts = append(m.streamParts, ContentPart{
 			Type:    PartError,
 			Content: msg.event.Content,
 		})
 		cmd := m.finalizeStream()
 		return m, tea.Batch(cmd, nextCmd)
-	case "msg_end":
+	case agent.EventMsgEnd:
 		m.tokenInput += msg.event.InputTokens
 		m.tokenOutput += msg.event.OutputTokens
 		m.contextWindowMax = msg.event.ContextWindowMax

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -44,7 +44,7 @@ func (c *Client) CreateConversation(ctx context.Context, vaultName string) (*api
 // Only fields used by the TUI are included; unknown JSON fields are ignored.
 // Keep in sync with the canonical type when adding new fields.
 type StreamEvent struct {
-	Type              string                `json:"type"` // "text" | "tool_start" | "tool_end" | "interrupted" | "msg_end" | "conv_id" | "error"
+	Type              string                `json:"type"` // agent.Event* constants
 	Content           string                `json:"content,omitempty"`
 	ConvID            string                `json:"convId,omitempty"`
 	Tool              string                `json:"tool,omitempty"`

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -92,16 +92,16 @@ func toolKeyArg(toolName string, input map[string]any) string {
 	// Map tool names to their key argument field.
 	var field string
 	switch toolName {
-	case "read_document", "create_document", "edit_document",
-		"edit_document_section", "get_document_versions":
+	case tools.ToolReadDocument, tools.ToolCreateDocument, tools.ToolEditDocument,
+		tools.ToolEditDocumentSection, tools.ToolGetDocumentVersions:
 		field = "path"
-	case "search_documents", "web_search":
+	case tools.ToolSearchDocuments, tools.ToolWebSearch:
 		field = "query"
-	case "list_folder_contents":
+	case tools.ToolListFolderContents:
 		field = "folder"
-	case "list_folders":
+	case tools.ToolListFolders:
 		field = "parent"
-	case "create_memory":
+	case tools.ToolCreateMemory:
 		field = "title"
 	}
 	if field != "" {
@@ -120,11 +120,11 @@ func toolDetail(toolName string, meta *tools.ToolResultMeta) string {
 		return ""
 	}
 	switch toolName {
-	case "read_document":
+	case tools.ToolReadDocument:
 		if meta.ContentLength != nil {
 			return fmt.Sprintf("%d chars", *meta.ContentLength)
 		}
-	case "search_documents":
+	case tools.ToolSearchDocuments:
 		var parts []string
 		if meta.ResultCount != nil {
 			parts = append(parts, fmt.Sprintf("%d docs", *meta.ResultCount))
@@ -135,15 +135,15 @@ func toolDetail(toolName string, meta *tools.ToolResultMeta) string {
 		if len(parts) > 0 {
 			return strings.Join(parts, ", ")
 		}
-	case "list_folder_contents", "list_folders", "list_labels":
+	case tools.ToolListFolderContents, tools.ToolListFolders, tools.ToolListLabels:
 		if meta.ResultCount != nil {
 			return fmt.Sprintf("%d results", *meta.ResultCount)
 		}
-	case "get_document_versions":
+	case tools.ToolGetDocumentVersions:
 		if meta.ResultCount != nil {
 			return fmt.Sprintf("%d versions", *meta.ResultCount)
 		}
-	case "web_search":
+	case tools.ToolWebSearch:
 		if meta.WebResultCount != nil {
 			return fmt.Sprintf("%d results", *meta.WebResultCount)
 		}


### PR DESCRIPTION
Code cleanup pass: extract shared constants, deduplicate repeated patterns, and flatten nested control flow across 25 files.

## New Features

- `tools.Tool*` constants — canonical tool name constants in `internal/tools/executor.go`, used across 6 packages (tools, mcptools, remote, agent, tui)
- `agent.Event*` constants — stream event type constants replacing 15+ string literals
- `tools.WriteTools` map — replaces `isWriteTool()` string comparison chain
- `docs/cleanup.md` — documents 8 remaining simplification opportunities for future work

## Changes

| Fix | Scope |
|-----|-------|
| `fstringEscaper` package-level var | 4 inline `NewReplacer` → 1 shared |
| Remove redundant `baseURL` param from `NewOAuthHandler` | Derived from `AuthHandler.BaseURL()` |
| `registerAuthRoutes` closure | Deduplicated rate-limit conditional in cmd_serve.go |
| `loadVaultInstructions` method | Flattened 3-level nesting → early returns |
| `Event*` stream event constants | 15+ string literals → compile-time constants |
| `decodeBody` in bookmark handlers | Raw `json.NewDecoder` → shared helper (gains MaxBytesReader) |
| `Tool*` name constants + `WriteTools` map | ~60 string literals → constants across 6 packages |

## Breaking Changes
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)