### PR TITLE
feat: embed sweep worker, concurrent pipeline, and job reprocess command

### DIFF
--- a/cmd/know/cmd_job_reprocess.go
+++ b/cmd/know/cmd_job_reprocess.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/raphi011/know/internal/apiclient"
+	"github.com/spf13/cobra"
+)
+
+var (
+	reprocessAPI   *apiFlags
+	reprocessVault string
+	reprocessYes   bool
+)
+
+var reprocessCmd = &cobra.Command{
+	Use:   "reprocess",
+	Short: "Reprocess all files (delete chunks, clear hashes, re-enqueue jobs)",
+	Long: `Force reprocessing of all files in the pipeline.
+
+This deletes all chunks, clears file content hashes, cancels pending jobs,
+and enqueues fresh parse/pdf/transcribe jobs for every file.
+
+The embed worker will automatically embed new chunks after processing.
+
+Examples:
+  know job reprocess --yes
+  know job reprocess --vault default --yes`,
+	RunE: runReprocess,
+}
+
+func init() {
+	reprocessAPI = addAPIFlags(reprocessCmd)
+	reprocessCmd.Flags().StringVar(&reprocessVault, "vault", "", "only reprocess files in this vault")
+	reprocessCmd.Flags().BoolVarP(&reprocessYes, "yes", "y", false, "skip confirmation prompt")
+	if err := reprocessCmd.RegisterFlagCompletionFunc("vault", noFileCompletions); err != nil {
+		panic(fmt.Sprintf("register vault completion: %v", err))
+	}
+}
+
+func runReprocess(_ *cobra.Command, _ []string) error {
+	if !reprocessYes {
+		scope := "all vaults"
+		if reprocessVault != "" {
+			scope = fmt.Sprintf("vault %q", reprocessVault)
+		}
+		fmt.Printf("This will delete all chunks and reprocess all files in %s.\nContinue? [y/N] ", scope)
+		var answer string
+		if _, err := fmt.Scanln(&answer); err != nil || (answer != "y" && answer != "Y") {
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+
+	client := reprocessAPI.newClient()
+	ctx := context.Background()
+
+	resp, err := client.Reprocess(ctx, apiclient.ReprocessRequest{
+		Vault: reprocessVault,
+	})
+	if err != nil {
+		return fmt.Errorf("reprocess: %w", err)
+	}
+
+	fmt.Printf("Reprocess complete:\n")
+	fmt.Printf("  Jobs cancelled: %d\n", resp.JobsCancelled)
+	fmt.Printf("  Hashes cleared: %d\n", resp.HashesCleared)
+	fmt.Printf("  Jobs enqueued:  %d\n", resp.JobsEnqueued)
+	return nil
+}

--- a/cmd/know/main.go
+++ b/cmd/know/main.go
@@ -106,6 +106,7 @@ func main() {
 	rootCmd.AddCommand(remoteCmd)
 	rootCmd.AddCommand(taskCmd)
 	rootCmd.AddCommand(browseCmd)
+	jobCmd.AddCommand(reprocessCmd)
 	rootCmd.AddCommand(jobCmd)
 	rootCmd.AddCommand(fetchCmd)
 	rootCmd.AddCommand(backupCmd)

--- a/docs/tech-auth.md
+++ b/docs/tech-auth.md
@@ -7,17 +7,17 @@ Technical reference for Know's authentication and authorization system. For user
 Know authenticates all API requests via `kh_`-prefixed bearer tokens. Tokens are issued either directly (bootstrap, API) or through OIDC login flows (device flow, OAuth PKCE). Authorization is vault-scoped: each token inherits its user's vault memberships and roles.
 
 ```
-                         ┌──────────────────────┐
-                         │   OIDC Provider       │
+                         ┌────────────────────────┐
+                         │   OIDC Provider        │
                          │ (GitHub, Google, etc.) │
-                         └──────────┬───────────┘
+                         └──────────┬─────────────┘
                                     │ ExchangeCode
                                     ▼
-┌─────────────┐    ┌──────────────────────────────────┐
-│ Claude Code  │    │         Auth Endpoints            │
-│ Cursor, CLI  │───▶│  /auth/* (device, PKCE)           │
-│ Native Apps  │    │  /oauth/* (DCR, authorize, token) │
-└──────┬──────┘    └──────────────┬───────────────────┘
+┌──────────────┐    ┌────────────────────────────────────┐
+│ Claude Code  │    │         Auth Endpoints             │
+│ Cursor, CLI  │───▶│  /auth/* (device, PKCE)            │
+│ Native Apps  │    │  /oauth/* (DCR, authorize, token)  │
+└──────┬───────┘    └──────────────┬─────────────────────┘
        │                          │ FindOrCreateUser
        │                          │ GenerateToken
        │                          ▼
@@ -28,15 +28,15 @@ Know authenticates all API requests via `kh_`-prefixed bearer tokens. Tokens are
        │ Authorization: Bearer  │
        ▼                        ▼
 ┌──────────────────────────────────────────────────────────┐
-│                    Auth Middleware                         │
-│  Bearer token → SHA256 → DB lookup → expiry check         │
-│  → user lookup → vault memberships → AuthContext           │
+│                    Auth Middleware                       │
+│  Bearer token → SHA256 → DB lookup → expiry check        │
+│  → user lookup → vault memberships → AuthContext         │
 └──────────────────────────┬───────────────────────────────┘
                            │
                            ▼
 ┌──────────────────────────────────────────────────────────┐
-│                   Vault Scope Middleware                   │
-│  vault name → DB lookup → CheckVaultRole → WithVaultID    │
+│                   Vault Scope Middleware                 │
+│  vault name → DB lookup → CheckVaultRole → WithVaultID   │
 └──────────────────────────┬───────────────────────────────┘
                            │
                            ▼
@@ -324,8 +324,8 @@ CLI                          Server                      OIDC Provider
  │                             │  → redirect to provider      │
  │                             │─────────────────────────────▶│
  │                             │                              │
- │                             │  GET /auth/callback           │
- │                             │  state = user_code.sig        │
+ │                             │  GET /auth/callback          │
+ │                             │  state = user_code.sig       │
  │                             │◀─────────────────────────────│
  │                             │                              │
  │                             │  ExchangeCode → UserInfo     │
@@ -372,7 +372,7 @@ MCP Client                   Server                      OIDC Provider
  │  {issuer, endpoints, ...}   │                              │
  │◀────────────────────────────│                              │
  │                             │                              │
- │  POST /oauth/register       │     (RFC 7591 DCR)          │
+ │  POST /oauth/register       │     (RFC 7591 DCR)           │
  │  {client_name, redirect_uris}                              │
  │────────────────────────────▶│                              │
  │  {client_id}                │                              │
@@ -391,11 +391,11 @@ MCP Client                   Server                      OIDC Provider
  │                             │  Redirect to provider        │
  │                             │─────────────────────────────▶│
  │                             │                              │
- │                             │  GET /auth/callback           │
- │                             │  state = oauth:payload.sig    │
+ │                             │  GET /auth/callback          │
+ │                             │  state = oauth:payload.sig   │
  │                             │◀─────────────────────────────│
  │                             │                              │
- │                             │  VerifyOAuthState             │
+ │                             │  VerifyOAuthState            │
  │                             │  ExchangeCode → UserInfo     │
  │                             │  FindOrCreateUser            │
  │                             │  GenerateToken → kh_...      │
@@ -407,9 +407,9 @@ MCP Client                   Server                      OIDC Provider
  │                             │    &state=client_state       │
  │                             │                              │
  │  POST /oauth/token          │                              │
- │  grant_type=authorization_code                             │
+ │  grant_type=authorization_code                              
  │  code=auth_code             │                              │
- │  code_verifier=...          │                              │
+ │  code_verifier=...          │                                 │
  │────────────────────────────▶│                              │
  │                             │  ConsumeOAuthAuthCode (atomic)│
  │                             │  Verify PKCE:                │

--- a/helm/know/templates/deployment.yaml
+++ b/helm/know/templates/deployment.yaml
@@ -254,6 +254,19 @@ spec:
             - name: KNOW_PIPELINE_WORKER_BATCH
               value: {{ .Values.pipeline.workerBatch | quote }}
             {{- end }}
+            {{- if .Values.pipeline.workerConcurrency }}
+            - name: KNOW_PIPELINE_WORKER_CONCURRENCY
+              value: {{ .Values.pipeline.workerConcurrency | quote }}
+            {{- end }}
+            # Embed worker
+            {{- if .Values.embedWorker.interval }}
+            - name: KNOW_EMBED_WORKER_INTERVAL
+              value: {{ .Values.embedWorker.interval | quote }}
+            {{- end }}
+            {{- if .Values.embedWorker.batch }}
+            - name: KNOW_EMBED_WORKER_BATCH
+              value: {{ .Values.embedWorker.batch | quote }}
+            {{- end }}
             # Chunking
             {{- if .Values.chunking.threshold }}
             - name: KNOW_CHUNK_THRESHOLD

--- a/helm/know/values.yaml
+++ b/helm/know/values.yaml
@@ -103,8 +103,14 @@ metrics:
 
 # Pipeline worker
 pipeline:
-  workerInterval: ""  # seconds between worker ticks (default: 5)
-  workerBatch: ""     # max jobs per tick (default: 10)
+  workerInterval: ""     # seconds between worker ticks (default: 5)
+  workerBatch: ""        # max jobs per tick (default: 10)
+  workerConcurrency: ""  # max concurrent jobs per tick (default: 5)
+
+# Embed worker
+embedWorker:
+  interval: ""  # seconds between embed worker ticks (default: 5)
+  batch: ""     # max chunks per embed tick (default: 100)
 
 # Chunking
 chunking:

--- a/internal/api/jobs.go
+++ b/internal/api/jobs.go
@@ -1,12 +1,14 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/raphi011/know/internal/event"
 	"github.com/raphi011/know/internal/httputil"
 	"github.com/raphi011/know/internal/logutil"
 	"github.com/raphi011/know/internal/models"
@@ -80,6 +82,86 @@ func (s *Server) getJobStatus(w http.ResponseWriter, r *http.Request) {
 		Durations:    durations,
 		Active:       active,
 		RecentFailed: recentFailed,
+	})
+}
+
+type reprocessRequest struct {
+	Vault string `json:"vault"` // optional vault ID filter
+}
+
+type reprocessResponse struct {
+	HashesCleared int `json:"hashes_cleared"`
+	JobsCancelled int `json:"jobs_cancelled"`
+	JobsEnqueued  int `json:"jobs_enqueued"`
+}
+
+func (s *Server) reprocessJobs(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	db := s.app.DBClient()
+	logger := logutil.FromCtx(ctx)
+
+	var req reprocessRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httputil.WriteProblem(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	// Validate vault exists if specified.
+	if req.Vault != "" {
+		vault, err := db.GetVault(ctx, req.Vault)
+		if err != nil {
+			logger.Error("reprocess: get vault", "vault", req.Vault, "error", err)
+			httputil.WriteProblem(w, http.StatusInternalServerError, "failed to look up vault")
+			return
+		}
+		if vault == nil {
+			httputil.WriteProblem(w, http.StatusNotFound, fmt.Sprintf("vault %q not found", req.Vault))
+			return
+		}
+	}
+
+	// 1. Cancel pending/running jobs.
+	cancelled, err := db.CancelPendingJobs(ctx, req.Vault)
+	if err != nil {
+		logger.Error("reprocess: cancel pending jobs", "error", err)
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to cancel pending jobs")
+		return
+	}
+
+	// 2. Delete chunks.
+	if err := db.DeleteChunksByVault(ctx, req.Vault); err != nil {
+		logger.Error("reprocess: delete chunks", "error", err)
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to delete chunks")
+		return
+	}
+
+	// 3. Clear file hashes.
+	cleared, err := db.ClearFileHashes(ctx, req.Vault)
+	if err != nil {
+		logger.Error("reprocess: clear file hashes", "error", err)
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to clear file hashes")
+		return
+	}
+
+	// 4. Enqueue fresh jobs.
+	enqueued, err := db.EnqueueReprocessJobs(ctx, req.Vault)
+	if err != nil {
+		logger.Error("reprocess: enqueue jobs", "error", err)
+		httputil.WriteProblem(w, http.StatusInternalServerError, "failed to enqueue reprocess jobs")
+		return
+	}
+
+	// 5. Wake pipeline worker.
+	if bus := s.app.EventBus(); bus != nil {
+		bus.Publish(event.ChangeEvent{Type: "job.created"})
+	}
+
+	logger.Info("reprocess complete", "vault", req.Vault, "cancelled", cancelled, "cleared", cleared, "enqueued", enqueued)
+
+	writeJSON(w, http.StatusOK, reprocessResponse{
+		JobsCancelled: cancelled,
+		HashesCleared: cleared,
+		JobsEnqueued:  enqueued,
 	})
 }
 

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -2996,6 +2996,38 @@ paths:
               schema:
                 $ref: "#/components/schemas/JobStatusResponse"
 
+  /jobs/reprocess:
+    post:
+      tags: [Jobs]
+      summary: Force reprocess all files
+      description: |
+        Deletes all chunks, clears file content hashes, cancels pending jobs,
+        and enqueues fresh parse/pdf/transcribe jobs for every file.
+        The embed worker will automatically embed new chunks after processing.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                vault:
+                  type: string
+                  description: Optional vault ID to filter reprocessing
+      responses:
+        "200":
+          description: Reprocess result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobs_cancelled:
+                    type: integer
+                  hashes_cleared:
+                    type: integer
+                  jobs_enqueued:
+                    type: integer
+
   # ── Config ──────────────────────────────────────────────
   /config:
     get:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -134,6 +134,7 @@ func (s *Server) Register(mux *http.ServeMux, authMw func(http.Handler) http.Han
 
 	// --- Jobs (pipeline status) ---
 	mux.Handle("GET /api/v1/jobs", g(s.getJobStatus))
+	mux.Handle("POST /api/v1/jobs/reprocess", g(s.reprocessJobs))
 
 	// --- Config ---
 	mux.Handle("GET /api/v1/config", g(s.getConfig))

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -778,6 +778,27 @@ func (c *Client) GetJobStatus(ctx context.Context, since string) (*JobStatusResp
 	return &resp, nil
 }
 
+// ReprocessRequest is the request body for POST /api/v1/jobs/reprocess.
+type ReprocessRequest struct {
+	Vault string `json:"vault,omitempty"`
+}
+
+// ReprocessResponse is the response from POST /api/v1/jobs/reprocess.
+type ReprocessResponse struct {
+	JobsCancelled int `json:"jobs_cancelled"`
+	HashesCleared int `json:"hashes_cleared"`
+	JobsEnqueued  int `json:"jobs_enqueued"`
+}
+
+// Reprocess triggers a full reprocess of all files, optionally filtered by vault.
+func (c *Client) Reprocess(ctx context.Context, req ReprocessRequest) (*ReprocessResponse, error) {
+	var resp ReprocessResponse
+	if err := c.Post(ctx, "/api/v1/jobs/reprocess", req, &resp); err != nil {
+		return nil, fmt.Errorf("reprocess: %w", err)
+	}
+	return &resp, nil
+}
+
 // VaultInfo holds comprehensive stats about a vault.
 type VaultInfo struct {
 	Name        string    `json:"name"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,8 +114,13 @@ type Config struct {
 	NFSPort    string // KNOW_NFS_PORT (default: "2049")
 
 	// Pipeline worker settings
-	PipelineWorkerInterval int // seconds between worker ticks (KNOW_PIPELINE_WORKER_INTERVAL, default: 5)
-	PipelineWorkerBatch    int // max jobs per tick (KNOW_PIPELINE_WORKER_BATCH, default: 10)
+	PipelineWorkerInterval    int // seconds between worker ticks (KNOW_PIPELINE_WORKER_INTERVAL, default: 5)
+	PipelineWorkerBatch       int // max jobs per tick (KNOW_PIPELINE_WORKER_BATCH, default: 10)
+	PipelineWorkerConcurrency int // max concurrent jobs per tick (KNOW_PIPELINE_WORKER_CONCURRENCY, default: 5)
+
+	// Embed worker settings
+	EmbedWorkerInterval int // seconds between embed worker ticks (KNOW_EMBED_WORKER_INTERVAL, default: 5)
+	EmbedWorkerBatch    int // max chunks per embed tick (KNOW_EMBED_WORKER_BATCH, default: 100)
 
 	// Chunking settings
 	ChunkThreshold  int // only chunk if content exceeds this length (default: 6000)
@@ -322,8 +327,13 @@ func Load() Config {
 		NFSPort:           getEnv("KNOW_NFS_PORT", "2049"),
 
 		// Pipeline worker
-		PipelineWorkerInterval: getEnvInt("KNOW_PIPELINE_WORKER_INTERVAL", 5),
-		PipelineWorkerBatch:    getEnvInt("KNOW_PIPELINE_WORKER_BATCH", 10),
+		PipelineWorkerInterval:    getEnvInt("KNOW_PIPELINE_WORKER_INTERVAL", 5),
+		PipelineWorkerBatch:       getEnvInt("KNOW_PIPELINE_WORKER_BATCH", 10),
+		PipelineWorkerConcurrency: getEnvInt("KNOW_PIPELINE_WORKER_CONCURRENCY", 5),
+
+		// Embed worker
+		EmbedWorkerInterval: getEnvInt("KNOW_EMBED_WORKER_INTERVAL", 5),
+		EmbedWorkerBatch:    getEnvInt("KNOW_EMBED_WORKER_BATCH", 100),
 
 		// Chunking
 		ChunkThreshold:  getEnvInt("KNOW_CHUNK_THRESHOLD", 6000),

--- a/internal/db/queries_chunk.go
+++ b/internal/db/queries_chunk.go
@@ -132,6 +132,19 @@ func (c *Client) GetUnembeddedChunks(ctx context.Context, fileID string) ([]mode
 	return allResults(results), nil
 }
 
+// GetUnembeddedChunksBatch returns up to limit chunks across all files that have no embedding yet.
+func (c *Client) GetUnembeddedChunksBatch(ctx context.Context, limit int) ([]models.Chunk, error) {
+	defer c.logOp(ctx, "chunk.get_unembedded_batch", time.Now())
+	sql := `SELECT * FROM chunk WHERE embedding IS NONE ORDER BY created_at ASC LIMIT $limit`
+	results, err := surrealdb.Query[[]models.Chunk](ctx, c.DB(), sql, map[string]any{
+		"limit": limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get unembedded chunks batch: %w", err)
+	}
+	return allResults(results), nil
+}
+
 func (c *Client) DeleteChunks(ctx context.Context, fileID string) error {
 	defer c.logOp(ctx, "chunk.delete", time.Now())
 	sql := `DELETE FROM chunk WHERE file = type::record("file", $file_id)`
@@ -139,6 +152,26 @@ func (c *Client) DeleteChunks(ctx context.Context, fileID string) error {
 		"file_id": fileID,
 	}); err != nil {
 		return fmt.Errorf("delete chunks: %w", err)
+	}
+	return nil
+}
+
+// DeleteChunksByVault deletes all chunks for files in the given vault.
+// If vaultID is empty, deletes all chunks across all vaults.
+func (c *Client) DeleteChunksByVault(ctx context.Context, vaultID string) error {
+	defer c.logOp(ctx, "chunk.delete_by_vault", time.Now())
+	var sql string
+	vars := map[string]any{}
+
+	if vaultID != "" {
+		sql = `DELETE FROM chunk WHERE file.vault = type::record("vault", $vault_id)`
+		vars["vault_id"] = bareID("vault", vaultID)
+	} else {
+		sql = `DELETE FROM chunk`
+	}
+
+	if _, err := surrealdb.Query[any](ctx, c.DB(), sql, vars); err != nil {
+		return fmt.Errorf("delete chunks by vault: %w", err)
 	}
 	return nil
 }

--- a/internal/db/queries_chunk_test.go
+++ b/internal/db/queries_chunk_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -559,5 +560,126 @@ func TestBatchUpdateChunkEmbeddings(t *testing.T) {
 		if len(ch.Embedding) != 384 {
 			t.Errorf("Expected embedding length 384, got %d for chunk %v", len(ch.Embedding), ch.Text)
 		}
+	}
+}
+
+func TestGetUnembeddedChunksBatch(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	doc, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID,
+		Path:    "/unembed-" + suffix + ".md",
+		Title:   "Unembed Test",
+		Content: "content",
+		Labels:  []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	docID := models.MustRecordIDString(doc.ID)
+
+	err = testDB.CreateChunks(ctx, []models.ChunkInput{
+		{FileID: docID, Text: "no embed 1", Position: 0, Labels: []string{}},
+		{FileID: docID, Text: "no embed 2", Position: 1, Labels: []string{}},
+		{FileID: docID, Text: "has embed", Position: 2, Labels: []string{}, Embedding: dummyEmbedding()},
+	})
+	if err != nil {
+		t.Fatalf("CreateChunks failed: %v", err)
+	}
+
+	// Should return at least 2 unembedded chunks
+	chunks, err := testDB.GetUnembeddedChunksBatch(ctx, 10)
+	if err != nil {
+		t.Fatalf("GetUnembeddedChunksBatch(10) failed: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Errorf("expected at least 2 unembedded chunks, got %d", len(chunks))
+	}
+
+	// Limit should be respected
+	limited, err := testDB.GetUnembeddedChunksBatch(ctx, 1)
+	if err != nil {
+		t.Fatalf("GetUnembeddedChunksBatch(1) failed: %v", err)
+	}
+	if len(limited) != 1 {
+		t.Errorf("expected exactly 1 chunk with limit=1, got %d", len(limited))
+	}
+}
+
+func TestDeleteChunksByVault(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+
+	vaultA := createTestVault(t, ctx, userID)
+	vaultAID := models.MustRecordIDString(vaultA.ID)
+	vaultB := createTestVault(t, ctx, userID)
+	vaultBID := models.MustRecordIDString(vaultB.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+
+	docA, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultAID,
+		Path:    "/delchunk-a-" + suffix + ".md",
+		Title:   "A",
+		Content: "content",
+		Labels:  []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile A failed: %v", err)
+	}
+	docAID := models.MustRecordIDString(docA.ID)
+
+	docB, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultBID,
+		Path:    "/delchunk-b-" + suffix + ".md",
+		Title:   "B",
+		Content: "content",
+		Labels:  []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile B failed: %v", err)
+	}
+	docBID := models.MustRecordIDString(docB.ID)
+
+	err = testDB.CreateChunks(ctx, []models.ChunkInput{
+		{FileID: docAID, Text: "chunk A", Position: 0, Labels: []string{}, Embedding: dummyEmbedding()},
+	})
+	if err != nil {
+		t.Fatalf("CreateChunks A failed: %v", err)
+	}
+	err = testDB.CreateChunks(ctx, []models.ChunkInput{
+		{FileID: docBID, Text: "chunk B", Position: 0, Labels: []string{}, Embedding: dummyEmbedding()},
+	})
+	if err != nil {
+		t.Fatalf("CreateChunks B failed: %v", err)
+	}
+
+	// Delete vault A chunks
+	if err := testDB.DeleteChunksByVault(ctx, vaultAID); err != nil {
+		t.Fatalf("DeleteChunksByVault failed: %v", err)
+	}
+
+	// Vault A should have 0 chunks
+	chunksA, err := testDB.GetChunks(ctx, docAID)
+	if err != nil {
+		t.Fatalf("GetChunks A failed: %v", err)
+	}
+	if len(chunksA) != 0 {
+		t.Errorf("expected 0 chunks for vault A, got %d", len(chunksA))
+	}
+
+	// Vault B should still have chunks
+	chunksB, err := testDB.GetChunks(ctx, docBID)
+	if err != nil {
+		t.Fatalf("GetChunks B failed: %v", err)
+	}
+	if len(chunksB) != 1 {
+		t.Errorf("expected 1 chunk for vault B, got %d", len(chunksB))
 	}
 }

--- a/internal/db/queries_file.go
+++ b/internal/db/queries_file.go
@@ -1286,3 +1286,24 @@ func (c *Client) IsPathNoEmbed(ctx context.Context, vaultID, filePath string) (b
 	rows := allResults(results)
 	return len(rows) > 0 && rows[0].Total > 0, nil
 }
+
+// ClearFileHashes sets hash = NONE for all files, optionally filtered by vault.
+// Returns the number of updated files.
+func (c *Client) ClearFileHashes(ctx context.Context, vaultID string) (int, error) {
+	defer c.logOp(ctx, "file.clear_hashes", time.Now())
+	var sql string
+	vars := map[string]any{}
+
+	if vaultID != "" {
+		sql = `UPDATE file SET hash = NONE WHERE vault = type::record("vault", $vault_id) AND is_folder = false RETURN AFTER`
+		vars["vault_id"] = bareID("vault", vaultID)
+	} else {
+		sql = `UPDATE file SET hash = NONE WHERE is_folder = false RETURN AFTER`
+	}
+
+	results, err := surrealdb.Query[[]models.File](ctx, c.DB(), sql, vars)
+	if err != nil {
+		return 0, fmt.Errorf("clear file hashes: %w", err)
+	}
+	return countResults(results), nil
+}

--- a/internal/db/queries_file_test.go
+++ b/internal/db/queries_file_test.go
@@ -1600,3 +1600,52 @@ func TestUpdateFileLabels(t *testing.T) {
 		t.Errorf("Expected empty labels, got %v", updated.Labels)
 	}
 }
+
+func TestClearFileHashes(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+	hash := "somehash123"
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID,
+		Path:    "/clearhash-" + suffix + ".md",
+		Title:   "Clear Hash",
+		Content: "content",
+		Labels:  []string{},
+		Hash:    &hash,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	// Verify hash is set
+	fetched, err := testDB.GetFileByID(ctx, fileID)
+	if err != nil {
+		t.Fatalf("GetFileByID (before) failed: %v", err)
+	}
+	if fetched.Hash == nil {
+		t.Fatal("expected hash to be set before ClearFileHashes")
+	}
+
+	cleared, err := testDB.ClearFileHashes(ctx, vaultID)
+	if err != nil {
+		t.Fatalf("ClearFileHashes failed: %v", err)
+	}
+	if cleared < 1 {
+		t.Errorf("expected at least 1 cleared, got %d", cleared)
+	}
+
+	// Hash should now be nil
+	fetched, err = testDB.GetFileByID(ctx, fileID)
+	if err != nil {
+		t.Fatalf("GetFileByID (after) failed: %v", err)
+	}
+	if fetched.Hash != nil {
+		t.Errorf("expected hash to be nil after ClearFileHashes, got %q", *fetched.Hash)
+	}
+}

--- a/internal/db/queries_job.go
+++ b/internal/db/queries_job.go
@@ -176,3 +176,69 @@ func (c *Client) ReconcileStaleRunningJobs(ctx context.Context) (int, error) {
 	}
 	return countResults(results), nil
 }
+
+// CancelPendingJobs cancels all pending/running jobs, optionally filtered by vault.
+// Returns the number of cancelled jobs.
+func (c *Client) CancelPendingJobs(ctx context.Context, vaultID string) (int, error) {
+	defer c.logOp(ctx, "pipeline_job.cancel_pending", time.Now())
+	var sql string
+	vars := map[string]any{}
+
+	if vaultID != "" {
+		sql = `UPDATE pipeline_job SET status = 'cancelled', completed_at = time::now()
+			WHERE status IN ['pending', 'running']
+			  AND file.vault = type::record("vault", $vault_id)
+			RETURN AFTER`
+		vars["vault_id"] = bareID("vault", vaultID)
+	} else {
+		sql = `UPDATE pipeline_job SET status = 'cancelled', completed_at = time::now()
+			WHERE status IN ['pending', 'running']
+			RETURN AFTER`
+	}
+
+	results, err := surrealdb.Query[[]models.PipelineJob](ctx, c.DB(), sql, vars)
+	if err != nil {
+		return 0, fmt.Errorf("cancel pending jobs: %w", err)
+	}
+	return countResults(results), nil
+}
+
+// EnqueueReprocessJobs creates parse/pdf/transcribe jobs for all files,
+// optionally filtered by vault. Returns the number of jobs created.
+func (c *Client) EnqueueReprocessJobs(ctx context.Context, vaultID string) (int, error) {
+	defer c.logOp(ctx, "pipeline_job.enqueue_reprocess", time.Now())
+
+	vaultFilter := ""
+	vars := map[string]any{}
+	if vaultID != "" {
+		vaultFilter = ` AND vault = type::record("vault", $vault_id)`
+		vars["vault_id"] = bareID("vault", vaultID)
+	}
+
+	// Insert jobs in three batches by file type to avoid nested IF syntax issues.
+	// SAFETY: jobType and mimeWhere are hardcoded literals, never from user input.
+	total := 0
+	queries := []struct {
+		jobType   string
+		mimeWhere string
+	}{
+		{"transcribe", `string::starts_with(mime_type, "audio/")`},
+		{"pdf", `mime_type = "application/pdf"`},
+		{"parse", `!string::starts_with(mime_type, "audio/") AND mime_type != "application/pdf"`},
+	}
+
+	for _, q := range queries {
+		sql := fmt.Sprintf(`INSERT INTO pipeline_job (
+			SELECT id AS file, "%s" AS type, "pending" AS status, 0 AS priority
+			FROM file WHERE is_folder = false AND %s%s
+		)`, q.jobType, q.mimeWhere, vaultFilter)
+
+		results, err := surrealdb.Query[[]models.PipelineJob](ctx, c.DB(), sql, vars)
+		if err != nil {
+			return total, fmt.Errorf("enqueue reprocess %s jobs: %w", q.jobType, err)
+		}
+		total += countResults(results)
+	}
+
+	return total, nil
+}

--- a/internal/db/queries_job_test.go
+++ b/internal/db/queries_job_test.go
@@ -690,3 +690,178 @@ func TestReconcileStaleRunningJobs(t *testing.T) {
 		t.Error("reconciled job should be claimable again")
 	}
 }
+
+func TestCancelPendingJobs(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+
+	vaultA := createTestVault(t, ctx, userID)
+	vaultAID := models.MustRecordIDString(vaultA.ID)
+	vaultB := createTestVault(t, ctx, userID)
+	vaultBID := models.MustRecordIDString(vaultB.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+
+	fileA1, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultAID, Path: "/cancel-a1-" + suffix + ".md", Title: "A1",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile A1 failed: %v", err)
+	}
+	fileA2, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultAID, Path: "/cancel-a2-" + suffix + ".md", Title: "A2",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile A2 failed: %v", err)
+	}
+	fileB1, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultBID, Path: "/cancel-b1-" + suffix + ".md", Title: "B1",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile B1 failed: %v", err)
+	}
+
+	fileA1ID := models.MustRecordIDString(fileA1.ID)
+	fileA2ID := models.MustRecordIDString(fileA2.ID)
+	fileB1ID := models.MustRecordIDString(fileB1.ID)
+
+	if err := testDB.CreateJob(ctx, fileA1ID, "parse", 10); err != nil {
+		t.Fatalf("CreateJob A1 failed: %v", err)
+	}
+	if err := testDB.CreateJob(ctx, fileA2ID, "parse", 10); err != nil {
+		t.Fatalf("CreateJob A2 failed: %v", err)
+	}
+	if err := testDB.CreateJob(ctx, fileB1ID, "parse", 10); err != nil {
+		t.Fatalf("CreateJob B1 failed: %v", err)
+	}
+
+	// Cancel only vault A jobs
+	cancelled, err := testDB.CancelPendingJobs(ctx, vaultAID)
+	if err != nil {
+		t.Fatalf("CancelPendingJobs failed: %v", err)
+	}
+	if cancelled != 2 {
+		t.Errorf("expected 2 cancelled, got %d", cancelled)
+	}
+
+	// Vault B job should still be claimable
+	jobs, err := testDB.ClaimJobs(ctx, 10)
+	if err != nil {
+		t.Fatalf("ClaimJobs failed: %v", err)
+	}
+	var foundB bool
+	for _, j := range jobs {
+		if models.MustRecordIDString(j.File) == fileB1ID {
+			foundB = true
+		}
+	}
+	if !foundB {
+		t.Error("vault B job should still be claimable after cancelling vault A")
+	}
+}
+
+func TestCancelPendingJobs_AllVaults(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+
+	file, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID: vaultID, Path: "/cancel-all-" + suffix + ".md", Title: "All",
+		Content: "content", Labels: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateFile failed: %v", err)
+	}
+	fileID := models.MustRecordIDString(file.ID)
+
+	if err := testDB.CreateJob(ctx, fileID, "parse", 10); err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	// Cancel with empty vaultID (all vaults)
+	cancelled, err := testDB.CancelPendingJobs(ctx, "")
+	if err != nil {
+		t.Fatalf("CancelPendingJobs (all) failed: %v", err)
+	}
+	if cancelled < 1 {
+		t.Errorf("expected at least 1 cancelled, got %d", cancelled)
+	}
+}
+
+func TestEnqueueReprocessJobs(t *testing.T) {
+	ctx := context.Background()
+	user := createTestUser(t, ctx)
+	userID := models.MustRecordIDString(user.ID)
+	vault := createTestVault(t, ctx, userID)
+	vaultID := models.MustRecordIDString(vault.ID)
+
+	suffix := fmt.Sprint(time.Now().UnixNano())
+
+	_, err := testDB.CreateFile(ctx, models.FileInput{
+		VaultID:  vaultID,
+		Path:     "/reprocess-" + suffix + ".md",
+		Title:    "Markdown",
+		Content:  "# Hello",
+		Labels:   []string{},
+		MimeType: "text/markdown",
+	})
+	if err != nil {
+		t.Fatalf("CreateFile (md) failed: %v", err)
+	}
+
+	_, err = testDB.CreateFile(ctx, models.FileInput{
+		VaultID:  vaultID,
+		Path:     "/reprocess-" + suffix + ".pdf",
+		Title:    "PDF",
+		Content:  "",
+		Labels:   []string{},
+		MimeType: "application/pdf",
+	})
+	if err != nil {
+		t.Fatalf("CreateFile (pdf) failed: %v", err)
+	}
+
+	_, err = testDB.CreateFile(ctx, models.FileInput{
+		VaultID:  vaultID,
+		Path:     "/reprocess-" + suffix + ".mp3",
+		Title:    "Audio",
+		Content:  "",
+		Labels:   []string{},
+		MimeType: "audio/mpeg",
+	})
+	if err != nil {
+		t.Fatalf("CreateFile (mp3) failed: %v", err)
+	}
+
+	count, err := testDB.EnqueueReprocessJobs(ctx, vaultID)
+	if err != nil {
+		t.Fatalf("EnqueueReprocessJobs failed: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 enqueued jobs, got %d", count)
+	}
+
+	// Claim all jobs and verify types
+	jobs, err := testDB.ClaimJobs(ctx, 10)
+	if err != nil {
+		t.Fatalf("ClaimJobs failed: %v", err)
+	}
+
+	typeSet := map[string]bool{}
+	for _, j := range jobs {
+		typeSet[j.Type] = true
+	}
+	for _, expected := range []string{"parse", "pdf", "transcribe"} {
+		if !typeSet[expected] {
+			t.Errorf("expected job type %q in claimed jobs", expected)
+		}
+	}
+}

--- a/internal/file/embed_worker.go
+++ b/internal/file/embed_worker.go
@@ -1,0 +1,190 @@
+package file
+
+import (
+	"context"
+	"time"
+
+	"github.com/raphi011/know/internal/db"
+	"github.com/raphi011/know/internal/event"
+	"github.com/raphi011/know/internal/logutil"
+	"github.com/raphi011/know/internal/metrics"
+	"github.com/raphi011/know/internal/models"
+	"github.com/raphi011/know/internal/worker"
+)
+
+// EmbedWorker periodically sweeps for unembedded chunks across all files
+// and embeds them in batches. This replaces per-file embed pipeline jobs.
+type EmbedWorker struct {
+	svc      *Service
+	db       *db.Client
+	bus      *event.Bus
+	metrics  *metrics.Metrics
+	interval time.Duration
+	batch    int
+}
+
+// NewEmbedWorker creates a new EmbedWorker.
+func NewEmbedWorker(svc *Service, dbClient *db.Client, bus *event.Bus, interval time.Duration, batch int, m *metrics.Metrics) *EmbedWorker {
+	if interval <= 0 {
+		panic("file.EmbedWorker: interval must be positive")
+	}
+	if batch <= 0 {
+		panic("file.EmbedWorker: batch must be positive")
+	}
+	return &EmbedWorker{
+		svc:      svc,
+		db:       dbClient,
+		bus:      bus,
+		metrics:  m,
+		interval: interval,
+		batch:    batch,
+	}
+}
+
+// Run starts the embed worker loop. It blocks until ctx is cancelled.
+func (w *EmbedWorker) Run(ctx context.Context) {
+	notify, unsub := worker.EventNotify(w.bus, "file.processed")
+	defer unsub()
+	loop := worker.NewWorkerLoop("embed worker", w.interval, w.tick, notify)
+	loop.Run(ctx)
+}
+
+func (w *EmbedWorker) tick(ctx context.Context) {
+	logger := logutil.FromCtx(ctx)
+
+	embedder := w.svc.getEmbedder()
+	mmEmbedder := w.svc.getMultimodalEmbedder()
+	if embedder == nil && mmEmbedder == nil {
+		return
+	}
+
+	chunks, err := w.db.GetUnembeddedChunksBatch(ctx, w.batch)
+	if err != nil {
+		logger.Error("embed worker: get unembedded chunks", "error", err)
+		return
+	}
+	if len(chunks) == 0 {
+		return
+	}
+
+	// Collect unique file IDs and batch-fetch file metadata.
+	fileIDSet := make(map[string]struct{})
+	for _, chunk := range chunks {
+		fileID, err := models.RecordIDString(chunk.File)
+		if err != nil {
+			logger.Warn("embed worker: failed to extract file ID from chunk", "error", err)
+			continue
+		}
+		fileIDSet[fileID] = struct{}{}
+	}
+	fileIDs := make([]string, 0, len(fileIDSet))
+	for id := range fileIDSet {
+		fileIDs = append(fileIDs, id)
+	}
+
+	files, err := w.db.GetFilesByIDs(ctx, fileIDs)
+	if err != nil {
+		logger.Error("embed worker: get files by ids", "error", err)
+		return
+	}
+
+	// Build file lookup: fileID → file.
+	type fileInfo struct {
+		title   string
+		path    string
+		vaultID string
+	}
+	fileLookup := make(map[string]fileInfo, len(files))
+	for _, f := range files {
+		fid, err := models.RecordIDString(f.ID)
+		if err != nil {
+			logger.Warn("embed worker: failed to extract file ID", "error", err)
+			continue
+		}
+		vid, err := models.RecordIDString(f.Vault)
+		if err != nil {
+			logger.Warn("embed worker: failed to extract vault ID", "file_id", fid, "error", err)
+			continue
+		}
+		fileLookup[fid] = fileInfo{title: f.Title, path: f.Path, vaultID: vid}
+	}
+
+	// Partition chunks into text and multimodal, filtering out no_embed files.
+	var textPending []embeddingTask
+	var mmPending []multimodalEmbeddingTask
+
+	for _, chunk := range chunks {
+		chunkID, err := models.RecordIDString(chunk.ID)
+		if err != nil {
+			logger.Warn("embed worker: failed to extract chunk ID", "error", err)
+			continue
+		}
+		fileID, err := models.RecordIDString(chunk.File)
+		if err != nil {
+			logger.Warn("embed worker: failed to extract file ID from chunk", "chunk_id", chunkID, "error", err)
+			continue
+		}
+
+		fi, ok := fileLookup[fileID]
+		if !ok {
+			// File was deleted after chunk was created — skip.
+			continue
+		}
+
+		if !w.svc.shouldEmbed(ctx, fi.vaultID, fi.path) {
+			// TODO: these chunks will be re-fetched every tick since they remain
+			// with embedding IS NONE. Consider adding a DB-level filter or a
+			// skip_embed flag on chunks to avoid repeated fetches.
+			logger.Debug("embed worker: skipping no_embed file", "file_id", fileID, "path", fi.path)
+			continue
+		}
+
+		if chunk.IsMultimodal() {
+			if chunk.Hash == nil {
+				logger.Warn("embed worker: multimodal chunk has no hash, skipping", "chunk_id", chunkID)
+				continue
+			}
+			mmPending = append(mmPending, multimodalEmbeddingTask{
+				chunkID:  chunkID,
+				dataHash: *chunk.Hash,
+				mimeType: chunk.MimeType,
+				text:     buildEmbeddingContext(chunk, fi.title, w.svc.embedMaxInputChars),
+			})
+		} else {
+			textPending = append(textPending, embeddingTask{
+				chunkID: chunkID,
+				text:    buildEmbeddingContext(chunk, fi.title, w.svc.embedMaxInputChars),
+			})
+		}
+	}
+
+	var total int
+
+	if len(textPending) > 0 && embedder != nil {
+		start := time.Now()
+		n, err := w.svc.embedTextChunks(ctx, embedder, textPending)
+		if err != nil {
+			logger.Error("embed worker: text embedding failed", "error", err)
+		}
+		total += n
+		if w.metrics != nil && n > 0 {
+			w.metrics.RecordPipelineJob("embed", "completed", time.Since(start))
+		}
+	}
+
+	if len(mmPending) > 0 {
+		start := time.Now()
+		n, err := w.svc.embedMultimodalChunks(ctx, mmEmbedder, embedder, mmPending)
+		if err != nil {
+			logger.Error("embed worker: multimodal embedding failed", "error", err)
+		}
+		total += n
+		if w.metrics != nil && n > 0 {
+			w.metrics.RecordPipelineJob("embed", "completed", time.Since(start))
+		}
+	}
+
+	if total > 0 {
+		logger.Info("embed worker: embedded chunks", "count", total, "text", len(textPending), "multimodal", len(mmPending))
+	}
+}

--- a/internal/file/handlers.go
+++ b/internal/file/handlers.go
@@ -81,16 +81,6 @@ func ParseHandler(svc *Service, bus *event.Bus) pipeline.Handler {
 			return fmt.Errorf("sync labels for %s: %w", doc.Path, err)
 		}
 
-		// Enqueue embed job so new chunks get embeddings.
-		if svc.getEmbedder() != nil && svc.shouldEmbed(ctx, vaultID, doc.Path) {
-			if err := svc.db.CreateJob(ctx, fileID, "embed", 0); err != nil {
-				return fmt.Errorf("create embed job for %s: %w", doc.Path, err)
-			}
-			if bus != nil {
-				bus.Publish(event.ChangeEvent{Type: "job.created"})
-			}
-		}
-
 		svc.publishFileEvent("file.processed", vaultID, doc)
 		return nil
 	}
@@ -127,15 +117,6 @@ func TranscribeHandler(svc *Service, bus *event.Bus) pipeline.Handler {
 		vaultID, err := models.RecordIDString(doc.Vault)
 		if err != nil {
 			logutil.FromCtx(ctx).Warn("failed to extract vault id after transcription", "file_id", fileID, "error", err)
-		}
-
-		if svc.getEmbedder() != nil && (vaultID == "" || svc.shouldEmbed(ctx, vaultID, doc.Path)) {
-			if err := svc.db.CreateJob(ctx, fileID, "embed", 0); err != nil {
-				return fmt.Errorf("create embed job after transcription: %w", err)
-			}
-			if bus != nil {
-				bus.Publish(event.ChangeEvent{Type: "job.created"})
-			}
 		}
 
 		// Enqueue summarize job if LLM is available — the handler checks
@@ -253,55 +234,7 @@ func SummarizeHandler(svc *Service, bus *event.Bus) pipeline.Handler {
 			return fmt.Errorf("sync summary chunks: %w", err)
 		}
 
-		// Enqueue embed job so new chunks get embeddings.
-		if svc.getEmbedder() != nil && svc.shouldEmbed(ctx, vaultID, doc.Path) {
-			if err := svc.db.CreateJob(ctx, fileID, "embed", 0); err != nil {
-				return fmt.Errorf("create embed job after summarization: %w", err)
-			}
-			if bus != nil {
-				bus.Publish(event.ChangeEvent{Type: "job.created"})
-			}
-		}
-
 		svc.publishFileEvent("file.processed", vaultID, doc)
-		return nil
-	}
-}
-
-// EmbedHandler returns a pipeline.Handler that embeds all un-embedded chunks
-// belonging to the job's file. This is the terminal step — no further job is created.
-func EmbedHandler(svc *Service) pipeline.Handler {
-	return func(ctx context.Context, job models.PipelineJob) error {
-		fileID, err := models.RecordIDString(job.File)
-		if err != nil {
-			return fmt.Errorf("extract file id: %w", err)
-		}
-
-		// Check if the file's folder has embeddings disabled (handles race
-		// where folder was marked no_embed after the embed job was enqueued).
-		doc, err := svc.db.GetFileByID(ctx, fileID)
-		if err != nil {
-			return fmt.Errorf("get file: %w", err)
-		}
-		if doc == nil {
-			return nil
-		}
-		vaultID, vErr := models.RecordIDString(doc.Vault)
-		if vErr != nil {
-			logutil.FromCtx(ctx).Warn("failed to extract vault id in embed handler", "file_id", fileID, "error", vErr)
-		}
-		if vErr == nil && !svc.shouldEmbed(ctx, vaultID, doc.Path) {
-			logutil.FromCtx(ctx).Debug("skipping embedding, folder has no_embed", "file_id", fileID, "path", doc.Path)
-			return nil
-		}
-
-		n, err := svc.EmbedPendingChunksForFile(ctx, fileID)
-		if err != nil {
-			return fmt.Errorf("embed chunks: %w", err)
-		}
-		if n > 0 {
-			logutil.FromCtx(ctx).Info("embed handler: embedded chunks", "file_id", fileID, "count", n)
-		}
 		return nil
 	}
 }

--- a/internal/file/pdf_handler.go
+++ b/internal/file/pdf_handler.go
@@ -58,16 +58,6 @@ func PDFHandler(svc *Service, bus *event.Bus) pipeline.Handler {
 			logger.Warn("failed to extract vault id after pdf processing", "file_id", fileID, "error", err)
 		}
 
-		// Enqueue embed job if any embedder is configured and folder allows embedding.
-		if (svc.getEmbedder() != nil || svc.getMultimodalEmbedder() != nil) && (vaultID == "" || svc.shouldEmbed(ctx, vaultID, doc.Path)) {
-			if err := svc.db.CreateJob(ctx, fileID, "embed", 0); err != nil {
-				return fmt.Errorf("create embed job for %s: %w", doc.Path, err)
-			}
-			if bus != nil {
-				bus.Publish(event.ChangeEvent{Type: "job.created"})
-			}
-		}
-
 		if vaultID != "" {
 			svc.publishFileEvent("file.processed", vaultID, doc)
 		}

--- a/internal/file/service.go
+++ b/internal/file/service.go
@@ -627,16 +627,7 @@ func (s *Service) ProcessFile(ctx context.Context, doc *models.File) error {
 		return fmt.Errorf("cancel parse job: %w", err)
 	}
 
-	// 7. Enqueue embed job for new chunks (mirrors ParseHandler behaviour).
-	if !models.IsAudioFile(doc.Path) && s.getEmbedder() != nil && s.shouldEmbed(ctx, vaultID, doc.Path) {
-		if err := s.db.CreateJob(ctx, fileID, "embed", 0); err != nil {
-			logutil.FromCtx(ctx).Warn("failed to enqueue embed job after sync process", "path", doc.Path, "error", err)
-		} else if s.bus != nil {
-			s.bus.Publish(event.ChangeEvent{Type: "job.created"})
-		}
-	}
-
-	// 8. Publish processed event
+	// 7. Publish processed event (embed worker picks up unembedded chunks automatically)
 	s.publishFileEvent("file.processed", vaultID, doc)
 
 	return nil
@@ -674,7 +665,7 @@ type embeddingTask struct {
 
 // storeEmbeddings stores pre-computed embeddings one-by-one.
 // Returns the number of successfully stored embeddings.
-// Failures are logged; the job retry mechanism handles re-running the embed job.
+// Failures are logged; the embed worker will retry on the next tick.
 func (s *Service) storeEmbeddings(ctx context.Context, updates []db.ChunkEmbeddingUpdate) int {
 	logger := logutil.FromCtx(ctx)
 	stored := 0

--- a/internal/pipeline/worker.go
+++ b/internal/pipeline/worker.go
@@ -2,6 +2,8 @@ package pipeline
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/raphi011/know/internal/db"
@@ -24,33 +26,38 @@ type jobStore interface {
 }
 
 // Worker claims jobs from the pipeline_job table and dispatches them to
-// registered handlers by job type. A single Worker goroutine replaces the
-// three separate processing/embedding/transcription workers.
+// registered handlers by job type. Jobs within a batch are processed
+// concurrently up to the configured concurrency limit.
 type Worker struct {
-	db       jobStore
-	handlers map[string]Handler
-	bus      *event.Bus
-	metrics  *metrics.Metrics
-	interval time.Duration
-	batch    int
+	db          jobStore
+	handlers    map[string]Handler
+	bus         *event.Bus
+	metrics     *metrics.Metrics
+	interval    time.Duration
+	batch       int
+	concurrency int
 }
 
 // NewWorker creates a new PipelineWorker.
-// Panics if interval <= 0 or batch <= 0 (programmer errors).
-func NewWorker(dbClient *db.Client, bus *event.Bus, interval time.Duration, batch int, m *metrics.Metrics) *Worker {
+// Panics if interval <= 0, batch <= 0, or concurrency <= 0 (programmer errors).
+func NewWorker(dbClient *db.Client, bus *event.Bus, interval time.Duration, batch, concurrency int, m *metrics.Metrics) *Worker {
 	if interval <= 0 {
 		panic("pipeline.Worker: interval must be positive")
 	}
 	if batch <= 0 {
 		panic("pipeline.Worker: batch must be positive")
 	}
+	if concurrency <= 0 {
+		panic("pipeline.Worker: concurrency must be positive")
+	}
 	return &Worker{
-		db:       dbClient,
-		handlers: make(map[string]Handler),
-		bus:      bus,
-		metrics:  m,
-		interval: interval,
-		batch:    batch,
+		db:          dbClient,
+		handlers:    make(map[string]Handler),
+		bus:         bus,
+		metrics:     m,
+		interval:    interval,
+		batch:       batch,
+		concurrency: concurrency,
 	}
 }
 
@@ -79,42 +86,63 @@ func (w *Worker) tick(ctx context.Context) {
 		return
 	}
 
-	logger := logutil.FromCtx(ctx)
+	sem := make(chan struct{}, w.concurrency)
+	var wg sync.WaitGroup
+
 	for _, job := range jobs {
 		if ctx.Err() != nil {
-			return
+			break
 		}
 
-		jobID, err := models.RecordIDString(job.ID)
-		if err != nil {
-			logger.Warn("pipeline worker: failed to extract job ID", "error", err)
-			continue
-		}
+		wg.Add(1)
+		sem <- struct{}{} // acquire semaphore slot
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }() // release semaphore slot
+			defer func() {
+				if r := recover(); r != nil {
+					logutil.FromCtx(ctx).Error("pipeline worker: handler panicked", "job_type", job.Type, "panic", fmt.Sprint(r))
+				}
+			}()
+			w.processJob(ctx, job)
+		}()
+	}
 
-		handler, ok := w.handlers[job.Type]
-		if !ok {
-			logger.Warn("pipeline worker: no handler for job type, skipping", "type", job.Type, "job_id", jobID)
-			if err := w.db.CompleteJob(ctx, jobID); err != nil {
-				logger.Error("pipeline worker: complete unhandled job", "job_id", jobID, "error", err)
-			}
-			continue
-		}
+	wg.Wait()
+}
 
-		start := time.Now()
-		if err := handler(ctx, job); err != nil {
-			w.handleFailure(ctx, job, jobID, err)
-			if w.metrics != nil {
-				w.metrics.RecordPipelineJob(job.Type, "failed", time.Since(start))
-			}
-			continue
-		}
+func (w *Worker) processJob(ctx context.Context, job models.PipelineJob) {
+	logger := logutil.FromCtx(ctx)
 
+	jobID, err := models.RecordIDString(job.ID)
+	if err != nil {
+		logger.Warn("pipeline worker: failed to extract job ID", "error", err)
+		return
+	}
+
+	handler, ok := w.handlers[job.Type]
+	if !ok {
+		logger.Warn("pipeline worker: no handler for job type, skipping", "type", job.Type, "job_id", jobID)
 		if err := w.db.CompleteJob(ctx, jobID); err != nil {
-			logger.Error("pipeline worker: complete job", "job_id", jobID, "type", job.Type, "error", err)
+			logger.Error("pipeline worker: complete unhandled job", "job_id", jobID, "error", err)
 		}
+		return
+	}
+
+	start := time.Now()
+	if err := handler(ctx, job); err != nil {
+		w.handleFailure(ctx, job, jobID, err)
 		if w.metrics != nil {
-			w.metrics.RecordPipelineJob(job.Type, "completed", time.Since(start))
+			w.metrics.RecordPipelineJob(job.Type, "failed", time.Since(start))
 		}
+		return
+	}
+
+	if err := w.db.CompleteJob(ctx, jobID); err != nil {
+		logger.Error("pipeline worker: complete job", "job_id", jobID, "type", job.Type, "error", err)
+	}
+	if w.metrics != nil {
+		w.metrics.RecordPipelineJob(job.Type, "completed", time.Since(start))
 	}
 }
 

--- a/internal/pipeline/worker_test.go
+++ b/internal/pipeline/worker_test.go
@@ -54,10 +54,11 @@ func (m *mockJobStore) FailJob(ctx context.Context, jobID, errMsg string) error 
 
 func newTestWorker(store jobStore) *Worker {
 	return &Worker{
-		db:       store,
-		handlers: make(map[string]Handler),
-		interval: 1 * time.Second,
-		batch:    10,
+		db:          store,
+		handlers:    make(map[string]Handler),
+		interval:    1 * time.Second,
+		batch:       10,
+		concurrency: 5,
 	}
 }
 
@@ -146,14 +147,17 @@ func TestWorker_HandleFailure_FailAtMax(t *testing.T) {
 // TestWorker_NewWorker_Panics verifies constructor panics on invalid arguments.
 func TestWorker_NewWorker_Panics(t *testing.T) {
 	tests := []struct {
-		name     string
-		interval time.Duration
-		batch    int
+		name        string
+		interval    time.Duration
+		batch       int
+		concurrency int
 	}{
-		{"zero interval", 0, 1},
-		{"negative interval", -1, 1},
-		{"zero batch", 1 * time.Second, 0},
-		{"negative batch", 1 * time.Second, -1},
+		{"zero interval", 0, 1, 1},
+		{"negative interval", -1, 1, 1},
+		{"zero batch", 1 * time.Second, 0, 1},
+		{"negative batch", 1 * time.Second, -1, 1},
+		{"zero concurrency", 1 * time.Second, 1, 0},
+		{"negative concurrency", 1 * time.Second, 1, -1},
 	}
 
 	for _, tt := range tests {
@@ -163,7 +167,91 @@ func TestWorker_NewWorker_Panics(t *testing.T) {
 					t.Fatal("expected panic but did not panic")
 				}
 			}()
-			NewWorker(nil, nil, tt.interval, tt.batch, nil)
+			NewWorker(nil, nil, tt.interval, tt.batch, tt.concurrency, nil)
 		})
+	}
+}
+
+// TestWorker_ConcurrentProcessing verifies that jobs are processed concurrently.
+func TestWorker_ConcurrentProcessing(t *testing.T) {
+	var running atomic.Int32
+	var maxRunning atomic.Int32
+
+	store := &mockJobStore{
+		claimFn: func(_ context.Context, _ int) ([]models.PipelineJob, error) {
+			return []models.PipelineJob{
+				{ID: surrealmodels.RecordID{Table: "pipeline_job", ID: "j1"}, Type: "parse"},
+				{ID: surrealmodels.RecordID{Table: "pipeline_job", ID: "j2"}, Type: "parse"},
+				{ID: surrealmodels.RecordID{Table: "pipeline_job", ID: "j3"}, Type: "parse"},
+			}, nil
+		},
+	}
+
+	w := &Worker{
+		db:          store,
+		handlers:    make(map[string]Handler),
+		interval:    1 * time.Second,
+		batch:       10,
+		concurrency: 3,
+	}
+
+	w.Register("parse", func(_ context.Context, _ models.PipelineJob) error {
+		cur := running.Add(1)
+		// Track max concurrent handlers running.
+		for {
+			old := maxRunning.Load()
+			if cur <= old || maxRunning.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+		running.Add(-1)
+		return nil
+	})
+
+	w.tick(context.Background())
+
+	if max := maxRunning.Load(); max < 2 {
+		t.Errorf("expected concurrent execution (max running >= 2), got %d", max)
+	}
+}
+
+// TestWorker_PanicRecovery verifies that a panicking handler does not crash the worker.
+func TestWorker_PanicRecovery(t *testing.T) {
+	var completed atomic.Int32
+
+	store := &mockJobStore{
+		claimFn: func(_ context.Context, _ int) ([]models.PipelineJob, error) {
+			return []models.PipelineJob{
+				{ID: surrealmodels.RecordID{Table: "pipeline_job", ID: "panic1"}, Type: "bad"},
+				{ID: surrealmodels.RecordID{Table: "pipeline_job", ID: "ok1"}, Type: "good"},
+			}, nil
+		},
+		completeFn: func(_ context.Context, _ string) error {
+			completed.Add(1)
+			return nil
+		},
+	}
+
+	w := &Worker{
+		db:          store,
+		handlers:    make(map[string]Handler),
+		interval:    1 * time.Second,
+		batch:       10,
+		concurrency: 2,
+	}
+
+	w.Register("bad", func(_ context.Context, _ models.PipelineJob) error {
+		panic("test panic")
+	})
+	w.Register("good", func(_ context.Context, _ models.PipelineJob) error {
+		return nil
+	})
+
+	// tick should not panic even though one handler panics.
+	w.tick(context.Background())
+
+	if c := completed.Load(); c < 1 {
+		t.Errorf("expected at least 1 completed job (the good one), got %d", c)
 	}
 }

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -101,6 +101,8 @@ type App struct {
 	bus                  *event.Bus
 	pipelineWorkerCancel context.CancelFunc // guarded by mu
 	pipelineWorkerDone   chan struct{}      // guarded by mu
+	embedWorkerCancel    context.CancelFunc // guarded by mu
+	embedWorkerDone      chan struct{}      // guarded by mu
 	serverConfig         ServerConfig       // guarded by mu
 }
 
@@ -254,9 +256,11 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 
 	popplerOK := pipeline.CheckPoppler() == nil
 
-	// pipelineWorkerDone defaults to a closed channel so <-pipelineWorkerDone is a no-op in Close
+	// pipelineWorkerDone/embedWorkerDone default to closed channels so <-done is a no-op in Close
 	pipelineWorkerDone := make(chan struct{})
 	close(pipelineWorkerDone)
+	embedWorkerDone := make(chan struct{})
+	close(embedWorkerDone)
 
 	searchSvc := search.NewService(dbClient, embedder)
 	remoteSvc := remote.NewService(dbClient)
@@ -301,6 +305,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		jinaClient:         jinaClient,
 		bus:                bus,
 		pipelineWorkerDone: pipelineWorkerDone,
+		embedWorkerDone:    embedWorkerDone,
 		serverConfig: ServerConfig{
 			Version:                 cfg.Version,
 			Commit:                  cfg.Commit,
@@ -456,6 +461,9 @@ func (a *App) Close(ctx context.Context) error {
 	pipelineCancel := a.pipelineWorkerCancel
 	pipelineDone := a.pipelineWorkerDone
 	a.pipelineWorkerCancel = nil
+	embedCancel := a.embedWorkerCancel
+	embedDone := a.embedWorkerDone
+	a.embedWorkerCancel = nil
 	a.mu.Unlock()
 
 	var errs []error
@@ -468,6 +476,16 @@ func (a *App) Close(ctx context.Context) error {
 		case <-ctx.Done():
 			logger.Warn("pipeline worker did not stop in time")
 			errs = append(errs, fmt.Errorf("pipeline worker: %w", ctx.Err()))
+		}
+	}
+	if embedCancel != nil {
+		logger.Info("stopping embed worker")
+		embedCancel()
+		select {
+		case <-embedDone:
+		case <-ctx.Done():
+			logger.Warn("embed worker did not stop in time")
+			errs = append(errs, fmt.Errorf("embed worker: %w", ctx.Err()))
 		}
 	}
 	if a.agentRunner != nil {
@@ -725,15 +743,45 @@ func (a *App) startPipelineWorker(cfg config.Config) {
 	a.mu.Unlock()
 
 	interval := time.Duration(cfg.PipelineWorkerInterval) * time.Second
-	w := pipeline.NewWorker(a.db, a.bus, interval, cfg.PipelineWorkerBatch, a.metrics)
+	w := pipeline.NewWorker(a.db, a.bus, interval, cfg.PipelineWorkerBatch, cfg.PipelineWorkerConcurrency, a.metrics)
 	w.Register("parse", file.ParseHandler(a.fileService, a.bus))
 	w.Register("transcribe", file.TranscribeHandler(a.fileService, a.bus))
 	w.Register("pdf", file.PDFHandler(a.fileService, a.bus))
 	w.Register("summarize", file.SummarizeHandler(a.fileService, a.bus))
-	w.Register("embed", file.EmbedHandler(a.fileService))
 	go func() {
 		defer close(done)
 		w.Run(workerCtx)
+	}()
+
+	a.startEmbedWorker(cfg)
+}
+
+// startEmbedWorker starts the background embed worker that sweeps for
+// unembedded chunks across all files and embeds them in batches.
+func (a *App) startEmbedWorker(cfg config.Config) {
+	a.mu.Lock()
+
+	if a.embedWorkerCancel != nil {
+		cancel := a.embedWorkerCancel
+		done := a.embedWorkerDone
+		a.embedWorkerCancel = nil
+		a.mu.Unlock()
+		cancel()
+		<-done
+		a.mu.Lock()
+	}
+
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	a.embedWorkerCancel = workerCancel
+	done := make(chan struct{})
+	a.embedWorkerDone = done
+	a.mu.Unlock()
+
+	embedInterval := time.Duration(cfg.EmbedWorkerInterval) * time.Second
+	ew := file.NewEmbedWorker(a.fileService, a.db, a.bus, embedInterval, cfg.EmbedWorkerBatch, a.metrics)
+	go func() {
+		defer close(done)
+		ew.Run(workerCtx)
 	}()
 }
 


### PR DESCRIPTION
Replace per-file embed pipeline jobs with a standalone EmbedWorker that batch-fetches
unembedded chunks across all files. Add concurrent job processing to the pipeline
worker and a `job reprocess` CLI command for force-reprocessing all files.

## New Features
- **EmbedWorker**: Standalone sweep worker that periodically batch-embeds unembedded chunks, replacing per-file embed job chaining from parse/pdf/transcribe/summarize handlers
- **Concurrent pipeline processing**: Semaphore-based concurrency for pipeline worker jobs (configurable via `KNOW_PIPELINE_WORKER_CONCURRENCY`, default: 5)
- **`know job reprocess` CLI + `POST /api/v1/jobs/reprocess`**: Force-reprocess all files — deletes chunks, clears file hashes, cancels pending jobs, and re-enqueues fresh parse/pdf/transcribe jobs
- **Embed worker config**: `KNOW_EMBED_WORKER_INTERVAL` (default: 5s), `KNOW_EMBED_WORKER_BATCH` (default: 100)

## Breaking Changes
- The `embed` pipeline job type is removed — embedding is now handled by the sweep worker automatically
- `pipeline.NewWorker` signature changed: added `concurrency int` parameter

## Code Quality Improvements (from PR review)
- Panic recovery in pipeline worker goroutines — prevents handler panics from crashing the server
- Added `logger.Warn` to 3 silent `continue` sites in embed_worker.go (RecordIDString failures)
- Nil guard on `*chunk.Hash` dereference for multimodal chunks
- Embedding failures logged at `Error` level (was `Warn`)
- Vault existence validation on reprocess endpoint (returns 404 for unknown vaults)
- Removed dead `ChunksDeleted` field from reprocess response struct
- Safety comment on `fmt.Sprintf` SQL pattern in `EnqueueReprocessJobs`
- Helm chart updated with all 3 new env vars
- 6 DB integration tests + 1 pipeline worker panic recovery test added