### PR TITLE
feat: browse search tab and markdown parser fix for list content

### DIFF
--- a/helm/know/Chart.yaml
+++ b/helm/know/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: know
 description: Know - Personal Knowledge RAG Database with REST API and WebDAV
 type: application
-version: 0.10.4
-appVersion: "0.14.0"
+version: 0.10.5
+appVersion: "0.15.0"
 keywords:
   - know
   - knowledge-graph

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -2056,6 +2056,12 @@ paths:
           schema:
             type: string
           description: Comma-separated label filter
+        - name: bm25_only
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: When true, use BM25 keyword search only (skip vector search)
       responses:
         "200":
           description: Search results

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -32,14 +32,17 @@ func (s *Server) searchDocuments(w http.ResponseWriter, r *http.Request) {
 		labels = strings.Split(l, ",")
 	}
 
+	bm25Only := r.URL.Query().Get("bm25_only") == "true"
+
 	ctx := r.Context()
 	logger := logutil.FromCtx(ctx)
 
 	results, err := s.app.SearchService().Search(ctx, search.SearchInput{
-		VaultID: vaultID,
-		Query:   query,
-		Labels:  labels,
-		Limit:   limit,
+		VaultID:  vaultID,
+		Query:    query,
+		Labels:   labels,
+		Limit:    limit,
+		BM25Only: bm25Only,
 	})
 	if err != nil {
 		httputil.WriteProblem(w, http.StatusInternalServerError, "search failed")

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -518,10 +518,14 @@ type ChunkMatch struct {
 }
 
 // SearchDocuments searches documents on the remote server.
-func (c *Client) SearchDocuments(ctx context.Context, vaultName, query string, limit int) ([]SearchResult, error) {
+// When bm25Only is true, only BM25 keyword search is used (no vector search).
+func (c *Client) SearchDocuments(ctx context.Context, vaultName, query string, limit int, bm25Only bool) ([]SearchResult, error) {
 	q := url.Values{"query": {query}}
 	if limit > 0 {
 		q.Set("limit", fmt.Sprintf("%d", limit))
+	}
+	if bm25Only {
+		q.Set("bm25_only", "true")
 	}
 	var resp httputil.ListResponse[SearchResult]
 	if err := c.Get(ctx, vaultPath(vaultName, "/search")+"?"+q.Encode(), &resp); err != nil {

--- a/internal/parser/markdown.go
+++ b/internal/parser/markdown.go
@@ -655,14 +655,35 @@ func codeBlockContent(source []byte, n *ast.CodeBlock) string {
 	return strings.TrimRight(sb.String(), "\n")
 }
 
-// blockLines extracts all text lines from a generic block node.
+// blockLines extracts all text lines from a block node.
+// For leaf blocks (Paragraph, etc.) it reads .Lines() directly.
+// For container blocks (List, Blockquote, etc.) whose .Lines() is empty,
+// it walks all descendant leaf nodes and collects their lines.
 func blockLines(source []byte, node ast.Node) string {
-	var sb strings.Builder
 	lines := node.Lines()
-	for i := range lines.Len() {
-		line := lines.At(i)
-		sb.Write(line.Value(source))
+	if lines.Len() > 0 {
+		var sb strings.Builder
+		for i := range lines.Len() {
+			line := lines.At(i)
+			sb.Write(line.Value(source))
+		}
+		return strings.TrimRight(sb.String(), "\n")
 	}
+
+	// Container node: collect lines from all descendant block leaves.
+	// Inline nodes (Text, CodeSpan, etc.) panic on .Lines(), so skip them.
+	var sb strings.Builder
+	_ = ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) { //nolint:errcheck // walker never returns an error
+		if !entering || n.Type() == ast.TypeInline {
+			return ast.WalkContinue, nil
+		}
+		childLines := n.Lines()
+		for i := range childLines.Len() {
+			line := childLines.At(i)
+			sb.Write(line.Value(source))
+		}
+		return ast.WalkContinue, nil
+	})
 	return strings.TrimRight(sb.String(), "\n")
 }
 

--- a/internal/parser/markdown_test.go
+++ b/internal/parser/markdown_test.go
@@ -701,3 +701,127 @@ func TestParseMarkdown_ExternalLinks_Empty(t *testing.T) {
 		t.Errorf("expected nil external links, got %v", doc.ExternalLinks)
 	}
 }
+
+func TestParseMarkdown_ListContentInSections(t *testing.T) {
+	content := `# Title
+
+## Section One
+
+- First item
+- Second item
+- Third item
+
+## Section Two
+
+Some paragraph text.
+
+- Item A
+- Item B
+`
+
+	doc := ParseMarkdown(content)
+
+	// Find sections by path instead of brittle indices.
+	findSection := func(substr string) *Section {
+		for i := range doc.Sections {
+			if strings.Contains(doc.Sections[i].Path, substr) {
+				return &doc.Sections[i]
+			}
+		}
+		return nil
+	}
+
+	// Section with only list items must have non-empty content.
+	sec1 := findSection("Section One")
+	if sec1 == nil {
+		t.Fatal("Section One not found")
+	}
+	if sec1.Content == "" {
+		t.Error("section with list items has empty Content")
+	}
+	if !strings.Contains(sec1.Content, "First item") {
+		t.Errorf("section content missing list item, got %q", sec1.Content)
+	}
+	if !strings.Contains(sec1.Content, "Third item") {
+		t.Errorf("section content missing last list item, got %q", sec1.Content)
+	}
+
+	// Section with paragraph + list must include both.
+	sec2 := findSection("Section Two")
+	if sec2 == nil {
+		t.Fatal("Section Two not found")
+	}
+	if !strings.Contains(sec2.Content, "paragraph text") {
+		t.Errorf("section content missing paragraph, got %q", sec2.Content)
+	}
+	if !strings.Contains(sec2.Content, "Item A") {
+		t.Errorf("section content missing list item, got %q", sec2.Content)
+	}
+}
+
+func TestParseMarkdown_NestedListContentInSections(t *testing.T) {
+	content := `## Config
+
+- Option A
+  - Sub-option 1
+  - Sub-option 2
+- Option B
+`
+
+	doc := ParseMarkdown(content)
+
+	// Find the Config section.
+	var configSection *Section
+	for i := range doc.Sections {
+		if strings.Contains(doc.Sections[i].Path, "Config") {
+			configSection = &doc.Sections[i]
+			break
+		}
+	}
+	if configSection == nil {
+		t.Fatal("Config section not found")
+	}
+	if configSection.Content == "" {
+		t.Fatal("Config section has empty Content")
+	}
+	if !strings.Contains(configSection.Content, "Option A") {
+		t.Errorf("missing top-level list item, got %q", configSection.Content)
+	}
+	if !strings.Contains(configSection.Content, "Sub-option 1") {
+		t.Errorf("missing nested list item, got %q", configSection.Content)
+	}
+}
+
+func TestParseMarkdown_BlockquoteContentInSections(t *testing.T) {
+	content := `## Quote Section
+
+> Some quoted text
+> spanning multiple lines
+
+## After Quote
+
+Regular paragraph.
+`
+
+	doc := ParseMarkdown(content)
+
+	var quoteSection *Section
+	for i := range doc.Sections {
+		if strings.Contains(doc.Sections[i].Path, "Quote Section") {
+			quoteSection = &doc.Sections[i]
+			break
+		}
+	}
+	if quoteSection == nil {
+		t.Fatal("Quote Section not found")
+	}
+	if quoteSection.Content == "" {
+		t.Fatal("blockquote section has empty Content")
+	}
+	if !strings.Contains(quoteSection.Content, "Some quoted text") {
+		t.Errorf("missing blockquote text, got %q", quoteSection.Content)
+	}
+	if !strings.Contains(quoteSection.Content, "spanning multiple lines") {
+		t.Errorf("missing second blockquote line, got %q", quoteSection.Content)
+	}
+}

--- a/internal/remote/executor.go
+++ b/internal/remote/executor.go
@@ -65,7 +65,7 @@ func (e *Executor) execSearch(ctx context.Context, vaultID, arguments string) (s
 	}
 
 	start := time.Now()
-	results, err := e.client.SearchDocuments(ctx, vaultID, input.Query, 20)
+	results, err := e.client.SearchDocuments(ctx, vaultID, input.Query, 20, false)
 	durationMs := time.Since(start).Milliseconds()
 	if err != nil {
 		return "", nil, fmt.Errorf("remote search: %w", err)

--- a/internal/tui/browse/browser.go
+++ b/internal/tui/browse/browser.go
@@ -36,10 +36,11 @@ type audioReadyMsg struct {
 	err        error
 }
 
-// Model is the root browser model composing a finder, links list, bookmarks, and viewer.
+// Model is the root browser model composing a search, finder, links list, bookmarks, and viewer.
 type Model struct {
 	state     viewState
 	activeTab Tab
+	search    searchModel
 	finder    finderModel
 	links     linksModel
 	bookmarks bookmarksModel
@@ -75,13 +76,14 @@ func initGlamour(isDark bool) (string, *glamour.TermRenderer) {
 // startTab selects which tab to show initially.
 func NewModel(client *apiclient.Client, vaultID string, files []models.FileEntry, isDark bool, startTab ...Tab) Model {
 	glamourStyle, r := initGlamour(isDark)
-	initial := TabAllFiles
+	initial := TabSearch
 	if len(startTab) > 0 {
 		initial = startTab[0]
 	}
 	return Model{
 		state:        stateFinding,
 		activeTab:    initial,
+		search:       newSearchModel(client, vaultID),
 		finder:       newFinder(files),
 		links:        newLinksModel(client, vaultID),
 		bookmarks:    newBookmarksModel(client, vaultID),
@@ -121,9 +123,14 @@ func renderContent(r *glamour.TermRenderer, doc *apiclient.Document) string {
 }
 
 func (m Model) Init() tea.Cmd {
+	if m.noFinder {
+		return nil
+	}
 	cmds := []tea.Cmd{m.links.loadLinks(), m.bookmarks.loadBookmarks()}
 	// Focus the input for the initial tab.
 	switch m.activeTab {
+	case TabSearch:
+		cmds = append(cmds, m.search.input.Focus())
 	case TabAllFiles:
 		cmds = append(cmds, m.finder.Init())
 	case TabLinks:
@@ -138,6 +145,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		contentHeight := msg.Height - 1 // reserve 1 line for tab bar
+		m.search.width = msg.Width
+		m.search.height = contentHeight
+		m.search.input.SetWidth(msg.Width - len(m.search.input.Prompt))
 		m.finder.picker.SetSize(msg.Width, contentHeight)
 		m.links.width = msg.Width
 		m.links.height = contentHeight
@@ -163,21 +173,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 
-		// Tab switching with 1/2/3 or Tab key (only in finding state, and only when
+		// Tab switching with Tab/Shift+Tab (only in finding state, and only when
 		// the links model isn't in a confirmation mode)
 		if m.state == stateFinding && !m.links.confirmDelete {
 			var newTab Tab = -1
 			switch msg.String() {
 			case "tab":
-				newTab = (m.activeTab + 1) % 3
+				newTab = (m.activeTab + 1) % tabCount
 			case "shift+tab":
-				newTab = (m.activeTab + 2) % 3
-			case "1":
-				newTab = TabAllFiles
-			case "2":
-				newTab = TabLinks
-			case "3":
-				newTab = TabBookmarks
+				newTab = (m.activeTab + tabCount - 1) % tabCount
 			}
 			if newTab >= 0 && newTab != m.activeTab {
 				m.activeTab = newTab
@@ -195,6 +199,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			slog.Warn("document fetch failed", "error", msg.err)
 			errMsg := fmt.Sprintf("Failed to open: %v", msg.err)
 			switch m.activeTab {
+			case TabSearch:
+				m.search.statusErr = errMsg
 			case TabAllFiles:
 				m.finder.statusErr = errMsg
 			case TabLinks:
@@ -204,6 +210,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		}
+		m.search.statusErr = ""
 		m.finder.statusErr = ""
 		m.links.statusErr = ""
 		m.bookmarks.statusErr = ""
@@ -292,6 +299,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Async messages must always reach their model regardless of active tab.
 	switch msg.(type) {
+	case searchResultsMsg, searchDebounceMsg:
+		var cmd tea.Cmd
+		m.search, cmd = m.search.Update(msg)
+		return m, cmd
 	case linksLoadedMsg, linkArchivedMsg, linkDeletedMsg:
 		var cmd tea.Cmd
 		m.links, cmd = m.links.Update(msg)
@@ -306,6 +317,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch m.state {
 	case stateFinding:
 		switch m.activeTab {
+		case TabSearch:
+			var cmd tea.Cmd
+			m.search, cmd = m.search.Update(msg)
+			return m, cmd
 		case TabAllFiles:
 			var cmd tea.Cmd
 			m.finder, cmd = m.finder.Update(msg)
@@ -346,6 +361,8 @@ func (m Model) View() tea.View {
 	case stateFinding:
 		tabBar := renderTabs(m.activeTab, len(m.links.allLinks), len(m.bookmarks.items))
 		switch m.activeTab {
+		case TabSearch:
+			content = tabBar + "\n" + m.search.View()
 		case TabAllFiles:
 			content = tabBar + "\n" + m.finder.View()
 		case TabLinks:
@@ -369,9 +386,12 @@ func (m *Model) editDocument() tea.Cmd {
 
 // focusActiveTab blurs all inputs then focuses the active tab's input.
 func (m *Model) focusActiveTab() tea.Cmd {
+	m.search.input.Blur()
 	m.finder.picker.Input.Blur()
 	m.links.input.Blur()
 	switch m.activeTab {
+	case TabSearch:
+		return m.search.input.Focus()
 	case TabAllFiles:
 		return m.finder.picker.Input.Focus()
 	case TabLinks:

--- a/internal/tui/browse/search.go
+++ b/internal/tui/browse/search.go
@@ -1,0 +1,277 @@
+package browse
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
+	"github.com/raphi011/know/internal/apiclient"
+	"github.com/raphi011/know/internal/tui/pick"
+)
+
+// searchResultsMsg is sent when a search API call completes.
+type searchResultsMsg struct {
+	query   string // the query that produced these results
+	results []apiclient.SearchResult
+	err     error
+}
+
+// searchDebounceMsg fires after the debounce delay; seq must match current
+// debounceSeq to trigger a search (stale ticks are discarded).
+type searchDebounceMsg struct {
+	seq int
+}
+
+type searchModel struct {
+	results []apiclient.SearchResult
+	cursor  int
+	offset  int
+	width   int
+	height  int
+
+	input       textinput.Model
+	searching   bool
+	statusErr   string
+	debounceSeq int
+	lastQuery   string // query that produced current results
+
+	client  *apiclient.Client
+	vaultID string
+}
+
+var (
+	snippetStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#9CA3AF"))
+	headingPathStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#7C3AED")).Bold(true)
+)
+
+func newSearchModel(client *apiclient.Client, vaultID string) searchModel {
+	ti := textinput.New()
+	ti.Placeholder = "Search documents..."
+	ti.CharLimit = 256
+	ti.Prompt = "/ "
+
+	styles := ti.Styles()
+	styles.Cursor.Blink = false
+	styles.Focused.Prompt = pick.PromptStyle
+	ti.SetStyles(styles)
+
+	return searchModel{
+		input:   ti,
+		client:  client,
+		vaultID: vaultID,
+	}
+}
+
+func (s searchModel) doSearch() tea.Cmd {
+	client := s.client
+	vaultID := s.vaultID
+	query := s.input.Value()
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		results, err := client.SearchDocuments(ctx, vaultID, query, 20, true)
+		return searchResultsMsg{query: query, results: results, err: err}
+	}
+}
+
+func (s *searchModel) ensureCursorVisible() {
+	visible := s.visibleRows()
+	if s.cursor < s.offset {
+		s.offset = s.cursor
+	}
+	if s.cursor >= s.offset+visible {
+		s.offset = s.cursor - visible + 1
+	}
+}
+
+func (s searchModel) visibleRows() int {
+	// input (1) + count line (1) + footer (1) = 3 lines overhead
+	// Each result takes 2 lines (path+title, snippet).
+	rows := max((s.height-3)/2, 1)
+	return rows
+}
+
+func (s searchModel) Update(msg tea.Msg) (searchModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case searchResultsMsg:
+		s.searching = false
+		// Discard stale responses from superseded queries.
+		if msg.query != s.input.Value() {
+			return s, nil
+		}
+		if msg.err != nil {
+			s.statusErr = fmt.Sprintf("Search failed: %v", msg.err)
+			s.results = nil
+			return s, nil
+		}
+		s.statusErr = ""
+		s.results = msg.results
+		s.lastQuery = msg.query
+		s.cursor = 0
+		s.offset = 0
+		return s, nil
+
+	case searchDebounceMsg:
+		if msg.seq != s.debounceSeq {
+			return s, nil // stale tick
+		}
+		query := s.input.Value()
+		if query == "" {
+			return s, nil
+		}
+		s.searching = true
+		return s, s.doSearch()
+
+	case tea.KeyPressMsg:
+		s.statusErr = ""
+
+		switch msg.String() {
+		case "enter":
+			// If we have results and a valid cursor, select the file.
+			if len(s.results) > 0 && s.cursor < len(s.results) {
+				path := s.results[s.cursor].Path
+				return s, func() tea.Msg {
+					return fileSelectedMsg{path: path}
+				}
+			}
+			// Otherwise trigger immediate search if we have a query.
+			if s.input.Value() != "" {
+				s.debounceSeq++ // cancel pending debounce
+				s.searching = true
+				return s, s.doSearch()
+			}
+			return s, nil
+		case "esc":
+			return s, tea.Quit
+		case "up":
+			if s.cursor > 0 {
+				s.cursor--
+				s.ensureCursorVisible()
+			}
+			return s, nil
+		case "down":
+			if s.cursor < len(s.results)-1 {
+				s.cursor++
+				s.ensureCursorVisible()
+			}
+			return s, nil
+		case "pgup":
+			s.cursor = max(s.cursor-s.visibleRows(), 0)
+			s.ensureCursorVisible()
+			return s, nil
+		case "pgdown":
+			s.cursor = min(s.cursor+s.visibleRows(), max(len(s.results)-1, 0))
+			s.ensureCursorVisible()
+			return s, nil
+		}
+	}
+
+	// Delegate remaining keys to text input.
+	prev := s.input.Value()
+	var cmd tea.Cmd
+	s.input, cmd = s.input.Update(msg)
+
+	if s.input.Value() != prev {
+		// Input changed — clear results if query is now empty, otherwise debounce.
+		if s.input.Value() == "" {
+			s.results = nil
+			s.lastQuery = ""
+			s.searching = false
+			return s, cmd
+		}
+		s.debounceSeq++
+		seq := s.debounceSeq
+		debounceCmd := tea.Tick(300*time.Millisecond, func(time.Time) tea.Msg {
+			return searchDebounceMsg{seq: seq}
+		})
+		return s, tea.Batch(cmd, debounceCmd)
+	}
+
+	return s, cmd
+}
+
+func (s searchModel) View() string {
+	var b strings.Builder
+
+	b.WriteString(s.input.View())
+	b.WriteString("\n")
+
+	// Count / status line
+	if s.searching {
+		b.WriteString(pick.CountStyle.Render("  Searching..."))
+	} else if s.input.Value() == "" {
+		b.WriteString(pick.CountStyle.Render("  Type to search documents"))
+	} else if len(s.results) == 0 {
+		b.WriteString(pick.CountStyle.Render(fmt.Sprintf("  No results for %q", s.lastQuery)))
+	} else {
+		b.WriteString(pick.CountStyle.Render(fmt.Sprintf("  %d results", len(s.results))))
+	}
+	b.WriteString("\n")
+
+	visible := s.visibleRows()
+	end := min(s.offset+visible, len(s.results))
+
+	for i := s.offset; i < end; i++ {
+		result := s.results[i]
+
+		prefix := "  "
+		style := pick.NormalStyle
+		if i == s.cursor {
+			prefix = "> "
+			style = pick.SelectedStyle
+		}
+
+		// Line 1: path + title
+		line := style.Render(result.Path)
+		if result.Title != "" {
+			line += "  " + pick.TitleStyle.Render(result.Title)
+		}
+		b.WriteString(prefix + line + "\n")
+
+		// Line 2: heading path + snippet (from top matched chunk)
+		snippetLine := "  "
+		if len(result.MatchedChunks) > 0 {
+			chunk := result.MatchedChunks[0]
+			if chunk.HeadingPath != nil && *chunk.HeadingPath != "" {
+				snippetLine += headingPathStyle.Render("## "+*chunk.HeadingPath) + " — "
+			}
+			snippet := truncateSnippet(chunk.Snippet, s.width-len(snippetLine)-4)
+			snippetLine += snippetStyle.Render(snippet)
+		}
+		b.WriteString(snippetLine + "\n")
+	}
+
+	// Pad remaining space (2 lines per result slot).
+	rendered := end - s.offset
+	for i := rendered; i < visible; i++ {
+		b.WriteString("\n\n")
+	}
+
+	// Footer
+	if s.statusErr != "" {
+		b.WriteString(errStyle.Render("  " + s.statusErr))
+	} else {
+		b.WriteString(pick.CountStyle.Render("  enter: open  esc: quit"))
+	}
+
+	return b.String()
+}
+
+// truncateSnippet shortens a snippet to fit within maxLen runes, adding "…" if truncated.
+func truncateSnippet(s string, maxLen int) string {
+	if maxLen <= 0 {
+		maxLen = 40
+	}
+	// Replace newlines with spaces for single-line display.
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.TrimSpace(s)
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}

--- a/internal/tui/browse/tabs.go
+++ b/internal/tui/browse/tabs.go
@@ -11,12 +11,16 @@ import (
 type Tab int
 
 const (
-	// TabAllFiles is the default tab showing all vault documents.
-	TabAllFiles Tab = iota
+	// TabSearch is the default tab for full-text search.
+	TabSearch Tab = iota
+	// TabAllFiles shows all vault documents with fuzzy filtering.
+	TabAllFiles
 	// TabLinks shows saved web clips.
 	TabLinks
 	// TabBookmarks shows user-bookmarked files and folders.
 	TabBookmarks
+
+	tabCount // sentinel — must be last
 )
 
 var (
@@ -36,6 +40,7 @@ func renderTabs(active Tab, linkCount, bookmarkCount int) string {
 		tab   Tab
 		label string
 	}{
+		{TabSearch, "Search"},
 		{TabAllFiles, "All Files"},
 		{TabLinks, fmt.Sprintf("Links (%d)", linkCount)},
 		{TabBookmarks, fmt.Sprintf("Bookmarks (%d)", bookmarkCount)},


### PR DESCRIPTION
Add a BM25 full-text search tab to the browse TUI and fix a parser bug that silently dropped list/blockquote content from chunks.

## New Features
- **Search tab** in `know browse` — default tab with server-side BM25 keyword search
  - Debounced live search (300ms) + Enter for immediate
  - Rich results: path, title, heading path, matched snippet
  - Same viewer integration (edit `e`, bookmark `b`) as other tabs
  - Stale response detection, 10s timeout
- **`bm25_only` API parameter** — `GET /api/v1/vaults/{vault}/search?bm25_only=true` skips vector search

## Bug Fixes
- **Markdown parser: list/blockquote content dropped** — `blockLines()` only read `.Lines()` from AST nodes, but goldmark container nodes (`ast.List`, `ast.Blockquote`) store content in child nodes. Documents with list-heavy sections produced empty chunks, breaking FTS indexing. Fixed by walking descendant block nodes.

## Breaking Changes
- `SearchDocuments` API client function signature changed: added `bm25Only bool` parameter
- Default browse tab changed from "All Files" to "Search"
- Number keys (1/2/3) no longer switch tabs (conflicts with search input); use Tab/Shift+Tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)