### PR TITLE
fix: FilterBar width and task toggle hash mismatch

### DIFF
--- a/internal/file/task_toggle.go
+++ b/internal/file/task_toggle.go
@@ -60,46 +60,27 @@ func (s *Service) ToggleTask(ctx context.Context, vaultID, taskID string) (*mode
 	parsed := parser.ParseMarkdown(rawContent)
 	contentBody := parsed.Content
 	lines := strings.Split(contentBody, "\n")
-	toggled := false
 
-	// Primary: try the recorded line number.
-	if task.LineNumber > 0 && task.LineNumber <= len(lines) {
-		idx := task.LineNumber - 1
-		if isMatchingCheckbox(lines[idx], task.ContentHash) {
-			lines[idx] = toggleLine(lines[idx])
-			toggled = true
+	// Use the parser's extracted tasks to find the matching line. This avoids
+	// hash mismatches between AST-derived text (used at extraction time) and
+	// raw line text (which retains markdown syntax like [[wiki-links]]).
+	toggleLine := -1
+	for _, pt := range parsed.Tasks {
+		if pt.ContentHash == task.ContentHash {
+			toggleLine = pt.LineNumber
+			break
 		}
 	}
 
-	// Fallback: scan nearby lines (±5). LineNumber is 1-based, so idx = LineNumber-1; start at idx-5 = LineNumber-6.
-	if !toggled {
-		start := max(0, task.LineNumber-6)
-		end := min(len(lines), task.LineNumber+5)
-		for i := start; i < end; i++ {
-			if isMatchingCheckbox(lines[i], task.ContentHash) {
-				lines[i] = toggleLine(lines[i])
-				toggled = true
-				logger.Info("toggle: task not at expected line, found nearby", "expected", task.LineNumber, "found", i+1, "task_id", taskID)
-				break
-			}
-		}
-	}
-
-	// Last resort: full file scan.
-	if !toggled {
-		for i := range lines {
-			if isMatchingCheckbox(lines[i], task.ContentHash) {
-				lines[i] = toggleLine(lines[i])
-				toggled = true
-				logger.Warn("toggle: task not found near expected line, required full file scan", "expected", task.LineNumber, "found", i+1, "task_id", taskID)
-				break
-			}
-		}
-	}
-
-	if !toggled {
+	if toggleLine <= 0 || toggleLine > len(lines) {
 		return nil, fmt.Errorf("could not find checkbox for task %s in file %s", taskID, doc.Path)
 	}
+
+	idx := toggleLine - 1
+	if toggleLine != task.LineNumber {
+		logger.Info("toggle: task line drifted", "expected", task.LineNumber, "found", toggleLine, "task_id", taskID)
+	}
+	lines[idx] = flipCheckbox(lines[idx])
 
 	// Reconstruct full content: contentBody is always a suffix of rawContent.
 	newBody := strings.Join(lines, "\n")
@@ -133,19 +114,8 @@ func (s *Service) ToggleTask(ctx context.Context, vaultID, taskID string) (*mode
 	return updated, nil
 }
 
-// isMatchingCheckbox checks if a line is a checkbox whose cleaned text matches the given content hash.
-func isMatchingCheckbox(line string, contentHash string) bool {
-	m := toggleCheckboxRegex.FindStringSubmatch(line)
-	if m == nil {
-		return false
-	}
-	rest := line[len(m[0]):]
-	cleaned := parser.CleanTaskText(rest)
-	return models.ContentHash(cleaned) == contentHash
-}
-
-// toggleLine flips `- [ ]` to `- [x]` or vice versa.
-func toggleLine(line string) string {
+// flipCheckbox flips `- [ ]` to `- [x]` or vice versa.
+func flipCheckbox(line string) string {
 	return toggleCheckboxRegex.ReplaceAllStringFunc(line, func(match string) string {
 		if strings.Contains(match, "[ ]") {
 			return strings.Replace(match, "[ ]", "[x]", 1)

--- a/internal/file/task_toggle_test.go
+++ b/internal/file/task_toggle_test.go
@@ -2,11 +2,9 @@ package file
 
 import (
 	"testing"
-
-	"github.com/raphi011/know/internal/models"
 )
 
-func TestToggleLine(t *testing.T) {
+func TestFlipCheckbox(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -56,15 +54,15 @@ func TestToggleLine(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := toggleLine(tt.input)
+			got := flipCheckbox(tt.input)
 			if got != tt.expected {
-				t.Errorf("toggleLine(%q) = %q, want %q", tt.input, got, tt.expected)
+				t.Errorf("flipCheckbox(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
 	}
 }
 
-func TestToggleLine_DoubleToggleRoundtrip(t *testing.T) {
+func TestFlipCheckbox_DoubleToggleRoundtrip(t *testing.T) {
 	lines := []string{
 		"- [ ] open task",
 		"- [x] done task",
@@ -74,8 +72,8 @@ func TestToggleLine_DoubleToggleRoundtrip(t *testing.T) {
 	}
 
 	for _, line := range lines {
-		toggled := toggleLine(line)
-		restored := toggleLine(toggled)
+		toggled := flipCheckbox(line)
+		restored := flipCheckbox(toggled)
 
 		// After double toggle, the text should match except [X] normalizes to [x].
 		expected := line
@@ -85,81 +83,5 @@ func TestToggleLine_DoubleToggleRoundtrip(t *testing.T) {
 		if restored != expected {
 			t.Errorf("double toggle of %q produced %q, want %q", line, restored, expected)
 		}
-	}
-}
-
-func TestIsMatchingCheckbox(t *testing.T) {
-	// Compute the content hash for "fix the bug" (same as CleanTaskText output).
-	hash := models.ContentHash("fix the bug")
-
-	tests := []struct {
-		name        string
-		line        string
-		contentHash string
-		expected    bool
-	}{
-		{
-			name:        "open checkbox matches",
-			line:        "- [ ] fix the bug",
-			contentHash: hash,
-			expected:    true,
-		},
-		{
-			name:        "done checkbox matches",
-			line:        "- [x] fix the bug",
-			contentHash: hash,
-			expected:    true,
-		},
-		{
-			name:        "done uppercase matches",
-			line:        "- [X] fix the bug",
-			contentHash: hash,
-			expected:    true,
-		},
-		{
-			name:        "checkbox with labels matches (labels stripped by CleanTaskText)",
-			line:        "- [ ] fix the bug #work #urgent",
-			contentHash: hash,
-			expected:    true,
-		},
-		{
-			name:        "checkbox with due date matches",
-			line:        "- [ ] fix the bug due:2026-03-20",
-			contentHash: hash,
-			expected:    true,
-		},
-		{
-			name:        "different text does not match",
-			line:        "- [ ] different task",
-			contentHash: hash,
-			expected:    false,
-		},
-		{
-			name:        "non-checkbox line does not match",
-			line:        "- regular list item",
-			contentHash: hash,
-			expected:    false,
-		},
-		{
-			name:        "empty line does not match",
-			line:        "",
-			contentHash: hash,
-			expected:    false,
-		},
-		{
-			name:        "indented checkbox matches",
-			line:        "  - [ ] fix the bug",
-			contentHash: hash,
-			expected:    true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := isMatchingCheckbox(tt.line, tt.contentHash)
-			if got != tt.expected {
-				t.Errorf("isMatchingCheckbox(%q, %q) = %v, want %v", tt.line, tt.contentHash, got, tt.expected)
-			}
-		})
 	}
 }

--- a/internal/tui/browse/browser.go
+++ b/internal/tui/browse/browser.go
@@ -173,15 +173,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		contentHeight := msg.Height - 1 // reserve 1 line for tab bar
 		m.search.width = msg.Width
 		m.search.height = contentHeight
+		m.search.filterBar.SetWidth(msg.Width)
 		m.finder.picker.SetSize(msg.Width, contentHeight)
 		m.links.width = msg.Width
 		m.links.height = contentHeight
+		m.links.filterBar.SetWidth(msg.Width)
 		m.bookmarks.width = msg.Width
 		m.bookmarks.height = contentHeight
+		m.bookmarks.filterBar.SetWidth(msg.Width)
 		m.tags.tagPicker.SetSize(msg.Width, contentHeight)
 		m.tags.filePicker.SetSize(msg.Width, contentHeight)
 		m.tasks.width = msg.Width
 		m.tasks.height = contentHeight
+		m.tasks.filterBar.SetWidth(msg.Width)
 		m.updateRenderer()
 		if m.state == stateViewing {
 			m.viewer.width = msg.Width

--- a/internal/tui/browse/filterbar.go
+++ b/internal/tui/browse/filterbar.go
@@ -109,6 +109,11 @@ func (f FilterBar) View() string {
 	return s
 }
 
+// SetWidth sets the width of the underlying text input.
+func (f *FilterBar) SetWidth(width int) {
+	f.input.SetWidth(width - len(f.input.Prompt))
+}
+
 // HeightLines returns the number of lines the filter bar occupies.
 func (f FilterBar) HeightLines() int {
 	if f.config.Hints != "" {


### PR DESCRIPTION
Follow-up fix for #201 (Query block parser rewrite + FilterBar + Tasks tab).

**FilterBar hint truncation**: `textinput.Model` inside `FilterBar` never had its `Width` set, so placeholder/hint text rendered as ~1 character ("F" instead of "Filter tasks..."). Added `SetWidth()` to `FilterBar` and call it from `WindowSizeMsg` for all 4 FilterBar-using tabs.

**Task toggle 500**: Content hash mismatch between extraction (AST-derived text, strips markdown syntax) and toggle (raw line text, retains `[[wiki-links]]`, `**bold**`, etc.). Now uses `ParseMarkdown`'s extracted tasks for lookup, ensuring identical hashing.

## Breaking Changes
- None